### PR TITLE
Fixed wrong path

### DIFF
--- a/examples/simpleapp/src/main/resources/settings_basic.conf
+++ b/examples/simpleapp/src/main/resources/settings_basic.conf
@@ -29,8 +29,8 @@ scorex {
     signersPublicKeys =
     signersThreshold =
     signersSecrets =
-    provingKeyFilePath = "../../sdk/src/test/resources/sample_proving_key_7_keys_with_threshold_5"
-    verificationKeyFilePath = "../../sdk/src/test/resources/sample_vk_7_keys_with_threshold_5"
+    provingKeyFilePath = "sdk/src/test/resources/sample_proving_key_7_keys_with_threshold_5"
+    verificationKeyFilePath = "sdk/src/test/resources/sample_vk_7_keys_with_threshold_5"
   }
 
   wallet {


### PR DESCRIPTION
Hello,
in building and rebuilding sidechains in testnet I noticed something wrong with the  `provingKeyFilePath `and `verificationKeyFilePath ` in the template for sidechain configurations `settings_basic.conf`.
I believe it should be fixed as I propose in this PR, so that the aforementioned files can be reach from the repo root.
Can you confirm my fix is correct?
If so, and if you are willing to accept the change, should master be targeted, or rather other branches?
Many thanks