### PR TITLE
Mo/schains 431 - OpenStakeTransaction

### DIFF
--- a/qa/SidechainTestFramework/sc_boostrap_info.py
+++ b/qa/SidechainTestFramework/sc_boostrap_info.py
@@ -101,7 +101,9 @@ class SCNodeConfiguration(object):
                  mempool_max_size = 300,
                  mempool_min_fee_rate = 0,
                  api_key=DEFAULT_API_KEY,
-                 max_fee=10000000):
+                 max_fee=10000000,
+                 forger_options = SCForgerConfiguration(),
+                 initial_private_keys = []):
         if submitter_private_keys_indexes is None:
             submitter_private_keys_indexes = list(range(7))
         self.mc_connection_info = mc_connection_info
@@ -116,6 +118,7 @@ class SCNodeConfiguration(object):
         self.max_fee = max_fee
         self.mempool_max_size = mempool_max_size
         self.mempool_min_fee_rate = mempool_min_fee_rate
+        self.initial_private_keys = initial_private_keys
 
 """
 The full network of many sidechain nodes connected to many mainchain nodes.

--- a/qa/SidechainTestFramework/sc_boostrap_info.py
+++ b/qa/SidechainTestFramework/sc_boostrap_info.py
@@ -102,7 +102,6 @@ class SCNodeConfiguration(object):
                  mempool_min_fee_rate = 0,
                  api_key=DEFAULT_API_KEY,
                  max_fee=10000000,
-                 forger_options = SCForgerConfiguration(),
                  initial_private_keys = []):
         if submitter_private_keys_indexes is None:
             submitter_private_keys_indexes = list(range(7))

--- a/qa/SidechainTestFramework/scutil.py
+++ b/qa/SidechainTestFramework/scutil.py
@@ -375,6 +375,8 @@ def initialize_sc_datadir(dirname, n, bootstrap_info=SCBootstrapInfo, sc_node_co
     api_key_hash = ""
     if sc_node_config.api_key != "":
         api_key_hash = calculateApiKeyHash(sc_node_config.api_key)
+    genesis_secrets += sc_node_config.initial_private_keys
+
     config = tmpConfig % {
         'NODE_NUMBER': n,
         'DIRECTORY': dirname,

--- a/qa/httpCalls/transaction/openStake.py
+++ b/qa/httpCalls/transaction/openStake.py
@@ -1,0 +1,16 @@
+import json
+#execute a transaction/openStake call
+def openStake(sidechainNode, boxid, address, forger_index, fee, format = False):
+      j = { 
+            "transactionInput": 
+            { 
+                "boxId": boxid 
+            },
+            "regularOutputProposition": address,
+            "forgerListIndex": forger_index,
+            "fee": fee,
+            "format": format 
+      }
+      request = json.dumps(j)
+      response = sidechainNode.transaction_openStake(request)
+      return response["result"]

--- a/qa/httpCalls/transaction/openStake.py
+++ b/qa/httpCalls/transaction/openStake.py
@@ -1,6 +1,6 @@
 import json
-#execute a transaction/openStake call
-def createOpenStakeTransaction(sidechainNode, boxid, address, forger_index, fee, format = False):
+#execute a transaction/createopenStakeTransaction call
+def createOpenStakeTransaction(sidechainNode, boxid, address, forger_index, fee, format = False, automaticSend = False):
       j = { 
             "transactionInput": 
             { 
@@ -9,8 +9,22 @@ def createOpenStakeTransaction(sidechainNode, boxid, address, forger_index, fee,
             "regularOutputProposition": address,
             "forgerListIndex": forger_index,
             "fee": fee,
-            "format": format 
+            "format": format,
+            "automaticSend": automaticSend
       }
       request = json.dumps(j)
       response = sidechainNode.transaction_createOpenStakeTransaction(request)
+      return response["result"]
+
+#execute a transaction/createOpenStakeTransactionSimplified call
+def createOpenStakeTransactionSimplified(sidechainNode, forger_proposition, forger_index, fee, format = False, automaticSend = False):
+      j = {
+            "forgerProposition": forger_proposition,
+            "forgerListIndex": forger_index,
+            "fee": fee,
+            "format": format,
+            "automaticSend": automaticSend
+      }
+      request = json.dumps(j)
+      response = sidechainNode.transaction_createOpenStakeTransactionSimplified(request)
       return response["result"]

--- a/qa/httpCalls/transaction/openStake.py
+++ b/qa/httpCalls/transaction/openStake.py
@@ -1,30 +1,30 @@
 import json
 #execute a transaction/createopenStakeTransaction call
-def createOpenStakeTransaction(sidechainNode, boxid, address, forger_index, fee, format = False, automaticSend = False):
+def createOpenStakeTransaction(sidechain_node, boxid, address, forger_index, fee, format = False, automatic_send = False):
       j = { 
             "transactionInput": 
             { 
                 "boxId": boxid 
             },
             "regularOutputProposition": address,
-            "forgerListIndex": forger_index,
+            "forgerIndex": forger_index,
             "fee": fee,
             "format": format,
-            "automaticSend": automaticSend
+            "automaticSend": automatic_send
       }
       request = json.dumps(j)
-      response = sidechainNode.transaction_createOpenStakeTransaction(request)
+      response = sidechain_node.transaction_createOpenStakeTransaction(request)
       return response["result"]
 
 #execute a transaction/createOpenStakeTransactionSimplified call
-def createOpenStakeTransactionSimplified(sidechainNode, forger_proposition, forger_index, fee, format = False, automaticSend = False):
+def createOpenStakeTransactionSimplified(sidechain_node, forger_proposition, forger_index, fee, format = False, automatic_send = False):
       j = {
             "forgerProposition": forger_proposition,
-            "forgerListIndex": forger_index,
+            "forgerIndex": forger_index,
             "fee": fee,
             "format": format,
-            "automaticSend": automaticSend
+            "automaticSend": automatic_send
       }
       request = json.dumps(j)
-      response = sidechainNode.transaction_createOpenStakeTransactionSimplified(request)
+      response = sidechain_node.transaction_createOpenStakeTransactionSimplified(request)
       return response["result"]

--- a/qa/httpCalls/transaction/openStake.py
+++ b/qa/httpCalls/transaction/openStake.py
@@ -1,6 +1,6 @@
 import json
 #execute a transaction/openStake call
-def openStake(sidechainNode, boxid, address, forger_index, fee, format = False):
+def createOpenStakeTransaction(sidechainNode, boxid, address, forger_index, fee, format = False):
       j = { 
             "transactionInput": 
             { 
@@ -12,5 +12,5 @@ def openStake(sidechainNode, boxid, address, forger_index, fee, format = False):
             "format": format 
       }
       request = json.dumps(j)
-      response = sidechainNode.transaction_openStake(request)
+      response = sidechainNode.transaction_createOpenStakeTransaction(request)
       return response["result"]

--- a/qa/httpCalls/transaction/openStake.py
+++ b/qa/httpCalls/transaction/openStake.py
@@ -1,6 +1,6 @@
 import json
 #execute a transaction/createopenStakeTransaction call
-def createOpenStakeTransaction(sidechain_node, boxid, address, forger_index, fee, format = False, automatic_send = False):
+def createOpenStakeTransaction(sidechain_node, boxid, address, forger_index, fee = 0, format = False, automatic_send = False):
       j = { 
             "transactionInput": 
             { 

--- a/qa/httpCalls/transaction/sendCoinsToAddress.py
+++ b/qa/httpCalls/transaction/sendCoinsToAddress.py
@@ -33,3 +33,17 @@ def sendCointsToMultipleAddress(sidechainNode, addresses, amounts, fee):
     response = sidechainNode.transaction_sendCoinsToAddress(request)
     return response["result"]["transactionId"]
 
+def sendCointsToMultipleAddress(sidechainNode, addresses, amounts, fee):
+    if (len(addresses) != len(amounts)):
+        return "Addresses and amunts have differente lengths!"
+    outputs = []
+    for i in range(0, len(addresses)):
+        outputs += [{"publicKey": addresses[i], "value": amounts[i]}]
+
+    j = {
+        "outputs": outputs,
+        "fee": fee
+    }
+    request = json.dumps(j)
+    response = sidechainNode.transaction_sendCoinsToAddress(request)
+    return response["result"]["transactionId"]

--- a/qa/httpCalls/transaction/sendTransaction.py
+++ b/qa/httpCalls/transaction/sendTransaction.py
@@ -1,0 +1,11 @@
+import json
+
+
+# execute a transaction/sendTransaction call
+def sendTransaction(sidechainNode, tx_bytes):
+    j = {
+        "transactionBytes": tx_bytes
+    }
+    request = json.dumps(j)
+    response = sidechainNode.transaction_sendTransaction(request)
+    return response

--- a/qa/sc_closed_forger.py
+++ b/qa/sc_closed_forger.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from test_framework.util import assert_false, assert_true, initialize_chain_clean, start_nodes, connect_nodes_bi, websocket_port_by_mc_node_index, forward_transfer_to_sidechain
+from test_framework.util import assert_true, initialize_chain_clean, start_nodes, connect_nodes_bi, websocket_port_by_mc_node_index, forward_transfer_to_sidechain
 from SidechainTestFramework.scutil import generate_secrets, start_sc_nodes, generate_next_blocks, bootstrap_sidechain_nodes, generate_secrets, generate_vrf_secrets
 from httpCalls.wallet.createPrivateKey25519 import http_wallet_createPrivateKey25519
 from httpCalls.transaction.makeForgerStake import makeForgerStake
 from httpCalls.wallet.createVrfSecret import http_wallet_createVrfSecret
 from httpCalls.wallet.allBoxes import http_wallet_allBoxes
 from httpCalls.transaction.sendCoinsToAddress import sendCoinsToAddress, sendCointsToMultipleAddress
-from httpCalls.transaction.openStake import createOpenStakeTransaction
+from httpCalls.transaction.openStake import createOpenStakeTransaction, createOpenStakeTransactionSimplified
 from httpCalls.transaction.sendTransaction import sendTransaction
 from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
     SCNetworkConfiguration, SCForgerConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH
@@ -221,8 +221,8 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         allBoxes = http_wallet_allBoxes(sc_node1)
         forger1_box = self.find_box(allBoxes, self.allowed_forger_propositions[1].publicKey)
         assert_true(forger1_box != {})
-        tx_bytes = createOpenStakeTransaction(sc_node1, forger1_box["id"],new_public_key,1,sc_fee)
-        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        #Try with automaticSend = True
+        res = createOpenStakeTransaction(sc_node1, forger1_box["id"],new_public_key,1,sc_fee, True, True)
         assert_true("error" not in res)
         self.sc_sync_all()
         generate_next_blocks(sc_node1, "first node", 1)
@@ -248,7 +248,8 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         allBoxes = http_wallet_allBoxes(sc_node1)
         forger2_box = self.find_box(allBoxes, self.allowed_forger_propositions[2].publicKey)
         assert_true(forger2_box != {})
-        tx_bytes = createOpenStakeTransaction(sc_node1, forger2_box["id"],new_public_key,2,sc_fee)
+        #Try the createOpenStakeTransactionSimplified endpoint
+        tx_bytes = createOpenStakeTransactionSimplified(sc_node1, self.allowed_forger_propositions[2].publicKey,2,sc_fee)
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
         assert_true("error" not in res)
         self.sc_sync_all()

--- a/qa/sc_closed_forger.py
+++ b/qa/sc_closed_forger.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from test_framework.util import assert_true, initialize_chain_clean, start_nodes, connect_nodes_bi, websocket_port_by_mc_node_index, forward_transfer_to_sidechain
+from test_framework.util import assert_true, assert_equal, initialize_chain_clean, start_nodes, connect_nodes_bi, websocket_port_by_mc_node_index, forward_transfer_to_sidechain
 from SidechainTestFramework.scutil import generate_secrets, start_sc_nodes, generate_next_blocks, bootstrap_sidechain_nodes, generate_secrets, generate_vrf_secrets
 from httpCalls.wallet.createPrivateKey25519 import http_wallet_createPrivateKey25519
 from httpCalls.transaction.makeForgerStake import makeForgerStake
@@ -9,6 +9,7 @@ from httpCalls.wallet.allBoxes import http_wallet_allBoxes
 from httpCalls.transaction.sendCoinsToAddress import sendCoinsToAddress, sendCointsToMultipleAddress
 from httpCalls.transaction.openStake import createOpenStakeTransaction, createOpenStakeTransactionSimplified
 from httpCalls.transaction.sendTransaction import sendTransaction
+from httpCalls.block.best import http_block_best
 from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
     SCNetworkConfiguration, SCForgerConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH
 from SidechainTestFramework.sidechainauthproxy import SCAPIException
@@ -188,7 +189,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         #Forger 0 opens the stake
         print("Forger 0 opens the stake")
-        tx_bytes = createOpenStakeTransaction(sc_node1, forger0_box["id"],new_public_key,0,sc_fee)
+        tx_bytes = createOpenStakeTransaction(sc_node1, forger0_box["id"],new_public_key,0,forger0_box["value"])
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
         assert_true("error" not in res)
         self.sc_sync_all()
@@ -206,6 +207,12 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         generate_next_blocks(sc_node1, "first node", 1)
         self.sc_sync_all()
+
+        #Verify that if we use fee = inputBox.value we don't generate new boxes.
+        print("Verify that if we use fee = inputBox.value we don't generate new boxes.")
+        bestBlock = http_block_best(sc_node1)
+        assert_equal(bestBlock["sidechainTransactions"][0]["newBoxes"], [])
+        print("Ok!")
 
         #Try to send an openStakeTransaction with the same forgerIndex of the previous one
         print("Try to send an openStakeTransaction with the same forgerIndex of the previous one")

--- a/qa/sc_closed_forger.py
+++ b/qa/sc_closed_forger.py
@@ -7,7 +7,7 @@ from httpCalls.transaction.makeForgerStake import makeForgerStake
 from httpCalls.wallet.createVrfSecret import http_wallet_createVrfSecret
 from httpCalls.wallet.allBoxes import http_wallet_allBoxes
 from httpCalls.transaction.sendCoinsToAddress import sendCoinsToAddress, sendCointsToMultipleAddress
-from httpCalls.transaction.openStake import openStake
+from httpCalls.transaction.openStake import createOpenStakeTransaction
 from httpCalls.transaction.sendTransaction import sendTransaction
 from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
     SCNetworkConfiguration, SCForgerConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH
@@ -139,7 +139,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         print("Try to send an openStake transaction with negative forgerIndex")
         error_occur = False
         try:
-            openStake(sc_node1, new_public_key_box["id"],new_public_key,-1,sc_fee)
+            createOpenStakeTransaction(sc_node1, new_public_key_box["id"],new_public_key,-1,sc_fee)
         except SCAPIException as e:
             print("Expected SCAPIException: " + e.error)
             error_occur = True
@@ -150,7 +150,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         print("Try to send an openStake transaction with empty output proposition")
         error_occur = False
         try:
-            openStake(sc_node1, new_public_key_box["id"],"",0,sc_fee)
+            createOpenStakeTransaction(sc_node1, new_public_key_box["id"],"",0,sc_fee)
         except SCAPIException as e:
             print("Expected SCAPIException: " + e.error)
             error_occur = True
@@ -161,7 +161,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         print("Try to send an openStake transaction with empty boxid")
         error_occur = False
         try:
-            openStake(sc_node1, "",new_public_key,0,sc_fee)
+            createOpenStakeTransaction(sc_node1, "",new_public_key,0,sc_fee)
         except SCAPIException as e:
             print("Expected SCAPIException: " + e.error)
             error_occur = True         
@@ -170,7 +170,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         #Try to send an openStake transaction with forgerIndex out of bounds
         print("Try to send an openStake transaction with forgerIndex out of bounds")
-        tx_bytes = openStake(sc_node1, new_public_key_box["id"],new_public_key,self.number_of_forgers,sc_fee)
+        tx_bytes = createOpenStakeTransaction(sc_node1, new_public_key_box["id"],new_public_key,self.number_of_forgers,sc_fee)
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
         assert_true("ForgerListIndex in OpenStakeTransaction is out of bound" in res["error"]["detail"])
         print("Ok!")
@@ -179,14 +179,14 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         print("Try to send openStake transaction with forgerIndex doesn't match the input proposition")
         forger0_box = self.find_box(allBoxes, self.allowed_forger_propositions[0].publicKey)
         assert_true(forger0_box != {})
-        tx_bytes = openStake(sc_node1, forger0_box["id"],new_public_key,2,sc_fee)
+        tx_bytes = createOpenStakeTransaction(sc_node1, forger0_box["id"],new_public_key,2,sc_fee)
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
         assert_true("OpenStakeTransaction input doesn't match the forgerListIndex" in res["error"]["detail"])
         print("Ok!")
 
         #Forger 0 opens the stake
         print("Forger 0 opens the stake")
-        tx_bytes = openStake(sc_node1, forger0_box["id"],new_public_key,0,sc_fee)
+        tx_bytes = createOpenStakeTransaction(sc_node1, forger0_box["id"],new_public_key,0,sc_fee)
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
         assert_true("error" not in res)
         self.sc_sync_all()
@@ -197,7 +197,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         allBoxes = http_wallet_allBoxes(sc_node1)
         forger0_box2 = self.find_box(allBoxes, self.allowed_forger_propositions[0].publicKey)
         assert_true(forger0_box2 != {})
-        tx_bytes = openStake(sc_node1, forger0_box2["id"],new_public_key,0,sc_fee)
+        tx_bytes = createOpenStakeTransaction(sc_node1, forger0_box2["id"],new_public_key,0,sc_fee)
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
         assert_true("Transaction is incompatible" in res["error"]["detail"])
         print("Ok!")
@@ -221,7 +221,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         allBoxes = http_wallet_allBoxes(sc_node1)
         forger1_box = self.find_box(allBoxes, self.allowed_forger_propositions[1].publicKey)
         assert_true(forger1_box != {})
-        tx_bytes = openStake(sc_node1, forger1_box["id"],new_public_key,1,sc_fee)
+        tx_bytes = createOpenStakeTransaction(sc_node1, forger1_box["id"],new_public_key,1,sc_fee)
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
         assert_true("error" not in res)
         self.sc_sync_all()
@@ -248,7 +248,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         allBoxes = http_wallet_allBoxes(sc_node1)
         forger2_box = self.find_box(allBoxes, self.allowed_forger_propositions[2].publicKey)
         assert_true(forger2_box != {})
-        tx_bytes = openStake(sc_node1, forger2_box["id"],new_public_key,2,sc_fee)
+        tx_bytes = createOpenStakeTransaction(sc_node1, forger2_box["id"],new_public_key,2,sc_fee)
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
         assert_true("error" not in res)
         self.sc_sync_all()

--- a/qa/sc_closed_forger.py
+++ b/qa/sc_closed_forger.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from test_framework.util import assert_true, initialize_chain_clean, start_nodes, connect_nodes_bi, websocket_port_by_mc_node_index, forward_transfer_to_sidechain
+from test_framework.util import assert_false, assert_true, initialize_chain_clean, start_nodes, connect_nodes_bi, websocket_port_by_mc_node_index, forward_transfer_to_sidechain
 from SidechainTestFramework.scutil import generate_secrets, start_sc_nodes, generate_next_blocks, bootstrap_sidechain_nodes, generate_secrets, generate_vrf_secrets
 from httpCalls.wallet.createPrivateKey25519 import http_wallet_createPrivateKey25519
 from httpCalls.transaction.makeForgerStake import makeForgerStake
 from httpCalls.wallet.createVrfSecret import http_wallet_createVrfSecret
+from httpCalls.wallet.allBoxes import http_wallet_allBoxes
+from httpCalls.transaction.sendCoinsToAddress import sendCoinsToAddress, sendCointsToMultipleAddress
+from httpCalls.transaction.openStake import openStake
+from httpCalls.transaction.sendTransaction import sendTransaction
 from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
     SCNetworkConfiguration, SCForgerConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH
+from SidechainTestFramework.sidechainauthproxy import SCAPIException
 
 """
     Setup 1 SC Node with a closed list of forger. Try to stake money with invalid forger info and verify that we are not allowed to stake.
@@ -14,8 +19,9 @@ from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreat
 class SidechainClosedForgerTest(SidechainTestFramework):
     number_of_mc_nodes = 1
     number_of_sidechain_nodes = 1
-    allowed_forger_proposition = generate_secrets("seed", 1)[0].publicKey
-    allowed_forger_vrf_public_key = generate_vrf_secrets("seed", 1)[0].publicKey
+    number_of_forgers = 5
+    allowed_forger_propositions = generate_secrets("seed", number_of_forgers)
+    allowed_forger_vrf_public_keys = generate_vrf_secrets("seed", number_of_forgers)
 
     def setup_chain(self):
         initialize_chain_clean(self.options.tmpdir, self.number_of_mc_nodes)
@@ -32,13 +38,14 @@ class SidechainClosedForgerTest(SidechainTestFramework):
     def sc_setup_chain(self):
         # Bootstrap new SC, specify SC node 1 connection to MC node 1
         mc_node_1 = self.nodes[0]
-        forger_configuration  = SCForgerConfiguration(True, [
-            [self.allowed_forger_proposition, self.allowed_forger_vrf_public_key]
-        ])
-
+        allowedForgers = []
+        for i in range (0, self.number_of_forgers):
+            allowedForgers += [[self.allowed_forger_propositions[i].publicKey, self.allowed_forger_vrf_public_keys[i].publicKey]]
+        forger_configuration  = SCForgerConfiguration(True, allowedForgers)
         sc_node_1_configuration = SCNodeConfiguration(
             MCConnectionInfo(address="ws://{0}:{1}".format(mc_node_1.hostname, websocket_port_by_mc_node_index(0))),
-            forger_options = forger_configuration
+            forger_options = forger_configuration,
+            initial_private_keys=list(map(lambda forger: forger.secret,self.allowed_forger_propositions))
         )
         network = SCNetworkConfiguration(SCCreationInfo(mc_node_1, 600, LARGE_WITHDRAWAL_EPOCH_LENGTH),
                                          sc_node_1_configuration)
@@ -47,6 +54,13 @@ class SidechainClosedForgerTest(SidechainTestFramework):
     def sc_setup_nodes(self):
         # Start 1 SC node
         return start_sc_nodes(self.number_of_sidechain_nodes, self.options.tmpdir)
+
+    def find_box(self, boxes, proposition):
+        found_box = {}
+        for box in boxes:
+            if (box["typeName"]=="ZenBox" and box["proposition"]["publicKey"] == proposition):
+                found_box = box
+        return found_box
 
     def run_test(self):
         self.sync_all()
@@ -57,12 +71,11 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         # Generate 1 SC block
         generate_next_blocks(sc_node1, "first node", 1)
-
         # We need regular coins (the genesis account balance is locked into forging stake), so we perform a
         # Forward transfer to sidechain for an amount equals to the genesis_account_balance
         forward_transfer_to_sidechain(self.sc_nodes_bootstrap_info.sidechain_id,
                                       mc_node1,
-                                      self.allowed_forger_proposition,
+                                      self.allowed_forger_propositions[0].publicKey,
                                       self.sc_nodes_bootstrap_info.genesis_account_balance,
                                       mc_node1.getnewaddress())
         self.sc_sync_all()
@@ -73,7 +86,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         print("Try to stake to an invalid blockSignProposition...")
         new_public_key = http_wallet_createPrivateKey25519(self.sc_nodes[0])
         new_vrf_public_key = http_wallet_createVrfSecret(sc_node1)
-        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_proposition, new_public_key, self.allowed_forger_vrf_public_key, forger_amount, sc_fee)
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, new_public_key, self.allowed_forger_vrf_public_keys[0].publicKey, forger_amount, sc_fee)
         print(result)
         assert_true('error' in result)
         assert_true('This publicKey is not allowed to forge' in result['error']['detail'])
@@ -81,7 +94,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         # Try to stake to an invalid vrfPublicKey
         print("Try to stake to an invalid vrfPublicKey...")
-        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_proposition, self.allowed_forger_proposition, new_vrf_public_key, forger_amount, sc_fee)
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, self.allowed_forger_propositions[0].publicKey, new_vrf_public_key, forger_amount, sc_fee)
         print(result)
         assert_true('error' in result)
         assert_true('This publicKey is not allowed to forge' in result['error']['detail'])
@@ -89,7 +102,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         # Try to stake with an invalid blockSignProposition and an invalid vrfPublicKey
         print("Try to stake to an invalid vrfPublicKey...")
-        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_proposition, new_public_key, new_vrf_public_key, forger_amount, sc_fee)
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, new_public_key, new_vrf_public_key, forger_amount, sc_fee)
         print(result)
         assert_true('error' in result)
         assert_true('This publicKey is not allowed to forge' in result['error']['detail'])
@@ -97,7 +110,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         # Try to stake with a valid blockSignProposition and a valid vrfPublickey
         print("Try to stake with a valid blockSignProposition and a valid vrfPublickey")
-        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_proposition, self.allowed_forger_proposition, self.allowed_forger_vrf_public_key, forger_amount, sc_fee)
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, self.allowed_forger_propositions[0].publicKey, self.allowed_forger_vrf_public_keys[0].publicKey, forger_amount, sc_fee)
         print(result)
         assert_true('result' in result)
         assert_true('transactionId' in result['result'])
@@ -106,6 +119,150 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         generate_next_blocks(sc_node1, "first node", 1)
         self.sc_sync_all()
 
+        # Create some ZenBoxes
+        print("Create some ZenBoxes")
+        sendCointsToMultipleAddress(sc_node1, list(map(lambda forger: forger.publicKey, self.allowed_forger_propositions)), [1000]*len(self.allowed_forger_propositions), 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        sendCoinsToAddress(sc_node1, new_public_key, 1500, 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        allBoxes = http_wallet_allBoxes(sc_node1)
+        new_public_key_box = self.find_box(allBoxes, new_public_key)
+        assert_true(new_public_key_box != {})
+
+        #Try to send an openStake transaction with negative forgerIndex
+        print("Try to send an openStake transaction with negative forgerIndex")
+        error_occur = False
+        try:
+            openStake(sc_node1, new_public_key_box["id"],new_public_key,-1,sc_fee)
+        except SCAPIException as e:
+            print("Expected SCAPIException: " + e.error)
+            error_occur = True
+        assert_true(error_occur, "Try to send an openStake transaction with negative forgerListIndex")
+        print("Ok!")
+
+        #Try to send an openStake transaction with empty output proposition
+        print("Try to send an openStake transaction with empty output proposition")
+        error_occur = False
+        try:
+            openStake(sc_node1, new_public_key_box["id"],"",0,sc_fee)
+        except SCAPIException as e:
+            print("Expected SCAPIException: " + e.error)
+            error_occur = True
+        assert_true(error_occur, "Try to send an openStake transaction with empty output proposition")
+        print("Ok!")
+
+        #Try to send an openStake transaction with empty boxid
+        print("Try to send an openStake transaction with empty boxid")
+        error_occur = False
+        try:
+            openStake(sc_node1, "",new_public_key,0,sc_fee)
+        except SCAPIException as e:
+            print("Expected SCAPIException: " + e.error)
+            error_occur = True         
+            assert_true(error_occur, "Try to send an openStake transaction with empty output proposition")
+        print("Ok!")
+
+        #Try to send an openStake transaction with forgerIndex out of bounds
+        print("Try to send an openStake transaction with forgerIndex out of bounds")
+        tx_bytes = openStake(sc_node1, new_public_key_box["id"],new_public_key,self.number_of_forgers,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
+        assert_true("ForgerListIndex in OpenStakeTransaction is out of bound" in res["error"]["detail"])
+        print("Ok!")
+
+        #Try to send openStake transaction with forgerIndex doesn't match the input proposition
+        print("Try to send openStake transaction with forgerIndex doesn't match the input proposition")
+        forger0_box = self.find_box(allBoxes, self.allowed_forger_propositions[0].publicKey)
+        assert_true(forger0_box != {})
+        tx_bytes = openStake(sc_node1, forger0_box["id"],new_public_key,2,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
+        assert_true("OpenStakeTransaction input doesn't match the forgerListIndex" in res["error"]["detail"])
+        print("Ok!")
+
+        #Forger 0 opens the stake
+        print("Forger 0 opens the stake")
+        tx_bytes = openStake(sc_node1, forger0_box["id"],new_public_key,0,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true("error" not in res)
+        self.sc_sync_all()
+        print("Ok!")
+
+        #Try to send an openStakeTransaction with the same forgerIndex of the previous one (in mempool)
+        print("Try to send an openStakeTransaction with the same forgerIndex of the previous one (in mempool)")
+        allBoxes = http_wallet_allBoxes(sc_node1)
+        forger0_box2 = self.find_box(allBoxes, self.allowed_forger_propositions[0].publicKey)
+        assert_true(forger0_box2 != {})
+        tx_bytes = openStake(sc_node1, forger0_box2["id"],new_public_key,0,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true("Transaction is incompatible" in res["error"]["detail"])
+        print("Ok!")
+
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        #Try to send an openStakeTransaction with the same forgerIndex of the previous one
+        print("Try to send an openStakeTransaction with the same forgerIndex of the previous one")
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true("Forger already opened the stake" in res["error"]["detail"])
+        print("Ok!")
+
+        #Forger 1 opens the stake
+        print("Forger 1 opens the stake")
+        sendCoinsToAddress(sc_node1, self.allowed_forger_propositions[1].publicKey, 1500, 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        allBoxes = http_wallet_allBoxes(sc_node1)
+        forger1_box = self.find_box(allBoxes, self.allowed_forger_propositions[1].publicKey)
+        assert_true(forger1_box != {})
+        tx_bytes = openStake(sc_node1, forger1_box["id"],new_public_key,1,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true("error" not in res)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+        print("Ok!")
+
+        # Try to stake with an invalid blockSignProposition and an invalid vrfPublicKey
+        print("Try to stake to an invalid vrfPublicKey...")
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, new_public_key, new_vrf_public_key, forger_amount, sc_fee)
+        print(result)
+        assert_true('error' in result)
+        assert_true('This publicKey is not allowed to forge' in result['error']['detail'])
+        print("Ok!")
+
+        #Forger 2 opens the stake
+        print("Forger 2 opens the stake")
+        sendCoinsToAddress(sc_node1, self.allowed_forger_propositions[2].publicKey, 1500, 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+
+        allBoxes = http_wallet_allBoxes(sc_node1)
+        forger2_box = self.find_box(allBoxes, self.allowed_forger_propositions[2].publicKey)
+        assert_true(forger2_box != {})
+        tx_bytes = openStake(sc_node1, forger2_box["id"],new_public_key,2,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true("error" not in res)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+        print("Ok!")
+
+        # Now the majority of the allowed forgers opened the stake (3/5) and we should be able to stake to a new forger
+        print("Now the majority of the allowed forgers opened the stake (3/5) and we should be able to stake to a new forger")
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, new_public_key, new_vrf_public_key, forger_amount, sc_fee)
+        print(result) 
+        assert_true('result' in result)
+        assert_true('transactionId' in result['result'])
+        print("Ok!")
 
 if __name__ == "__main__":
     SidechainClosedForgerTest().main()

--- a/qa/sc_closed_forger.py
+++ b/qa/sc_closed_forger.py
@@ -59,11 +59,10 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         return start_sc_nodes(self.number_of_sidechain_nodes, self.options.tmpdir)
 
     def find_box(self, boxes, proposition):
-        found_box = {}
         for box in boxes:
             if (box["typeName"]=="ZenBox" and box["proposition"]["publicKey"] == proposition):
-                found_box = box
-        return found_box
+                return box
+        return {}
 
     def run_test(self):
         self.sync_all()
@@ -146,7 +145,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         except SCAPIException as e:
             print("Expected SCAPIException: " + e.error)
             error_occur = True
-        assert_true(error_occur, "Try to send an openStake transaction with negative forgerListIndex")
+        assert_true(error_occur, "Try to send an openStake transaction with negative forgerIndex")
         print("Ok!")
 
         #Try to send an openStake transaction with empty output proposition
@@ -175,7 +174,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         print("Try to send an openStake transaction with forgerIndex out of bounds")
         tx_bytes = createOpenStakeTransaction(sc_node1, new_public_key_box["id"],new_public_key,self.number_of_forgers,sc_fee)
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
-        assert_true("ForgerListIndex in OpenStakeTransaction is out of bound" in res["error"]["detail"])
+        assert_true("ForgerIndex in OpenStakeTransaction is out of bound" in res["error"]["detail"])
         print("Ok!")
 
         #Try to send openStake transaction with forgerIndex doesn't match the input proposition
@@ -184,7 +183,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         assert_true(forger0_box != {})
         tx_bytes = createOpenStakeTransaction(sc_node1, forger0_box["id"],new_public_key,2,sc_fee)
         res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
-        assert_true("OpenStakeTransaction input doesn't match the forgerListIndex" in res["error"]["detail"])
+        assert_true("OpenStakeTransaction input doesn't match the forgerIndex" in res["error"]["detail"])
         print("Ok!")
 
         #Forger 0 opens the stake
@@ -258,14 +257,20 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         allBoxes = http_wallet_allBoxes(sc_node1)
         forger2_box = self.find_box(allBoxes, self.allowed_forger_propositions[2].publicKey)
-        assert_true(forger2_box != {})
+        assert_true(forger2_box != {})         
         #Try the createOpenStakeTransactionSimplified endpoint
-        tx_bytes = createOpenStakeTransactionSimplified(sc_node1, self.allowed_forger_propositions[2].publicKey,2,sc_fee)
-        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        tx_bytes = createOpenStakeTransactionSimplified(sc_node1, self.allowed_forger_propositions[2].publicKey,2,forger2_box["value"])
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
         assert_true("error" not in res)
+        print("Ok!")
         self.sc_sync_all()
-        generate_next_blocks(sc_node1, "first node", 1)
+        generate_next_blocks(sc_node1, "first node", 1)[0]
         self.sc_sync_all()
+     
+        #Verify that we have created an openStakeTransaction with fee = inputBox.value. We should have newBoxes empty.
+        print("Verify that we have created an openStakeTransaction with fee = inputBox.value. We should have newBoxes empty.")
+        block = http_block_best(sc_node1)
+        assert_equal(block["sidechainTransactions"][0]["newBoxes"], [])
         print("Ok!")
 
         # Now the majority of the allowed forgers opened the stake (3/5) and we should be able to stake to a new forger
@@ -274,6 +279,23 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         print(result) 
         assert_true('result' in result)
         assert_true('transactionId' in result['result'])
+        print("Ok!")
+
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        # Try to create an openStake transaction with the forge operation already opened. The transaction should be rejected.
+        print("Try to create an openStake transaction with the forge operation already opened. The transaction should be rejected.")
+        sendCoinsToAddress(sc_node1, self.allowed_forger_propositions[3].publicKey, 1500, 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        tx_bytes = createOpenStakeTransactionSimplified(sc_node1, self.allowed_forger_propositions[3].publicKey,3,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true('error' in res)
+        assert_true('OpenStakeTransactions are not allowed because the forger operation has already been opened' in res['error']['detail'])
         print("Ok!")
 
 if __name__ == "__main__":

--- a/qa/sc_closed_forger.py
+++ b/qa/sc_closed_forger.py
@@ -15,6 +15,8 @@ from SidechainTestFramework.sidechainauthproxy import SCAPIException
 
 """
     Setup 1 SC Node with a closed list of forger. Try to stake money with invalid forger info and verify that we are not allowed to stake.
+    After that open the stake to the world using the openStakeTransaction and verify that a generic proposition (not included in the forger list) 
+    is allowed to forge.
 """
 class SidechainClosedForgerTest(SidechainTestFramework):
     number_of_mc_nodes = 1

--- a/qa/sc_closed_forger.py
+++ b/qa/sc_closed_forger.py
@@ -231,7 +231,9 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         self.sc_sync_all()
         print("Ok!")
 
-        # Try to stake with an invalid blockSignProposition and an invalid vrfPublicKey
+        # Try to stake with an invalid blockSignProposition and an invalid vrfPublicKey.
+        # It should be fail because the majority of the allowed forgers didn't opened the stake yet.
+        # (At this time only 2/5 of the allowed forgers opened the stake).
         print("Try to stake to an invalid vrfPublicKey...")
         result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, new_public_key, new_vrf_public_key, forger_amount, sc_fee)
         print(result)

--- a/qa/sc_closed_forger.py
+++ b/qa/sc_closed_forger.py
@@ -48,7 +48,8 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         sc_node_1_configuration = SCNodeConfiguration(
             MCConnectionInfo(address="ws://{0}:{1}".format(mc_node_1.hostname, websocket_port_by_mc_node_index(0))),
             forger_options = forger_configuration,
-            initial_private_keys=list(map(lambda forger: forger.secret,self.allowed_forger_propositions))
+            initial_private_keys=list(map(lambda forger: forger.secret,self.allowed_forger_propositions)),
+            max_fee=10000000000000
         )
         network = SCNetworkConfiguration(SCCreationInfo(mc_node_1, 600, LARGE_WITHDRAWAL_EPOCH_LENGTH),
                                          sc_node_1_configuration)

--- a/sdk/src/main/java/com/horizen/transaction/CoreTransactionsIdsEnum.java
+++ b/sdk/src/main/java/com/horizen/transaction/CoreTransactionsIdsEnum.java
@@ -3,7 +3,8 @@ package com.horizen.transaction;
 public enum CoreTransactionsIdsEnum {
     SidechainCoreTransactionId((byte)1),
     MC2SCAggregatedTransactionId((byte)2),
-    FeePaymentsTransactionId((byte)3);
+    FeePaymentsTransactionId((byte)3),
+    OpenStakeTransactionId((byte)4);
 
     private final byte id;
 

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
@@ -99,9 +99,9 @@ public class OpenStakeTransaction extends SidechainNoncedTransaction<PublicKey25
                     "unsupported version number.", id()));
         }
 
-        if (inputsIds.isEmpty() || outputsData.isEmpty())
+        if (inputsIds.isEmpty())
             throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
-                    "no input and output data present.", id()));
+                    "no input data present.", id()));
 
         if (inputsIds.size() != 1) {
             throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
@@ -1,0 +1,148 @@
+package com.horizen.transaction;
+
+import com.google.common.primitives.Ints;
+import com.horizen.box.BoxUnlocker;
+import com.horizen.box.ZenBox;
+import com.horizen.box.data.ZenBoxData;
+import com.horizen.proof.Proof;
+import com.horizen.proposition.Proposition;
+import com.horizen.proposition.PublicKey25519Proposition;
+import com.horizen.transaction.exception.TransactionSemanticValidityException;
+import scala.Array;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static com.horizen.transaction.CoreTransactionsIdsEnum.OpenStakeTransactionId;
+
+public class OpenStakeTransaction extends SidechainNoncedTransaction<PublicKey25519Proposition, ZenBox, ZenBoxData>{
+    public final static byte OPEN_STAKE_TRANSACTION_VERSION = 1;
+
+    final List<byte[]> inputsIds;
+    private final List<ZenBoxData> outputsData;
+    final List<Proof<Proposition>> proofs;
+
+    private final long fee;
+
+    private final byte version;
+
+    private List<BoxUnlocker<PublicKey25519Proposition>> unlockers;
+
+    private final int forgerListIndex;
+
+    public OpenStakeTransaction(List<byte[]> inputsIds,
+                                List<ZenBoxData> outputsData,
+                                List<Proof<Proposition>> proofs,
+                                int forgerListIndex,
+                                long fee,
+                                byte version) {
+        Objects.requireNonNull(inputsIds, "Inputs Ids list can't be null.");
+        Objects.requireNonNull(outputsData, "Outputs Data list can't be null.");
+        Objects.requireNonNull(proofs, "Proofs list can't be null.");
+
+        this.inputsIds = inputsIds;
+        this.outputsData = outputsData;
+        this.proofs = proofs;
+        this.forgerListIndex = forgerListIndex;
+        this.fee = fee;
+        this.version = version;
+    }
+
+    @Override
+    public TransactionSerializer serializer() {
+        return OpenStakeTransactionSerializer.getSerializer();
+    }
+
+    @Override
+    public synchronized List<BoxUnlocker<PublicKey25519Proposition>> unlockers() {
+        if(unlockers == null) {
+            unlockers = new ArrayList<>();
+            for (int i = 0; i < inputsIds.size() && i < proofs.size(); i++) {
+                int finalI = i;
+                BoxUnlocker<PublicKey25519Proposition> unlocker = new BoxUnlocker() {
+                    @Override
+                    public byte[] closedBoxId() {
+                        return inputsIds.get(finalI);
+                    }
+
+                    @Override
+                    public Proof boxKey() {
+                        return proofs.get(finalI);
+                    }
+                };
+                unlockers.add(unlocker);
+            }
+        }
+
+        return Collections.unmodifiableList(unlockers);
+    }
+
+    @Override
+    protected List<ZenBoxData> getOutputData(){
+        return outputsData;
+    }
+
+    @Override
+    public long fee() {
+        return this.fee;
+    }
+
+    @Override
+    public void transactionSemanticValidity() throws TransactionSemanticValidityException {
+        if (version != OPEN_STAKE_TRANSACTION_VERSION) {
+            throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
+                    "unsupported version number.", id()));
+        }
+
+        if (inputsIds.isEmpty() || outputsData.isEmpty())
+            throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
+                    "no input and output data present.", id()));
+
+        if (inputsIds.size() != 1) {
+            throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
+                    "input size != 1.", id()));
+        }
+
+        // check that we have enough proofs and try to open each box only once.
+        if (inputsIds.size() != proofs.size() || inputsIds.size() != boxIdsToOpen().size())
+            throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
+                    "inputs number is not consistent to proofs number.", id()));
+
+        if (forgerListIndex < 0) {
+            throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
+                    "forgerList index negative.", id()));
+        }
+    }
+
+    @Override
+    public byte transactionTypeId() {
+        return OpenStakeTransactionId.id();
+    }
+
+    @Override
+    public byte version() {
+        return version;
+    }
+
+    @Override
+    public Boolean isCustom() { return false; }
+
+    @Override
+    public byte[] customFieldsData() {
+        return Array.emptyByteArray();
+    }
+
+    @Override
+    public byte[] customDataMessageToSign() {
+        return Ints.toByteArray(this.forgerListIndex);
+    }
+
+    public int getForgerListIndex() { return this.forgerListIndex; }
+
+    public TransactionIncompatibilityChecker incompatibilityChecker() {
+        return new OpenStakeTransactionIncompatibilityChecker();
+    }
+
+}

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
@@ -20,6 +20,12 @@ import java.util.Objects;
 
 import static com.horizen.transaction.CoreTransactionsIdsEnum.OpenStakeTransactionId;
 
+/**
+ * OpenStakeTransaction is used to open the forging stake to the world.
+ * It can be used when the flag "restrictForger" is enabled and can be fired only by the allowed forgers inside the "allowedForgers" list.
+ * This transaction has 1 input and 1 output. It contains a custom field "forgerIndex" that identify a specific forger inside the "allowedForgers" list.
+ * The input must be locked by the corresponding proposition indexed by "forgerIndex" inside the "allowedForgers" list.
+ */
 public class OpenStakeTransaction extends SidechainNoncedTransaction<PublicKey25519Proposition, ZenBox, ZenBoxData>{
     public final static byte OPEN_STAKE_TRANSACTION_VERSION = 1;
 
@@ -44,6 +50,10 @@ public class OpenStakeTransaction extends SidechainNoncedTransaction<PublicKey25
         Objects.requireNonNull(inputsIds, "Inputs Ids list can't be null.");
         Objects.requireNonNull(outputsData, "Outputs Data list can't be null.");
         Objects.requireNonNull(proofs, "Proofs list can't be null.");
+
+        if(inputsIds.size() != 1) {
+            throw new IllegalArgumentException("Input Ids list should contains only 1 element!");
+        }
 
         this.inputsIds = inputsIds;
         this.outputsData = outputsData;

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
@@ -20,7 +20,7 @@ import static com.horizen.transaction.CoreTransactionsIdsEnum.OpenStakeTransacti
 /**
  * OpenStakeTransaction is used to open the forging stake to the world.
  * It can be used when the flag "restrictForger" is enabled and can be fired only by the allowed forgers inside the "allowedForgers" list.
- * This transaction has 1 input and 1 output. It contains a custom field "forgerIndex" that identify a specific forger inside the "allowedForgers" list.
+ * This transaction has 1 input and 0 or 1 output. It contains a custom field "forgerIndex" that identify a specific forger inside the "allowedForgers" list.
  * The input must be locked by the corresponding proposition indexed by "forgerIndex" inside the "allowedForgers" list.
  */
 public class OpenStakeTransaction extends SidechainNoncedTransaction<PublicKey25519Proposition, ZenBox, ZenBoxData>{

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
@@ -149,7 +149,7 @@ public class OpenStakeTransaction extends SidechainNoncedTransaction<PublicKey25
 
 
     public static OpenStakeTransaction create(Pair<ZenBox, PrivateKey25519> from,
-                                              Optional<PublicKey25519Proposition> changeAddress,
+                                              PublicKey25519Proposition changeAddress,
                                               int forgerIndex,
                                               long fee) throws TransactionSemanticValidityException {
         if(from == null)
@@ -158,8 +158,8 @@ public class OpenStakeTransaction extends SidechainNoncedTransaction<PublicKey25
             throw new IllegalArgumentException("Fee can't be greater than the input!");
 
         Optional<ZenBoxData> output = Optional.empty();
-        if(changeAddress.isPresent() && from.getKey().value() > fee) {
-            output = Optional.of(new ZenBoxData(changeAddress.get(), from.getKey().value() - fee));
+        if(from.getKey().value() > fee) {
+            output = Optional.of(new ZenBoxData(changeAddress, from.getKey().value() - fee));
         }
         OpenStakeTransaction unsignedTransaction = new OpenStakeTransaction(from.getKey().id(), output, null, forgerIndex, fee, OPEN_STAKE_TRANSACTION_VERSION);
 

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionIncompatibilityChecker.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionIncompatibilityChecker.java
@@ -11,7 +11,7 @@ public class OpenStakeTransactionIncompatibilityChecker extends DefaultTransacti
             OpenStakeTransaction openStakeTransaction = (OpenStakeTransaction) newTx;
             for (T mempoolTx: currentTxs) {
                 if (mempoolTx instanceof OpenStakeTransaction) {
-                    if (openStakeTransaction.getForgerListIndex() == ((OpenStakeTransaction) mempoolTx).getForgerListIndex()) {
+                    if (openStakeTransaction.getForgerIndex() == ((OpenStakeTransaction) mempoolTx).getForgerIndex()) {
                         return false;
                     }
                 }

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionIncompatibilityChecker.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionIncompatibilityChecker.java
@@ -1,0 +1,22 @@
+package com.horizen.transaction;
+
+import java.util.List;
+
+public class OpenStakeTransactionIncompatibilityChecker extends DefaultTransactionIncompatibilityChecker{
+    @Override
+    public <T extends BoxTransaction> boolean isTransactionCompatible(T newTx, List<T> currentTxs) {
+        if (!super.isTransactionCompatible(newTx, currentTxs)) {
+            return false;
+        } else if (newTx instanceof OpenStakeTransaction) {
+            OpenStakeTransaction openStakeTransaction = (OpenStakeTransaction) newTx;
+            for (T mempoolTx: currentTxs) {
+                if (mempoolTx instanceof OpenStakeTransaction) {
+                    if (openStakeTransaction.getForgerListIndex() == ((OpenStakeTransaction) mempoolTx).getForgerListIndex()) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionSerializer.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionSerializer.java
@@ -1,0 +1,73 @@
+package com.horizen.transaction;
+
+import com.horizen.box.data.ZenBoxData;
+import com.horizen.box.data.ZenBoxDataSerializer;
+import com.horizen.proof.Proof;
+import com.horizen.proof.Signature25519Serializer;
+import com.horizen.proposition.Proposition;
+import com.horizen.utils.ListSerializer;
+import scorex.core.NodeViewModifier$;
+import scorex.util.serialization.Reader;
+import scorex.util.serialization.Writer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.horizen.transaction.BoxTransaction.MAX_TRANSACTION_UNLOCKERS;
+import static com.horizen.transaction.OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION;
+
+public class OpenStakeTransactionSerializer implements TransactionSerializer<OpenStakeTransaction>
+{
+    private static OpenStakeTransactionSerializer serializer;
+
+    private static ListSerializer<ZenBoxData> outputsSerializer = new ListSerializer(ZenBoxDataSerializer.getSerializer());
+
+    private final static ListSerializer<Proof<Proposition>> proofsSerializer = new ListSerializer(Signature25519Serializer.getSerializer(), MAX_TRANSACTION_UNLOCKERS);
+
+    static {
+        serializer = new OpenStakeTransactionSerializer();
+    }
+
+    private OpenStakeTransactionSerializer() {
+        super();
+    }
+
+    public static OpenStakeTransactionSerializer getSerializer() {
+        return serializer;
+    }
+
+    @Override
+    public void serialize(OpenStakeTransaction transaction, Writer writer) {
+        writer.put(transaction.version());
+        writer.putLong(transaction.fee());
+        writer.putInt(transaction.inputsIds.size());
+        for (byte[] id: transaction.inputsIds) {
+            writer.putBytes(id);
+        }
+        outputsSerializer.serialize(transaction.getOutputData(), writer);
+        proofsSerializer.serialize(transaction.proofs, writer);
+        writer.putInt(transaction.getForgerListIndex());
+    }
+
+    @Override
+    public OpenStakeTransaction parse(Reader reader) {
+        byte version = reader.getByte();
+        if (version != OPEN_STAKE_TRANSACTION_VERSION) {
+            throw new IllegalArgumentException(String.format("Unsupported transaction version[%d].", version));
+        }
+
+        long fee = reader.getLong();
+        int inputsNum = reader.getInt();
+
+        ArrayList<byte[]> inputsIds = new ArrayList<>();
+        for(int i = 0; i < inputsNum; i++) {
+            inputsIds.add(reader.getBytes(NodeViewModifier$.MODULE$.ModifierIdSize()));
+        }
+
+        List<ZenBoxData> outputsData = outputsSerializer.parse(reader);
+        List<Proof<Proposition>> proofs = proofsSerializer.parse(reader);
+        int forgerListIndex = reader.getInt();
+
+        return new OpenStakeTransaction(inputsIds, outputsData, proofs, forgerListIndex, fee, version);
+    }
+}

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionSerializer.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionSerializer.java
@@ -2,16 +2,12 @@ package com.horizen.transaction;
 
 import com.horizen.box.data.ZenBoxData;
 import com.horizen.box.data.ZenBoxDataSerializer;
-import com.horizen.proof.Proof;
-import com.horizen.proof.ProofSerializer;
+import com.horizen.proof.Signature25519;
 import com.horizen.proof.Signature25519Serializer;
-import com.horizen.proposition.Proposition;
-import com.horizen.utils.ListSerializer;
 import scorex.core.NodeViewModifier$;
 import scorex.util.serialization.Reader;
 import scorex.util.serialization.Writer;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.horizen.transaction.OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION;
@@ -19,10 +15,6 @@ import static com.horizen.transaction.OpenStakeTransaction.OPEN_STAKE_TRANSACTIO
 public class OpenStakeTransactionSerializer implements TransactionSerializer<OpenStakeTransaction>
 {
     private static OpenStakeTransactionSerializer serializer;
-
-    private static ListSerializer<ZenBoxData> outputsSerializer = new ListSerializer(ZenBoxDataSerializer.getSerializer());
-
-    private final static ProofSerializer proofsSerializer =  Signature25519Serializer.getSerializer();
 
     static {
         serializer = new OpenStakeTransactionSerializer();
@@ -40,9 +32,14 @@ public class OpenStakeTransactionSerializer implements TransactionSerializer<Ope
     public void serialize(OpenStakeTransaction transaction, Writer writer) {
         writer.put(transaction.version());
         writer.putLong(transaction.fee());
-        writer.putBytes(transaction.inputsIds);
-        outputsSerializer.serialize(transaction.getOutputData(), writer);
-        proofsSerializer.serialize(transaction.proofs, writer);
+        writer.putBytes(transaction.inputId);
+        if(transaction.getOutputBox().isPresent()) {
+            writer.putInt(1);
+            ZenBoxDataSerializer.getSerializer().serialize(transaction.getOutputBox().get(), writer);
+        } else {
+            writer.putInt(0);
+        }
+        Signature25519Serializer.getSerializer().serialize(transaction.proof, writer);
         writer.putInt(transaction.getForgerIndex());
     }
 
@@ -57,15 +54,15 @@ public class OpenStakeTransactionSerializer implements TransactionSerializer<Ope
 
         byte[] inputsId = reader.getBytes(NodeViewModifier$.MODULE$.ModifierIdSize());
 
-        List<ZenBoxData> outputsData = outputsSerializer.parse(reader);
+        int outputDataIsPresent = reader.getInt();
         java.util.Optional<ZenBoxData> output = Optional.empty();
-        if (outputsData.size() > 0) {
-            output = Optional.of(outputsData.get(0));
+        if (outputDataIsPresent == 1) {
+            output = Optional.of(ZenBoxDataSerializer.getSerializer().parse(reader));
         }
 
-        Proof<Proposition> proof = proofsSerializer.parse(reader);
-        int forgerListIndex = reader.getInt();
+        Signature25519 proof = Signature25519Serializer.getSerializer().parse(reader);
+        int forgerIndex = reader.getInt();
 
-        return new OpenStakeTransaction(inputsId, output, proof, forgerListIndex, fee, version);
+        return new OpenStakeTransaction(inputsId, output, proof, forgerIndex, fee, version);
     }
 }

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -313,7 +313,7 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
               throw new Exception("Forger already opened the stake!")
             }
           case None =>
-            throw new Exception("Forger list doesn't find in the Storage")
+            throw new Exception("Forger list was not found in the Storage!")
         }
         stateStorage.getBox(openStakeTransaction.unlockers().get(0).closedBoxId()) match {
           case Some(closedBox) =>

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -301,8 +301,6 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
     if (!tx.isInstanceOf[MC2SCAggregatedTransaction]) {
 
       if (tx.isInstanceOf[OpenStakeTransaction]) {
-        if (!params.restrictForgers)
-          throw new Exception("OpenStakeTransactions are not allowed with restrictForgers=false!")
         if (isForgingOpen())
           throw new Exception("OpenStakeTransactions are not allowed because the forger operation has already been opened!")
         val openStakeTransaction = tx.asInstanceOf[OpenStakeTransaction]
@@ -358,7 +356,7 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
       newBoxes
         .filter(box => box.isInstanceOf[ForgerBox])
         .foreach(forgerBox => {
-          if (params.restrictForgers && !isForgerOpen) {
+          if (!isForgerOpen) {
             val vrfPublicKey: VrfPublicKey = forgerBox.vrfPubKey()
             val blockSignProposition: PublicKey25519Proposition = forgerBox.blockSignProposition()
             if (!params.allowedForgersList.contains((blockSignProposition, vrfPublicKey))) {

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -188,10 +188,13 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
     val forgerListIndexes = new JArrayList[Int]()
     mod.transactions.foreach(tx => {
       if (tx.isInstanceOf[OpenStakeTransaction]) {
+        if (!params.restrictForgers) {
+          throw new IllegalArgumentException("OpenStakeTransactions are not allowed with restrictForgers=false!")
+        }
         val openStakeTransaction = tx.asInstanceOf[OpenStakeTransaction]
-        if (forgerListIndexes.contains(openStakeTransaction.getForgerListIndex))
+        if (forgerListIndexes.contains(openStakeTransaction.getForgerIndex))
           throw new IllegalArgumentException(s"Block ${mod.id} contains OpenStakeTransactions with duplicated forgerListIndex")
-        forgerListIndexes.add(openStakeTransaction.getForgerListIndex)
+        forgerListIndexes.add(openStakeTransaction.getForgerIndex)
       }
     })
     
@@ -304,12 +307,12 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
         if (!params.restrictForgers)
           throw new Exception("OpenStakeTransactions are not allowed with restrictForgers=false!")
         val openStakeTransaction = tx.asInstanceOf[OpenStakeTransaction]
-        if (openStakeTransaction.getForgerListIndex >= params.allowedForgersList.size || openStakeTransaction.getForgerListIndex < 0) {
+        if (openStakeTransaction.getForgerIndex >= params.allowedForgersList.size || openStakeTransaction.getForgerIndex < 0) {
           throw new Exception("ForgerListIndex in OpenStakeTransaction is out of bound!")
         }
         stateStorage.getForgerList match {
           case Some(forgerList) =>
-            if (forgerList.forgerIndexes(openStakeTransaction.getForgerListIndex) == 1) {
+            if (forgerList.forgerIndexes(openStakeTransaction.getForgerIndex) == 1) {
               throw new Exception("Forger already opened the stake!")
             }
           case None =>
@@ -318,7 +321,7 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
         stateStorage.getBox(openStakeTransaction.unlockers().get(0).closedBoxId()) match {
           case Some(closedBox) =>
             if (!closedBox.proposition().asInstanceOf[PublicKey25519Proposition]
-              .equals(params.allowedForgersList.asJava.get(openStakeTransaction.getForgerListIndex)._1)) {
+              .equals(params.allowedForgersList.asJava.get(openStakeTransaction.getForgerIndex)._1)) {
               throw new Exception("OpenStakeTransaction input doesn't match the forgerListIndex!")
             }
           case None =>
@@ -401,16 +404,19 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
 
   //Take the list of transactions inside a block and calculate the forgerList indexes to update
   def getRestrictForgerIndexToUpdate(txs:  Seq[SidechainTransaction[Proposition, Box[Proposition]]]): Array[Int] = {
-    val forgerIndexesToUpdate = new JArrayList[Int]()
     if (txs != null) {
-      txs.foreach(tx => {
+      txs.flatMap(tx => {
         if (tx.isInstanceOf[OpenStakeTransaction]) {
           val openStakeTransaction: OpenStakeTransaction = tx.asInstanceOf[OpenStakeTransaction]
-          forgerIndexesToUpdate.add(openStakeTransaction.getForgerListIndex)
+          Some(openStakeTransaction.getForgerIndex)
+        } else {
+          None
         }
-      })
+      }).toArray
     }
-    forgerIndexesToUpdate.asScala.toArray
+    else {
+      Array[Int]()
+    }
   }
 
   // apply global changes and delegate SDK unknown part to Sidechain.applyChanges(...)

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -322,7 +322,7 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
               throw new Exception("OpenStakeTransaction input doesn't match the forgerListIndex!")
             }
           case None =>
-            throw new Exception("Input box doesn't find!")
+            throw new Exception("Input box not found!")
         }
       }
 

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -312,6 +312,9 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
         }
         stateStorage.getForgerList match {
           case Some(forgerList) =>
+            if (openStakeTransaction.getForgerIndex >= forgerList.forgerIndexes.length) {
+              throw new Exception("OpenStakeTransaction forgerIndex out of bound!")
+            }
             if (forgerList.forgerIndexes(openStakeTransaction.getForgerIndex) == 1) {
               throw new Exception("Forger already opened the stake!")
             }

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -188,9 +188,6 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
     val forgerListIndexes = new JArrayList[Int]()
     mod.transactions.foreach(tx => {
       if (tx.isInstanceOf[OpenStakeTransaction]) {
-        if (!params.restrictForgers) {
-          throw new IllegalArgumentException("OpenStakeTransactions are not allowed with restrictForgers=false!")
-        }
         val openStakeTransaction = tx.asInstanceOf[OpenStakeTransaction]
         if (forgerListIndexes.contains(openStakeTransaction.getForgerIndex))
           throw new IllegalArgumentException(s"Block ${mod.id} contains OpenStakeTransactions with duplicated forgerIndex")
@@ -306,7 +303,7 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
       if (tx.isInstanceOf[OpenStakeTransaction]) {
         if (!params.restrictForgers)
           throw new Exception("OpenStakeTransactions are not allowed with restrictForgers=false!")
-        if (openForger())
+        if (isForgingOpen())
           throw new Exception("OpenStakeTransactions are not allowed because the forger operation has already been opened!")
         val openStakeTransaction = tx.asInstanceOf[OpenStakeTransaction]
         if (openStakeTransaction.getForgerIndex >= params.allowedForgersList.size || openStakeTransaction.getForgerIndex < 0) {
@@ -357,10 +354,11 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
         throw new Exception("Amounts sum of CoinsBoxes is incorrect. " +
           s"ClosedBox amount - $closedCoinsBoxesAmount, NewBoxesAmount - $newCoinsBoxesAmount, Fee - ${tx.fee()}")
 
+      lazy val isForgerOpen = isForgingOpen()
       newBoxes
         .filter(box => box.isInstanceOf[ForgerBox])
         .foreach(forgerBox => {
-          if (params.restrictForgers && !openForger()) {
+          if (params.restrictForgers && !isForgerOpen) {
             val vrfPublicKey: VrfPublicKey = forgerBox.vrfPubKey()
             val blockSignProposition: PublicKey25519Proposition = forgerBox.blockSignProposition()
             if (!params.allowedForgersList.contains((blockSignProposition, vrfPublicKey))) {
@@ -380,15 +378,19 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
   }
 
   //Check if the majority of the allowed forgers opened the stake to everyone
-  def openForger(): Boolean = {
-    val nOpenForger: Int = stateStorage.getForgerList match {
-      case Some(forgerList: ForgerList) =>
-        forgerList.forgerIndexes.sum
-      case None =>
-        log.error("No forgerList found in the Storage!")
-        0
+  def isForgingOpen(): Boolean = {
+    if (!params.restrictForgers)
+      true
+    else {
+      val nOpenForger: Int = stateStorage.getForgerList match {
+        case Some(forgerList: ForgerList) =>
+          forgerList.forgerIndexes.sum
+        case None =>
+          log.error("No forgerList found in the Storage!")
+          0
+      }
+      nOpenForger > params.allowedForgersList.size / 2
     }
-    nOpenForger > params.allowedForgersList.size / 2
   }
 
   override def applyModifier(mod: SidechainBlock): Try[SidechainState] = {

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -307,7 +307,7 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
         if (openStakeTransaction.getForgerListIndex >= params.allowedForgersList.size || openStakeTransaction.getForgerListIndex < 0) {
           throw new Exception("ForgerListIndex in OpenStakeTransaction is out of bound!")
         }
-        stateStorage.getForgerListIndexes match {
+        stateStorage.getForgerList match {
           case Some(forgerList) =>
             if (forgerList.forgerIndexes(openStakeTransaction.getForgerListIndex) == 1) {
               throw new Exception("Forger already opened the stake!")
@@ -373,12 +373,12 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
 
   //Check if the majority of the allowed forgers opened the stake to everyone
   def openForger(): Boolean = {
-    var nOpenForger = 0
-    stateStorage.getForgerListIndexes match {
+    val nOpenForger: Int = stateStorage.getForgerList match {
       case Some(forgerList: ForgerList) =>
-        nOpenForger = forgerList.forgerIndexes.sum
+        forgerList.forgerIndexes.sum
       case None =>
         log.error("No forgerList found in the Storage!")
+        0
     }
     nOpenForger > params.allowedForgersList.size / 2
   }

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -562,7 +562,7 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
     new SidechainCoreTransaction(boxIds, outputs, proofs.asJava, fee, SidechainCoreTransaction.SIDECHAIN_CORE_TRANSACTION_VERSION)
   }
 
-  def openStakeTransaction: Route = (post & path("openStake")) {
+  def openStakeTransaction: Route = (post & path("createOpenStakeTransaction")) {
     entity(as[ReqOpenStake]) { body =>
       applyOnNodeView { sidechainNodeView =>
         val wallet = sidechainNodeView.getNodeWallet

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -30,7 +30,6 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.control.Breaks._
 import scala.util.{Failure, Success, Try}
 import java.util.{Optional => JOptional}
-import scala.collection.mutable
 
 case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
                                         sidechainNodeViewHolderRef: ActorRef,
@@ -517,7 +516,7 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
         .filter(box => box.proposition().equals(PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(body.forgerProposition))))
       if (inputBox.isEmpty)
         throw new IllegalArgumentException("Unable to find input for Proposition "+body.forgerProposition)
-      createAndSignOpenStakeTransaction(wallet, inputBox, body.forgerProposition, body.forgerListIndex, body.fee)
+      createAndSignOpenStakeTransaction(wallet, inputBox.head, body.forgerProposition, body.forgerListIndex, body.fee)
     }
   }
 
@@ -532,49 +531,45 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
       //Collect input box
       val inputBox = wallet.allBoxes().asScala
         .filter(box => BytesUtils.toHexString(box.id()).equals(body.transactionInput.boxId))
-      if (inputBox.length == 0) {
+      if (inputBox.isEmpty) {
         throw new IllegalArgumentException("Unable to find input!")
       }
       if (inputBox.length > 1) {
         throw new IllegalArgumentException("To much inputs found!")
       }
 
-      createAndSignOpenStakeTransaction(wallet, inputBox, body.regularOutputProposition, body.forgerListIndex, body.fee)
+      createAndSignOpenStakeTransaction(wallet, inputBox.head, body.regularOutputProposition, body.forgerListIndex, body.fee)
     }
   }
 
 
-  private def createAndSignOpenStakeTransaction(wallet: NodeWallet, inputBox: mutable.Buffer[Box[Proposition]], outputProposition: String,
+  private def createAndSignOpenStakeTransaction(wallet: NodeWallet, inputBox: Box[Proposition], outputProposition: String,
                                                 forgerListIndex: Int, inputFee: Option[Long]): Try[OpenStakeTransaction] = {
     //Collect fee
     val fee = inputFee.getOrElse(0L)
     if (fee < 0) {
       throw new IllegalArgumentException("Fee can't be negative!")
     }
-    if (fee > inputBox(0).value) {
+    if (fee > inputBox.value) {
       throw new IllegalArgumentException("Fee can't be greater than the input!")
     }
 
     //Collect output box
-    val outputs: JList[ZenBoxData] = new JArrayList()
-    outputs.add(new ZenBoxData(
-      PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(outputProposition)),
-      inputBox(0).value() - fee))
+    var output:JOptional[ZenBoxData] = JOptional.empty()
+    if (fee < inputBox.value()) {
+      output = JOptional.of(new ZenBoxData(
+        PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(outputProposition)),
+        inputBox.value() - fee))
+    }
 
     Try {
-      val boxIds = inputBox.map(_.id()).asJava
       // Create unsigned tx
-      // Create a list of fake proofs for further messageToSign calculation
-      val fakeProofs: JList[Proof[Proposition]] = Collections.nCopies(1, null)
-
-      val unsignedTransaction = new OpenStakeTransaction(boxIds, outputs, fakeProofs, forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
+      val unsignedTransaction = new OpenStakeTransaction(inputBox.id(), output, null, forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
 
       // Create signed tx.
       val messageToSign = unsignedTransaction.messageToSign()
-      val proofs = inputBox.map(box => {
-        wallet.secretByPublicKey(box.proposition()).get().sign(messageToSign).asInstanceOf[Proof[Proposition]]
-      })
-      new OpenStakeTransaction(boxIds, outputs, proofs.asJava, forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
+      val proof = wallet.secretByPublicKey(inputBox.proposition()).get().sign(messageToSign).asInstanceOf[Proof[Proposition]]
+      new OpenStakeTransaction(inputBox.id(), output, proof, forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
     }
   }
 

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -660,7 +660,6 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
 
     new SidechainCoreTransaction(boxIds, outputs, proofs.asJava, fee, SidechainCoreTransaction.SIDECHAIN_CORE_TRANSACTION_VERSION)
   }
-
 }
 
 
@@ -766,7 +765,7 @@ object SidechainTransactionRestScheme {
                                        automaticSend: Option[Boolean],
                                        @JsonDeserialize(contentAs = classOf[java.lang.Long]) fee: Option[Long]) {
     require(transactionInput != null, "Empty input")
-    require(regularOutputProposition.nonEmpty, "Empty output")
+    require(regularOutputProposition.nonEmpty, "Empty regularOutputProposition")
     require(forgerListIndex >= 0, "Forger list index negative")
   }
 
@@ -776,6 +775,7 @@ object SidechainTransactionRestScheme {
                                        format: Option[Boolean],
                                        automaticSend: Option[Boolean],
                                        @JsonDeserialize(contentAs = classOf[java.lang.Long]) fee: Option[Long]) {
+    require(forgerProposition.nonEmpty, "Empty forgerProposition")
     require(forgerListIndex >= 0, "Forger list index negative")
   }
 }

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -41,7 +41,7 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
 
   override val route: Route = (pathPrefix("transaction")) {
     allTransactions ~ findById ~ decodeTransactionBytes ~ createCoreTransaction ~ createCoreTransactionSimplified ~
-    sendCoinsToAddress ~ sendTransaction ~ withdrawCoins ~ makeForgerStake ~ spendForgingStake ~ openStakeTransaction
+    sendCoinsToAddress ~ sendTransaction ~ withdrawCoins ~ makeForgerStake ~ spendForgingStake ~ createOpenStakeTransaction ~ sendOpenStakeTransaction
   }
 
   /**
@@ -472,6 +472,75 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
     }
   }
 
+  def createOpenStakeTransaction: Route = (post & path("createOpenStakeTransaction")) {
+    entity(as[ReqOpenStake]) { body =>
+      val transaction = createAndSignOpenStakeTransaction(body)
+      if (body.format.getOrElse(false))
+        ApiResponseUtil.toResponse(TransactionDTO(transaction.asInstanceOf[SCBT]))
+      else
+        ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(transaction.asInstanceOf[SCBT]))))
+    }
+  }
+
+  def sendOpenStakeTransaction: Route = (post & path("sendOpenStakeTransaction")) {
+    entity(as[ReqOpenStake]) { body =>
+      val transaction = createAndSignOpenStakeTransaction(body)
+      validateAndSendTransaction(transaction.asInstanceOf[SidechainTypes#SCBT])
+    }
+  }
+
+  /**
+   * Create and sign a openStakeTransaction
+   * @return a signed OpenStakeTransaction or a GenericTransactionError
+   */
+  private def createAndSignOpenStakeTransaction(body: ReqOpenStake): OpenStakeTransaction = {
+    applyOnNodeView { sidechainNodeView =>
+      val wallet = sidechainNodeView.getNodeWallet
+
+      //Collect fee
+      val fee = body.fee.getOrElse(0L)
+      if (fee < 0) {
+        throw new IllegalArgumentException("Fee can't be negative!")
+      }
+
+      //Collect input box
+      val inputBox = wallet.allBoxes().asScala
+        .filter(box => BytesUtils.toHexString(box.id()).equals(body.transactionInput.boxId))
+      if (inputBox.length == 0) {
+        throw new IllegalArgumentException("Unable to find input!")
+      }
+      if (inputBox.length > 1) {
+        throw new IllegalArgumentException("To much inputs found!")
+      }
+      val boxIds = inputBox.map(_.id()).asJava
+
+      //Collect output box
+      val outputs: JList[ZenBoxData] = new JArrayList()
+      outputs.add(new ZenBoxData(
+        PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(body.regularOutputProposition)),
+        inputBox(0).value() - fee))
+
+      try {
+        // Create unsigned tx
+        // Create a list of fake proofs for further messageToSign calculation
+        val fakeProofs: JList[Proof[Proposition]] = Collections.nCopies(1, null)
+
+        val unsignedTransaction = new OpenStakeTransaction(boxIds, outputs, fakeProofs, body.forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
+
+        // Create signed tx.
+        val messageToSign = unsignedTransaction.messageToSign()
+        val proofs = inputBox.map(box => {
+          wallet.secretByPublicKey(box.proposition()).get().sign(messageToSign).asInstanceOf[Proof[Proposition]]
+        })
+       new OpenStakeTransaction(boxIds, outputs, proofs.asJava, body.forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
+      } catch {
+        case t: Throwable =>
+          throw new RuntimeException("Error during the creation of the OpenStakeTransaction!")
+      }
+    }
+
+  }
+
   // try to get the first PublicKey25519Proposition in the wallet
   // None - if not present.
   private def getChangeAddress(wallet: NodeWallet): Option[PublicKey25519Proposition] = {
@@ -562,58 +631,6 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
     new SidechainCoreTransaction(boxIds, outputs, proofs.asJava, fee, SidechainCoreTransaction.SIDECHAIN_CORE_TRANSACTION_VERSION)
   }
 
-  def openStakeTransaction: Route = (post & path("createOpenStakeTransaction")) {
-    entity(as[ReqOpenStake]) { body =>
-      applyOnNodeView { sidechainNodeView =>
-        val wallet = sidechainNodeView.getNodeWallet
-
-        //Collect fee
-        val fee = body.fee.getOrElse(0L)
-        if (fee < 0) {
-          throw new IllegalArgumentException("Fee can't be negative!")
-        }
-
-        //Collect input box
-        val inputBox = wallet.allBoxes().asScala
-          .filter(box => BytesUtils.toHexString(box.id()).equals(body.transactionInput.boxId))
-        if (inputBox.length == 0) {
-          throw new IllegalArgumentException("Unable to find input!")
-        }
-        if (inputBox.length > 1) {
-          throw new IllegalArgumentException("To much inputs found!")
-        }
-        val boxIds = inputBox.map(_.id()).asJava
-
-        //Collect output box
-        val outputs: JList[ZenBoxData] = new JArrayList()
-        outputs.add(new ZenBoxData(
-          PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(body.regularOutputProposition)),
-          inputBox(0).value() - fee))
-
-        try {
-          // Create unsigned tx
-          // Create a list of fake proofs for further messageToSign calculation
-          val fakeProofs: JList[Proof[Proposition]] = Collections.nCopies(1, null)
-
-          val unsignedTransaction = new OpenStakeTransaction(boxIds, outputs, fakeProofs, body.forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
-
-          // Create signed tx.
-          val messageToSign = unsignedTransaction.messageToSign()
-          val proofs = inputBox.map(box => {
-            wallet.secretByPublicKey(box.proposition()).get().sign(messageToSign).asInstanceOf[Proof[Proposition]]
-          })
-          val transaction = new OpenStakeTransaction(boxIds, outputs, proofs.asJava, body.forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
-          if (body.format.getOrElse(false))
-            ApiResponseUtil.toResponse(TransactionDTO(transaction.asInstanceOf[SCBT]))
-          else
-            ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(transaction.asInstanceOf[SCBT]))))
-        } catch {
-          case t: Throwable =>
-            ApiResponseUtil.toResponse(GenericTransactionError("GenericTransactionError", JOptional.of(t)))
-        }
-      }
-    }
-  }
 }
 
 

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -17,7 +17,7 @@ import com.horizen.box.{Box, ZenBox, ForgerBox}
 import com.horizen.companion.SidechainTransactionsCompanion
 import com.horizen.node.{NodeWallet, SidechainNodeView}
 import com.horizen.params.NetworkParams
-import com.horizen.proof.{Proof}
+import com.horizen.proof.Proof
 import com.horizen.proposition._
 import com.horizen.serialization.Views
 import com.horizen.transaction._
@@ -30,6 +30,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.control.Breaks._
 import scala.util.{Failure, Success, Try}
 import java.util.{Optional => JOptional}
+import scala.collection.mutable
 
 case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
                                         sidechainNodeViewHolderRef: ActorRef,
@@ -41,7 +42,7 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
 
   override val route: Route = (pathPrefix("transaction")) {
     allTransactions ~ findById ~ decodeTransactionBytes ~ createCoreTransaction ~ createCoreTransactionSimplified ~
-    sendCoinsToAddress ~ sendTransaction ~ withdrawCoins ~ makeForgerStake ~ spendForgingStake ~ createOpenStakeTransaction ~ sendOpenStakeTransaction
+    sendCoinsToAddress ~ sendTransaction ~ withdrawCoins ~ makeForgerStake ~ spendForgingStake ~ createOpenStakeTransaction ~ createOpenStakeTransactionSimplified
   }
 
   /**
@@ -474,18 +475,42 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
 
   def createOpenStakeTransaction: Route = (post & path("createOpenStakeTransaction")) {
     entity(as[ReqOpenStake]) { body =>
-      val transaction = createAndSignOpenStakeTransaction(body)
-      if (body.format.getOrElse(false))
-        ApiResponseUtil.toResponse(TransactionDTO(transaction.asInstanceOf[SCBT]))
-      else
-        ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(transaction.asInstanceOf[SCBT]))))
+      val transaction = buildOpenStakeTransaction(body)
+      if (body.automaticSend.getOrElse(true)) {
+        validateAndSendTransaction(transaction.asInstanceOf[SidechainTypes#SCBT])
+      } else {
+        if (body.format.getOrElse(false))
+          ApiResponseUtil.toResponse(TransactionDTO(transaction.asInstanceOf[SCBT]))
+        else
+          ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(transaction.asInstanceOf[SCBT]))))
+      }
     }
   }
 
-  def sendOpenStakeTransaction: Route = (post & path("sendOpenStakeTransaction")) {
-    entity(as[ReqOpenStake]) { body =>
-      val transaction = createAndSignOpenStakeTransaction(body)
-      validateAndSendTransaction(transaction.asInstanceOf[SidechainTypes#SCBT])
+  def createOpenStakeTransactionSimplified: Route = (post & path("createOpenStakeTransactionSimplified")) {
+    entity(as[ReqOpenStakeSimplified]) { body =>
+      val transaction = buildOpenStakeTransactionSimplified(body)
+      if (body.automaticSend.getOrElse(true)) {
+        validateAndSendTransaction(transaction.asInstanceOf[SidechainTypes#SCBT])
+      } else {
+        if (body.format.getOrElse(false))
+          ApiResponseUtil.toResponse(TransactionDTO(transaction.asInstanceOf[SCBT]))
+        else
+          ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(transaction.asInstanceOf[SCBT]))))
+      }
+    }
+  }
+
+  private def buildOpenStakeTransactionSimplified(body: ReqOpenStakeSimplified): OpenStakeTransaction = {
+    applyOnNodeView { sidechainNodeView =>
+      val wallet = sidechainNodeView.getNodeWallet
+
+      //Collect input box
+      val inputBox = wallet.allBoxes().asScala
+        .filter(box => box.proposition().equals(PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(body.forgerProposition))))
+      if (inputBox.isEmpty)
+        throw new IllegalArgumentException("Unable to find input for Proposition "+body.forgerProposition)
+      createAndSignOpenStakeTransaction(wallet, inputBox, body.forgerProposition, body.forgerListIndex, body.fee)
     }
   }
 
@@ -493,15 +518,9 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
    * Create and sign a openStakeTransaction
    * @return a signed OpenStakeTransaction or a GenericTransactionError
    */
-  private def createAndSignOpenStakeTransaction(body: ReqOpenStake): OpenStakeTransaction = {
+  private def buildOpenStakeTransaction(body: ReqOpenStake): OpenStakeTransaction = {
     applyOnNodeView { sidechainNodeView =>
       val wallet = sidechainNodeView.getNodeWallet
-
-      //Collect fee
-      val fee = body.fee.getOrElse(0L)
-      if (fee < 0) {
-        throw new IllegalArgumentException("Fee can't be negative!")
-      }
 
       //Collect input box
       val inputBox = wallet.allBoxes().asScala
@@ -512,33 +531,44 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
       if (inputBox.length > 1) {
         throw new IllegalArgumentException("To much inputs found!")
       }
-      val boxIds = inputBox.map(_.id()).asJava
 
-      //Collect output box
-      val outputs: JList[ZenBoxData] = new JArrayList()
-      outputs.add(new ZenBoxData(
-        PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(body.regularOutputProposition)),
-        inputBox(0).value() - fee))
+      createAndSignOpenStakeTransaction(wallet, inputBox, body.regularOutputProposition, body.forgerListIndex, body.fee)
+    }
+  }
 
-      try {
-        // Create unsigned tx
-        // Create a list of fake proofs for further messageToSign calculation
-        val fakeProofs: JList[Proof[Proposition]] = Collections.nCopies(1, null)
 
-        val unsignedTransaction = new OpenStakeTransaction(boxIds, outputs, fakeProofs, body.forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
-
-        // Create signed tx.
-        val messageToSign = unsignedTransaction.messageToSign()
-        val proofs = inputBox.map(box => {
-          wallet.secretByPublicKey(box.proposition()).get().sign(messageToSign).asInstanceOf[Proof[Proposition]]
-        })
-       new OpenStakeTransaction(boxIds, outputs, proofs.asJava, body.forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
-      } catch {
-        case t: Throwable =>
-          throw new RuntimeException("Error during the creation of the OpenStakeTransaction!")
-      }
+  private def createAndSignOpenStakeTransaction(wallet: NodeWallet, inputBox: mutable.Buffer[Box[Proposition]], outputProposition: String,
+                                                forgerListIndex: Int, inputFee: Option[Long]): OpenStakeTransaction = {
+    //Collect fee
+    val fee = inputFee.getOrElse(0L)
+    if (fee < 0) {
+      throw new IllegalArgumentException("Fee can't be negative!")
     }
 
+    //Collect output box
+    val outputs: JList[ZenBoxData] = new JArrayList()
+    outputs.add(new ZenBoxData(
+      PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(outputProposition)),
+      inputBox(0).value() - fee))
+
+    try {
+      val boxIds = inputBox.map(_.id()).asJava
+      // Create unsigned tx
+      // Create a list of fake proofs for further messageToSign calculation
+      val fakeProofs: JList[Proof[Proposition]] = Collections.nCopies(1, null)
+
+      val unsignedTransaction = new OpenStakeTransaction(boxIds, outputs, fakeProofs, forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
+
+      // Create signed tx.
+      val messageToSign = unsignedTransaction.messageToSign()
+      val proofs = inputBox.map(box => {
+        wallet.secretByPublicKey(box.proposition()).get().sign(messageToSign).asInstanceOf[Proof[Proposition]]
+      })
+      new OpenStakeTransaction(boxIds, outputs, proofs.asJava, forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
+    } catch {
+      case t: Throwable =>
+        throw new RuntimeException("Error during the creation of the OpenStakeTransaction!")
+    }
   }
 
   // try to get the first PublicKey25519Proposition in the wallet
@@ -733,12 +763,21 @@ object SidechainTransactionRestScheme {
                                        regularOutputProposition: String,
                                        forgerListIndex: Int,
                                        format: Option[Boolean],
+                                       automaticSend: Option[Boolean],
                                        @JsonDeserialize(contentAs = classOf[java.lang.Long]) fee: Option[Long]) {
     require(transactionInput != null, "Empty input")
     require(regularOutputProposition.nonEmpty, "Empty output")
     require(forgerListIndex >= 0, "Forger list index negative")
   }
 
+  @JsonView(Array(classOf[Views.Default]))
+  private[api] case class ReqOpenStakeSimplified(forgerProposition: String,
+                                       forgerListIndex: Int,
+                                       format: Option[Boolean],
+                                       automaticSend: Option[Boolean],
+                                       @JsonDeserialize(contentAs = classOf[java.lang.Long]) fee: Option[Long]) {
+    require(forgerListIndex >= 0, "Forger list index negative")
+  }
 }
 
 object SidechainTransactionErrorResponse {

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -561,18 +561,10 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
       throw new IllegalArgumentException("Fee can't be greater than the input!")
     }
 
-    //Collect output box
-    var output:JOptional[ZenBoxData] = JOptional.empty()
-    if (fee < inputBox.value()) {
-      output = JOptional.of(new ZenBoxData(
-        PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(outputProposition)),
-        inputBox.value() - fee))
-    }
-
     Try {
       //Create the openStakeTransaction
       OpenStakeTransaction.create(new JPair[ZenBox,PrivateKey25519](inputBox.asInstanceOf[ZenBox],inputPrivateKey),
-        JOptional.of(PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(outputProposition))),
+        PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(outputProposition)),
         forgerIndex,
         fee
       )

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -475,33 +475,40 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
 
   def createOpenStakeTransaction: Route = (post & path("createOpenStakeTransaction")) {
     entity(as[ReqOpenStake]) { body =>
-      val transaction = buildOpenStakeTransaction(body)
-      if (body.automaticSend.getOrElse(true)) {
-        validateAndSendTransaction(transaction.asInstanceOf[SidechainTypes#SCBT])
-      } else {
-        if (body.format.getOrElse(false))
-          ApiResponseUtil.toResponse(TransactionDTO(transaction.asInstanceOf[SCBT]))
-        else
-          ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(transaction.asInstanceOf[SCBT]))))
+      buildOpenStakeTransaction(body) match {
+        case Success(tx) =>
+          if (body.automaticSend.getOrElse(true)) {
+            validateAndSendTransaction(tx.asInstanceOf[SidechainTypes#SCBT])
+          } else {
+            if (body.format.getOrElse(false))
+              ApiResponseUtil.toResponse(TransactionDTO(tx.asInstanceOf[SCBT]))
+            else
+              ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(tx.asInstanceOf[SCBT]))))
+          }
+        case Failure(exception) =>
+          ApiResponseUtil.toResponse(GenericTransactionError("GenericTransactionError", JOptional.of(exception)))
       }
     }
   }
 
   def createOpenStakeTransactionSimplified: Route = (post & path("createOpenStakeTransactionSimplified")) {
     entity(as[ReqOpenStakeSimplified]) { body =>
-      val transaction = buildOpenStakeTransactionSimplified(body)
-      if (body.automaticSend.getOrElse(true)) {
-        validateAndSendTransaction(transaction.asInstanceOf[SidechainTypes#SCBT])
-      } else {
-        if (body.format.getOrElse(false))
-          ApiResponseUtil.toResponse(TransactionDTO(transaction.asInstanceOf[SCBT]))
-        else
-          ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(transaction.asInstanceOf[SCBT]))))
-      }
+     buildOpenStakeTransactionSimplified(body) match {
+       case Success(tx) =>
+         if (body.automaticSend.getOrElse(true)) {
+           validateAndSendTransaction(tx.asInstanceOf[SidechainTypes#SCBT])
+         } else {
+           if (body.format.getOrElse(false))
+             ApiResponseUtil.toResponse(TransactionDTO(tx.asInstanceOf[SCBT]))
+           else
+             ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(tx.asInstanceOf[SCBT]))))
+         }
+       case Failure(exception) =>
+         ApiResponseUtil.toResponse(GenericTransactionError("GenericTransactionError", JOptional.of(exception)))     }
     }
   }
 
-  private def buildOpenStakeTransactionSimplified(body: ReqOpenStakeSimplified): OpenStakeTransaction = {
+  private def buildOpenStakeTransactionSimplified(body: ReqOpenStakeSimplified): Try[OpenStakeTransaction] = {
     applyOnNodeView { sidechainNodeView =>
       val wallet = sidechainNodeView.getNodeWallet
 
@@ -518,7 +525,7 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
    * Create and sign a openStakeTransaction
    * @return a signed OpenStakeTransaction or a GenericTransactionError
    */
-  private def buildOpenStakeTransaction(body: ReqOpenStake): OpenStakeTransaction = {
+  private def buildOpenStakeTransaction(body: ReqOpenStake): Try[OpenStakeTransaction] = {
     applyOnNodeView { sidechainNodeView =>
       val wallet = sidechainNodeView.getNodeWallet
 
@@ -538,11 +545,14 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
 
 
   private def createAndSignOpenStakeTransaction(wallet: NodeWallet, inputBox: mutable.Buffer[Box[Proposition]], outputProposition: String,
-                                                forgerListIndex: Int, inputFee: Option[Long]): OpenStakeTransaction = {
+                                                forgerListIndex: Int, inputFee: Option[Long]): Try[OpenStakeTransaction] = {
     //Collect fee
     val fee = inputFee.getOrElse(0L)
     if (fee < 0) {
       throw new IllegalArgumentException("Fee can't be negative!")
+    }
+    if (fee > inputBox(0).value) {
+      throw new IllegalArgumentException("Fee can't be greater than the input!")
     }
 
     //Collect output box
@@ -551,7 +561,7 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
       PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(outputProposition)),
       inputBox(0).value() - fee))
 
-    try {
+    Try {
       val boxIds = inputBox.map(_.id()).asJava
       // Create unsigned tx
       // Create a list of fake proofs for further messageToSign calculation
@@ -565,9 +575,6 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
         wallet.secretByPublicKey(box.proposition()).get().sign(messageToSign).asInstanceOf[Proof[Proposition]]
       })
       new OpenStakeTransaction(boxIds, outputs, proofs.asJava, forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
-    } catch {
-      case t: Throwable =>
-        throw new RuntimeException("Error during the creation of the OpenStakeTransaction!")
     }
   }
 

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -715,8 +715,8 @@ object SidechainTransactionRestScheme {
   private[api] case class ReqOpenStake(transactionInput: TransactionInput,
                                        regularOutputProposition: String,
                                        forgerListIndex: Int,
-                                       fee: Option[Long],
-                                       format: Option[Boolean]) {
+                                       format: Option[Boolean],
+                                       @JsonDeserialize(contentAs = classOf[java.lang.Long]) fee: Option[Long]) {
     require(transactionInput != null, "Empty input")
     require(regularOutputProposition.nonEmpty, "Empty output")
     require(forgerListIndex >= 0, "Forger list index negative")

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -2,7 +2,6 @@ package com.horizen.api.http
 
 import java.lang
 import java.util.{Collections, ArrayList => JArrayList, List => JList}
-
 import akka.actor.{ActorRef, ActorRefFactory}
 import akka.http.scaladsl.server.Route
 import akka.pattern.ask
@@ -18,7 +17,7 @@ import com.horizen.box.{Box, ZenBox, ForgerBox}
 import com.horizen.companion.SidechainTransactionsCompanion
 import com.horizen.node.{NodeWallet, SidechainNodeView}
 import com.horizen.params.NetworkParams
-import com.horizen.proof.Proof
+import com.horizen.proof.{Proof}
 import com.horizen.proposition._
 import com.horizen.serialization.Views
 import com.horizen.transaction._
@@ -42,7 +41,7 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
 
   override val route: Route = (pathPrefix("transaction")) {
     allTransactions ~ findById ~ decodeTransactionBytes ~ createCoreTransaction ~ createCoreTransactionSimplified ~
-    sendCoinsToAddress ~ sendTransaction ~ withdrawCoins ~ makeForgerStake ~ spendForgingStake
+    sendCoinsToAddress ~ sendTransaction ~ withdrawCoins ~ makeForgerStake ~ spendForgingStake ~ openStakeTransaction
   }
 
   /**
@@ -562,6 +561,59 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
 
     new SidechainCoreTransaction(boxIds, outputs, proofs.asJava, fee, SidechainCoreTransaction.SIDECHAIN_CORE_TRANSACTION_VERSION)
   }
+
+  def openStakeTransaction: Route = (post & path("openStake")) {
+    entity(as[ReqOpenStake]) { body =>
+      applyOnNodeView { sidechainNodeView =>
+        val wallet = sidechainNodeView.getNodeWallet
+
+        //Collect fee
+        val fee = body.fee.getOrElse(0L)
+        if (fee < 0) {
+          throw new IllegalArgumentException("Fee can't be negative!")
+        }
+
+        //Collect input box
+        val inputBox = wallet.allBoxes().asScala
+          .filter(box => BytesUtils.toHexString(box.id()).equals(body.transactionInput.boxId))
+        if (inputBox.length == 0) {
+          throw new IllegalArgumentException("Unable to find input!")
+        }
+        if (inputBox.length > 1) {
+          throw new IllegalArgumentException("To much inputs found!")
+        }
+        val boxIds = inputBox.map(_.id()).asJava
+
+        //Collect output box
+        val outputs: JList[ZenBoxData] = new JArrayList()
+        outputs.add(new ZenBoxData(
+          PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(body.regularOutputProposition)),
+          inputBox(0).value() - fee))
+
+        try {
+          // Create unsigned tx
+          // Create a list of fake proofs for further messageToSign calculation
+          val fakeProofs: JList[Proof[Proposition]] = Collections.nCopies(1, null)
+
+          val unsignedTransaction = new OpenStakeTransaction(boxIds, outputs, fakeProofs, body.forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
+
+          // Create signed tx.
+          val messageToSign = unsignedTransaction.messageToSign()
+          val proofs = inputBox.map(box => {
+            wallet.secretByPublicKey(box.proposition()).get().sign(messageToSign).asInstanceOf[Proof[Proposition]]
+          })
+          val transaction = new OpenStakeTransaction(boxIds, outputs, proofs.asJava, body.forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
+          if (body.format.getOrElse(false))
+            ApiResponseUtil.toResponse(TransactionDTO(transaction.asInstanceOf[SCBT]))
+          else
+            ApiResponseUtil.toResponse(TransactionBytesDTO(BytesUtils.toHexString(companion.toBytes(transaction.asInstanceOf[SCBT]))))
+        } catch {
+          case t: Throwable =>
+            ApiResponseUtil.toResponse(GenericTransactionError("GenericTransactionError", JOptional.of(t)))
+        }
+      }
+    }
+  }
 }
 
 
@@ -657,6 +709,17 @@ object SidechainTransactionRestScheme {
                                                       format: Option[Boolean]) {
     require(transactionInputs.nonEmpty, "Empty inputs list")
     require(regularOutputs.nonEmpty || forgerOutputs.nonEmpty, "Empty outputs")
+  }
+
+  @JsonView(Array(classOf[Views.Default]))
+  private[api] case class ReqOpenStake(transactionInput: TransactionInput,
+                                       regularOutputProposition: String,
+                                       forgerListIndex: Int,
+                                       fee: Option[Long],
+                                       format: Option[Boolean]) {
+    require(transactionInput != null, "Empty input")
+    require(regularOutputProposition.nonEmpty, "Empty output")
+    require(forgerListIndex >= 0, "Forger list index negative")
   }
 
 }

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -17,11 +17,12 @@ import com.horizen.box.{Box, ZenBox, ForgerBox}
 import com.horizen.companion.SidechainTransactionsCompanion
 import com.horizen.node.{NodeWallet, SidechainNodeView}
 import com.horizen.params.NetworkParams
-import com.horizen.proof.Proof
+import com.horizen.proof.{Proof}
 import com.horizen.proposition._
+import com.horizen.secret.PrivateKey25519
 import com.horizen.serialization.Views
 import com.horizen.transaction._
-import com.horizen.utils.{BytesUtils, ZenCoinsUtils}
+import com.horizen.utils.{BytesUtils, ZenCoinsUtils, Pair => JPair}
 import scorex.core.settings.RESTApiSettings
 
 import scala.collection.JavaConverters._
@@ -512,11 +513,17 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
       val wallet = sidechainNodeView.getNodeWallet
 
       //Collect input box
-      val inputBox = wallet.allBoxes().asScala
-        .filter(box => box.proposition().equals(PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(body.forgerProposition))))
-      if (inputBox.isEmpty)
-        throw new IllegalArgumentException("Unable to find input for Proposition "+body.forgerProposition)
-      createAndSignOpenStakeTransaction(wallet, inputBox.head, body.forgerProposition, body.forgerListIndex, body.fee)
+      wallet.allBoxes().asScala
+        .find(box => box.proposition().equals(PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(body.forgerProposition)))
+          && box.value() >= body.fee.getOrElse(0L)) match {
+        case Some(inputBox) =>
+          //Collect input private key
+          val inputPrivateKey = wallet.secretByPublicKey(inputBox.proposition()).get().asInstanceOf[PrivateKey25519]
+          //Create openStakeTransaction
+          createAndSignOpenStakeTransaction(inputBox, inputPrivateKey, body.forgerProposition, body.forgerIndex, body.fee)
+        case None =>
+          throw new IllegalArgumentException("Unable to find input for Proposition "+body.forgerProposition)
+      }
     }
   }
 
@@ -529,22 +536,22 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
       val wallet = sidechainNodeView.getNodeWallet
 
       //Collect input box
-      val inputBox = wallet.allBoxes().asScala
-        .filter(box => BytesUtils.toHexString(box.id()).equals(body.transactionInput.boxId))
-      if (inputBox.isEmpty) {
-        throw new IllegalArgumentException("Unable to find input!")
+      wallet.allBoxes().asScala
+        .find(box => BytesUtils.toHexString(box.id()).equals(body.transactionInput.boxId)) match {
+        case Some(inputBox) =>
+          //Collect input private key
+          val inputPrivateKey = wallet.secretByPublicKey(inputBox.proposition()).get().asInstanceOf[PrivateKey25519]
+          //Create openStakeTransaction
+          createAndSignOpenStakeTransaction(inputBox, inputPrivateKey, body.regularOutputProposition, body.forgerIndex, body.fee)
+        case None =>
+          throw new IllegalArgumentException("Unable to find input!")
       }
-      if (inputBox.length > 1) {
-        throw new IllegalArgumentException("To much inputs found!")
-      }
-
-      createAndSignOpenStakeTransaction(wallet, inputBox.head, body.regularOutputProposition, body.forgerListIndex, body.fee)
     }
   }
 
 
-  private def createAndSignOpenStakeTransaction(wallet: NodeWallet, inputBox: Box[Proposition], outputProposition: String,
-                                                forgerListIndex: Int, inputFee: Option[Long]): Try[OpenStakeTransaction] = {
+  private def createAndSignOpenStakeTransaction(inputBox: Box[Proposition], inputPrivateKey: PrivateKey25519, outputProposition: String,
+                                                forgerIndex: Int, inputFee: Option[Long]): Try[OpenStakeTransaction] = {
     //Collect fee
     val fee = inputFee.getOrElse(0L)
     if (fee < 0) {
@@ -563,13 +570,12 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
     }
 
     Try {
-      // Create unsigned tx
-      val unsignedTransaction = new OpenStakeTransaction(inputBox.id(), output, null, forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
-
-      // Create signed tx.
-      val messageToSign = unsignedTransaction.messageToSign()
-      val proof = wallet.secretByPublicKey(inputBox.proposition()).get().sign(messageToSign).asInstanceOf[Proof[Proposition]]
-      new OpenStakeTransaction(inputBox.id(), output, proof, forgerListIndex, fee, OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION)
+      //Create the openStakeTransaction
+      OpenStakeTransaction.create(new JPair[ZenBox,PrivateKey25519](inputBox.asInstanceOf[ZenBox],inputPrivateKey),
+        JOptional.of(PublicKey25519PropositionSerializer.getSerializer.parseBytes(BytesUtils.fromHexString(outputProposition))),
+        forgerIndex,
+        fee
+      )
     }
   }
 
@@ -762,23 +768,23 @@ object SidechainTransactionRestScheme {
   @JsonView(Array(classOf[Views.Default]))
   private[api] case class ReqOpenStake(transactionInput: TransactionInput,
                                        regularOutputProposition: String,
-                                       forgerListIndex: Int,
+                                       forgerIndex: Int,
                                        format: Option[Boolean],
                                        automaticSend: Option[Boolean],
                                        @JsonDeserialize(contentAs = classOf[java.lang.Long]) fee: Option[Long]) {
     require(transactionInput != null, "Empty input")
     require(regularOutputProposition.nonEmpty, "Empty regularOutputProposition")
-    require(forgerListIndex >= 0, "Forger list index negative")
+    require(forgerIndex >= 0, "Forger list index negative")
   }
 
   @JsonView(Array(classOf[Views.Default]))
   private[api] case class ReqOpenStakeSimplified(forgerProposition: String,
-                                       forgerListIndex: Int,
+                                       forgerIndex: Int,
                                        format: Option[Boolean],
                                        automaticSend: Option[Boolean],
                                        @JsonDeserialize(contentAs = classOf[java.lang.Long]) fee: Option[Long]) {
     require(forgerProposition.nonEmpty, "Empty forgerProposition")
-    require(forgerListIndex >= 0, "Forger list index negative")
+    require(forgerIndex >= 0, "Forger list index negative")
   }
 }
 

--- a/sdk/src/main/scala/com/horizen/companion/SidechainTransactionsCompanion.scala
+++ b/sdk/src/main/scala/com/horizen/companion/SidechainTransactionsCompanion.scala
@@ -14,5 +14,6 @@ case class SidechainTransactionsCompanion(customTransactionSerializers: JHashMap
     new JHashMap[JByte, TransactionSerializer[SidechainTypes#SCBT]]() {{
       put(MC2SCAggregatedTransactionId.id(), MC2SCAggregatedTransactionSerializer.getSerializer.asInstanceOf[TransactionSerializer[SidechainTypes#SCBT]])
       put(SidechainCoreTransactionId.id(), SidechainCoreTransactionSerializer.getSerializer.asInstanceOf[TransactionSerializer[SidechainTypes#SCBT]])
+      put(OpenStakeTransactionId.id(), OpenStakeTransactionSerializer.getSerializer.asInstanceOf[TransactionSerializer[SidechainTypes#SCBT]])
     }},
     customTransactionSerializers)

--- a/sdk/src/main/scala/com/horizen/forge/ForgerList.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgerList.scala
@@ -1,0 +1,38 @@
+package com.horizen.forge
+
+import scorex.core.serialization.{BytesSerializable, ScorexSerializer}
+import scorex.util.serialization.{Reader, Writer}
+
+case class ForgerList(forgerIndexes: Array[Int]) extends BytesSerializable {
+  override type M = ForgerList
+
+  def updateIndexes(indexToUpdate: Array[Int]): Unit = {
+    indexToUpdate.foreach(toUpdate => {
+      if (toUpdate < forgerIndexes.length) {
+        forgerIndexes(toUpdate) = 1
+      }
+    })
+  }
+
+  override def serializer: ScorexSerializer[ForgerList] = ForgerListSerializer
+}
+
+object ForgerListSerializer extends ScorexSerializer[ForgerList] {
+  override def serialize(obj: ForgerList, w: Writer): Unit = {
+    w.putInt(obj.forgerIndexes.size)
+    obj.forgerIndexes.foreach(index => {
+      w.putInt(index)
+    })
+  }
+
+  override def parse(r: Reader): ForgerList = {
+    val nElement = r.getInt()
+    System.out.println("nElement "+nElement)
+    val indexes: Array[Int] = new Array[Int](nElement)
+    for (i <- 0 until nElement) {
+      indexes(i) = r.getInt()
+      System.out.println("INDEX di "+i+" = "+indexes(i))
+    }
+    ForgerList(indexes)
+  }
+}

--- a/sdk/src/main/scala/com/horizen/forge/ForgerList.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgerList.scala
@@ -6,12 +6,15 @@ import scorex.util.serialization.{Reader, Writer}
 case class ForgerList(forgerIndexes: Array[Int]) extends BytesSerializable {
   override type M = ForgerList
 
-  def updateIndexes(indexToUpdate: Array[Int]): Unit = {
+  def updateIndexes(indexToUpdate: Array[Int]): ForgerList = {
     indexToUpdate.foreach(toUpdate => {
       if (toUpdate < forgerIndexes.length) {
         forgerIndexes(toUpdate) = 1
+      } else {
+        throw new IndexOutOfBoundsException("Forger index to update is out of bound!")
       }
     })
+    ForgerList(forgerIndexes)
   }
 
   override def serializer: ScorexSerializer[ForgerList] = ForgerListSerializer

--- a/sdk/src/main/scala/com/horizen/forge/ForgerList.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgerList.scala
@@ -27,11 +27,9 @@ object ForgerListSerializer extends ScorexSerializer[ForgerList] {
 
   override def parse(r: Reader): ForgerList = {
     val nElement = r.getInt()
-    System.out.println("nElement "+nElement)
     val indexes: Array[Int] = new Array[Int](nElement)
     for (i <- 0 until nElement) {
       indexes(i) = r.getInt()
-      System.out.println("INDEX di "+i+" = "+indexes(i))
     }
     ForgerList(indexes)
   }

--- a/sdk/src/main/scala/com/horizen/fork/BaseConsensusEpochFork.scala
+++ b/sdk/src/main/scala/com/horizen/fork/BaseConsensusEpochFork.scala
@@ -2,6 +2,7 @@ package com.horizen.fork
 
 class BaseConsensusEpochFork (val epochNumber: ForkConsensusEpochNumber) {
   def backwardTransferLimitEnabled(): Boolean = false
+  def openStakeTransactionEnabled(): Boolean = false
 }
 
 case class ForkConsensusEpochNumber(mainnetEpochNumber: Int, regtestEpochNumber: Int, testnetEpochNumber: Int) {}

--- a/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
+++ b/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
@@ -2,4 +2,5 @@ package com.horizen.fork
 
 class SidechainFork1(override val epochNumber: ForkConsensusEpochNumber) extends BaseConsensusEpochFork(epochNumber) {
   override def backwardTransferLimitEnabled(): Boolean = true
+  override def openStakeTransactionEnabled(): Boolean = true
 }

--- a/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
+++ b/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
@@ -191,12 +191,15 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
           ForgerListSerializer.parseBytesTry(baw.data)
         } match {
           case Success(Success(forgerIndexes)) => Some(forgerIndexes)
+          case Success(Failure(_)) =>
+            log.error("Error while forger list indexes information parsing.")
+            Option.empty
           case Failure(exception) =>
             log.error("Error while forger list indexes information parsing.", exception)
             Option.empty
         }
       }
-      case _ => Option.empty
+      case None => Option.empty
     }
   }
 
@@ -302,6 +305,7 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
     if(scHasCeased)
       updateList.add(new JPair(ceasingStateKey, new ByteArrayWrapper(Array.emptyByteArray)))
 
+    //Set ForgerList indexes
     val tryForgerListSerialized = getForgerListIndexes
 
     if (tryForgerListSerialized.isDefined) {

--- a/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
+++ b/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
@@ -184,7 +184,7 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
     }
   }
 
-  def getForgerListIndexes: Option[ForgerList] = {
+  def getForgerList: Option[ForgerList] = {
     storage.get(forgerListIndexKey).asScala match {
       case Some(baw) => {
         Try {
@@ -306,15 +306,13 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
       updateList.add(new JPair(ceasingStateKey, new ByteArrayWrapper(Array.emptyByteArray)))
 
     //Set ForgerList indexes
-    val tryForgerListSerialized = getForgerListIndexes
-
-    if (tryForgerListSerialized.isDefined) {
-      val forgerListSerialized = tryForgerListSerialized.get
-      forgerListSerialized.updateIndexes(forgerListIndexes)
-      updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(forgerListSerialized)))
-    } else {
-      val emptyForgerListIndex = ForgerList(new Array[Int](forgerListSize))
-      updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(emptyForgerListIndex)))
+    getForgerList match {
+      case Some(forgerList) =>
+        forgerList.updateIndexes(forgerListIndexes)
+        updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(forgerList)))
+      case None =>
+        val emptyForgerListIndex = ForgerList(new Array[Int](forgerListSize))
+        updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(emptyForgerListIndex)))
     }
 
     storage.update(version, updateList, removeList)

--- a/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
+++ b/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
@@ -36,7 +36,7 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
 
   private[horizen] val ceasingStateKey = Utils.calculateKey("ceasingStateKey".getBytes)
 
-  private[horizen] val forgerListIndexKey = calculateKey("forgerListIndexKey".getBytes)
+  private[horizen] val forgerListIndexKey = Utils.calculateKey("forgerListIndexKey".getBytes)
 
   private val undefinedWithdrawalEpochCounter: Int = -1
   private[horizen] def getWithdrawalEpochCounterKey(withdrawalEpoch: Int): ByteArrayWrapper = {

--- a/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
+++ b/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
@@ -8,6 +8,7 @@ import com.horizen.block.{WithdrawalEpochCertificate, WithdrawalEpochCertificate
 import com.horizen.box.{WithdrawalRequestBox, WithdrawalRequestBoxSerializer}
 import com.horizen.companion.SidechainBoxesCompanion
 import com.horizen.consensus._
+import com.horizen.forge.{ForgerList, ForgerListSerializer}
 import com.horizen.utils.{ByteArrayWrapper, ListSerializer, WithdrawalEpochInfo, WithdrawalEpochInfoSerializer, Pair => JPair, _}
 import scorex.util.ScorexLogging
 
@@ -34,6 +35,8 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
   private[horizen] val consensusEpochKey = Utils.calculateKey("consensusEpoch".getBytes)
 
   private[horizen] val ceasingStateKey = Utils.calculateKey("ceasingStateKey".getBytes)
+
+  private[horizen] val forgerListIndexKey = calculateKey("forgerListIndexKey".getBytes)
 
   private val undefinedWithdrawalEpochCounter: Int = -1
   private[horizen] def getWithdrawalEpochCounterKey(withdrawalEpoch: Int): ByteArrayWrapper = {
@@ -181,6 +184,22 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
     }
   }
 
+  def getForgerListIndexes: Option[ForgerList] = {
+    storage.get(forgerListIndexKey).asScala match {
+      case Some(baw) => {
+        Try {
+          ForgerListSerializer.parseBytesTry(baw.data)
+        } match {
+          case Success(Success(forgerIndexes)) => Some(forgerIndexes)
+          case Failure(exception) =>
+            log.error("Error while forger list indexes information parsing.", exception)
+            Option.empty
+        }
+      }
+      case _ => Option.empty
+    }
+  }
+
   def update(version: ByteArrayWrapper,
              withdrawalEpochInfo: WithdrawalEpochInfo,
              boxUpdateList: Set[SidechainTypes#SCB],
@@ -190,7 +209,9 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
              topQualityCertificateOpt: Option[WithdrawalEpochCertificate],
              blockFeeInfo: BlockFeeInfo,
              utxoMerkleTreeRootOpt: Option[Array[Byte]],
-             scHasCeased: Boolean): Try[SidechainStateStorage] = Try {
+             scHasCeased: Boolean,
+             forgerListIndexes: Array[Int],
+             forgerListSize: Int): Try[SidechainStateStorage] = Try {
     require(withdrawalEpochInfo != null, "WithdrawalEpochInfo must be NOT NULL.")
     require(boxUpdateList != null, "List of Boxes to add/update must be NOT NULL. Use empty List instead.")
     require(boxIdsRemoveSet != null, "List of Box IDs to remove must be NOT NULL. Use empty List instead.")
@@ -280,6 +301,17 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
     // If sidechain has ceased set the flag
     if(scHasCeased)
       updateList.add(new JPair(ceasingStateKey, new ByteArrayWrapper(Array.emptyByteArray)))
+
+    val tryForgerListSerialized = getForgerListIndexes
+
+    if (tryForgerListSerialized.isDefined) {
+      val forgerListSerialized = tryForgerListSerialized.get
+      forgerListSerialized.updateIndexes(forgerListIndexes)
+      updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(forgerListSerialized)))
+    } else {
+      val emptyForgerListIndex = ForgerList(new Array[Int](forgerListSize))
+      updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(emptyForgerListIndex)))
+    }
 
     storage.update(version, updateList, removeList)
     this

--- a/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
+++ b/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
@@ -308,8 +308,10 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
     //Set ForgerList indexes
     getForgerList match {
       case Some(forgerList) =>
-        forgerList.updateIndexes(forgerListIndexes)
-        updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(forgerList)))
+        if (forgerListIndexes.length != 0) {
+          val updatedForgerList = forgerList.updateIndexes(forgerListIndexes)
+          updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(updatedForgerList)))
+        }
       case None =>
         val emptyForgerListIndex = ForgerList(new Array[Int](forgerListSize))
         updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(emptyForgerListIndex)))

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -105,14 +105,9 @@ class SidechainStateTest
     RegularTransaction.create(from, to, fee)
   }
 
-  def getOpenStakeTransaction(boxesWithSecretToOpen: (ZenBox,PrivateKey25519), forgerListIndex: Int): OpenStakeTransaction = {
+  def getOpenStakeTransaction(boxesWithSecretToOpen: (ZenBox,PrivateKey25519), forgerIndex: Int, fee: JOptional[Long]): OpenStakeTransaction = {
     val from: JPair[ZenBox,PrivateKey25519] =  new JPair[ZenBox,PrivateKey25519](boxesWithSecretToOpen._1, boxesWithSecretToOpen._2)
-
-    val minimumFee = 5L
-    val maxTo = boxesWithSecretToOpen._1.value() - minimumFee
-    val to: JOptional[ZenBoxData] = JOptional.of(new ZenBoxData(getPrivateKey25519List(1).get(0).publicImage(), maxTo))
-
-    OpenStakeTransaction.create(from, to, forgerListIndex, minimumFee)
+    OpenStakeTransaction.create(from, JOptional.of(getPrivateKey25519List(1).get(0).publicImage()), forgerIndex, fee.orElseGet(() => 5L))
   }
 
   @Test
@@ -414,6 +409,9 @@ class SidechainStateTest
 
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
+
+    Mockito.when(mockedBlock.sidechainTransactions)
+      .thenReturn(Seq())
 
     Mockito.when(mockedBlock.parentId)
       .thenReturn(bytesToId(stateVersion.last.data))
@@ -745,7 +743,7 @@ class SidechainStateTest
       (secretList(3).publicImage(), vrfList(3)),
       (secretList(4).publicImage(), vrfList(4)),
     )
-
+    var forgerListIndexes = ForgerList(Array[Int](1,1,0,0,0))
     // NEGATIVE TESTS
 
     //Test validate(Transaction) with restrict forger disabled
@@ -753,7 +751,8 @@ class SidechainStateTest
     Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq())
     var openStakeTransaction = getOpenStakeTransaction(
       (boxList.head.asInstanceOf[ZenBox], secretList.head),
-      0
+      0,
+      JOptional.empty()
     )
     var tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
     assertFalse("Transaction validation must fail.",
@@ -763,21 +762,24 @@ class SidechainStateTest
     //Test validate(Transaction) with restrict forger enabled and forgerListIndex out of bound
     Mockito.when(mockedParams.restrictForgers).thenReturn(true)
     Mockito.when(mockedParams.allowedForgersList).thenReturn(forgerList)
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
       (boxList.head.asInstanceOf[ZenBox], secretList.head),
-      10
+      10,
+      JOptional.empty()
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
     assertFalse("Transaction validation must fail.",
       tryValidate.isSuccess)
-    assertTrue(tryValidate.failed.get.getMessage.equals("ForgerListIndex in OpenStakeTransaction is out of bound!"))
+    assertTrue(tryValidate.failed.get.getMessage.equals("ForgerIndex in OpenStakeTransaction is out of bound!"))
 
 
     //Test validate(Transaction) with restrict forger enabled and forger list indexes is not present in the storage
     Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {None})
     openStakeTransaction = getOpenStakeTransaction(
       (boxList.head.asInstanceOf[ZenBox], secretList.head),
-      0
+      0,
+      JOptional.empty()
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
     assertFalse("Transaction validation must fail.",
@@ -786,11 +788,11 @@ class SidechainStateTest
 
 
     //Test validate(Transaction) with restrict forger enabled and try to update an existing forger index
-    var forgerListIndexes = ForgerList(Array[Int](1,1,0,0,0))
     Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
       (boxList.head.asInstanceOf[ZenBox], secretList.head),
-      0
+      0,
+      JOptional.empty()
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
     assertFalse("Transaction validation must fail.",
@@ -802,20 +804,36 @@ class SidechainStateTest
     Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
       (boxList.head.asInstanceOf[ZenBox], secretList.head),
-      3
+      3,
+      JOptional.empty()
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
     assertFalse("Transaction validation must fail.",
       tryValidate.isSuccess)
-    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransaction input doesn't match the forgerListIndex!"))
+    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransaction input doesn't match the forgerIndex!"))
+
+    //Test validate(Transaction) with the forge operation already opened.
+    forgerListIndexes = ForgerList(Array[Int](1,1,1,0,0))
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
+    openStakeTransaction = getOpenStakeTransaction(
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
+      3,
+      JOptional.empty()
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransactions are not allowed because the forger operation has already been opened!"))
 
     //POSITIVE TESTS
 
     //Test validate(Transaction) with restrict forger enabled and correct index
+    forgerListIndexes = ForgerList(Array[Int](0,1,0,0,0))
     Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
       (boxList.head.asInstanceOf[ZenBox], secretList.head),
-      0
+      0,
+      JOptional.empty()
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
     assertTrue("Transaction validation must not fail.",

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -632,8 +632,6 @@ class SidechainStateTest
       )
     )
 
-    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Option.empty})
-
     Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Option.empty})
 
     Mockito.when(mockedStateForgerBoxStorage.lastVersionId).thenReturn(Some(stateVersion.last))
@@ -716,7 +714,7 @@ class SidechainStateTest
     stateVersion.clear()
     stateVersion += getVersion
     transactionList.clear()
-    transactionList += getRegularTransaction(1, 1, Seq(), 5)
+    transactionList += getRegularTransaction(1, 1, 0, Seq(), 5)
 
     Mockito.when(mockedStateStorage.lastVersionId).thenReturn(Some(stateVersion.last))
 
@@ -725,6 +723,8 @@ class SidechainStateTest
         val boxId = answer.getArgument(0).asInstanceOf[Array[Byte]]
         boxList.find(_.id().sameElements(boxId))
       })
+
+    Mockito.when(mockedStateStorage.getConsensusEpochNumber).thenReturn(Some(intToConsensusEpochNumber(1)))
 
     Mockito.when(mockedStateForgerBoxStorage.lastVersionId).thenReturn(Some(stateVersion.last))
 

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -107,7 +107,7 @@ class SidechainStateTest
 
   def getOpenStakeTransaction(boxesWithSecretToOpen: (ZenBox,PrivateKey25519), forgerIndex: Int, fee: JOptional[Long]): OpenStakeTransaction = {
     val from: JPair[ZenBox,PrivateKey25519] =  new JPair[ZenBox,PrivateKey25519](boxesWithSecretToOpen._1, boxesWithSecretToOpen._2)
-    OpenStakeTransaction.create(from, JOptional.of(getPrivateKey25519List(1).get(0).publicImage()), forgerIndex, fee.orElseGet(() => 5L))
+    OpenStakeTransaction.create(from, getPrivateKey25519List(1).get(0).publicImage(), forgerIndex, fee.orElseGet(() => 5L))
   }
 
   @Test
@@ -757,7 +757,7 @@ class SidechainStateTest
     var tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
     assertFalse("Transaction validation must fail.",
       tryValidate.isSuccess)
-    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransactions are not allowed with restrictForgers=false!"))
+    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransactions are not allowed because the forger operation has already been opened!"))
 
     //Test validate(Transaction) with restrict forger enabled and forgerListIndex out of bound
     Mockito.when(mockedParams.restrictForgers).thenReturn(true)

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -1,6 +1,6 @@
 package com.horizen
 
-import java.util.{ArrayList => JArrayList, List => JList}
+import java.util.{Optional => JOptional, ArrayList => JArrayList, List => JList}
 import com.horizen.block.{MainchainBlockReferenceData, SidechainBlock, WithdrawalEpochCertificate}
 import com.horizen.box.data.{BoxData, ForgerBoxData, WithdrawalRequestBoxData, ZenBoxData}
 import com.horizen.box._
@@ -105,18 +105,12 @@ class SidechainStateTest
     RegularTransaction.create(from, to, fee)
   }
 
-  def getOpenStakeTransaction(boxesWithSecretToOpen: Seq[(ZenBox,PrivateKey25519)], forgerListIndex: Int): OpenStakeTransaction = {
-    val from: JList[JPair[ZenBox,PrivateKey25519]] = new JArrayList[JPair[ZenBox,PrivateKey25519]]()
-    from.addAll(boxesWithSecretToOpen.map{case (box, secret) => new JPair[ZenBox,PrivateKey25519](box, secret)}.asJava)
-    val to: JList[ZenBoxData] = new JArrayList()
-    val totalFrom = boxesWithSecretToOpen.map{case (box, _) => box.value()}.sum
+  def getOpenStakeTransaction(boxesWithSecretToOpen: (ZenBox,PrivateKey25519), forgerListIndex: Int): OpenStakeTransaction = {
+    val from: JPair[ZenBox,PrivateKey25519] =  new JPair[ZenBox,PrivateKey25519](boxesWithSecretToOpen._1, boxesWithSecretToOpen._2)
 
     val minimumFee = 5L
-    val maxTo = totalFrom - minimumFee
-
-    for(s <- getPrivateKey25519List(1).asScala) {
-      to.add(new ZenBoxData(s.publicImage(), maxTo))
-    }
+    val maxTo = boxesWithSecretToOpen._1.value() - minimumFee
+    val to: JOptional[ZenBoxData] = JOptional.of(new ZenBoxData(getPrivateKey25519List(1).get(0).publicImage(), maxTo))
 
     OpenStakeTransaction.create(from, to, forgerListIndex, minimumFee)
   }
@@ -758,7 +752,7 @@ class SidechainStateTest
     Mockito.when(mockedParams.restrictForgers).thenReturn(false)
     Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq())
     var openStakeTransaction = getOpenStakeTransaction(
-      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
       0
     )
     var tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
@@ -770,7 +764,7 @@ class SidechainStateTest
     Mockito.when(mockedParams.restrictForgers).thenReturn(true)
     Mockito.when(mockedParams.allowedForgersList).thenReturn(forgerList)
     openStakeTransaction = getOpenStakeTransaction(
-      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
       10
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
@@ -782,7 +776,7 @@ class SidechainStateTest
     //Test validate(Transaction) with restrict forger enabled and forger list indexes is not present in the storage
     Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {None})
     openStakeTransaction = getOpenStakeTransaction(
-      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
       0
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
@@ -795,7 +789,7 @@ class SidechainStateTest
     var forgerListIndexes = ForgerList(Array[Int](1,1,0,0,0))
     Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
-      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
       0
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
@@ -807,7 +801,7 @@ class SidechainStateTest
     forgerListIndexes = ForgerList(Array[Int](0,1,0,0,0))
     Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
-      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
       3
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
@@ -820,7 +814,7 @@ class SidechainStateTest
     //Test validate(Transaction) with restrict forger enabled and correct index
     Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
-      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
       0
     )
     tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -8,14 +8,15 @@ import com.horizen.consensus.{ConsensusEpochNumber, intToConsensusEpochNumber}
 import com.horizen.cryptolibprovider.FieldElementUtils
 import com.horizen.fixtures.{SecretFixture, SidechainTypesTestsExtension, StoreFixture, TransactionFixture}
 import com.horizen.fork.{ForkManager, ForkManagerUtil, SimpleForkConfigurator}
+import com.horizen.forge.ForgerList
 import com.horizen.params.MainNetParams
-import com.horizen.proposition.Proposition
+import com.horizen.proposition.{Proposition, VrfPublicKey}
 import com.horizen.secret.PrivateKey25519
 import com.horizen.storage.{SidechainStateForgerBoxStorage, SidechainStateStorage}
 import com.horizen.state.{ApplicationState, SidechainStateReader}
 import com.horizen.transaction.exception.TransactionSemanticValidityException
 import com.horizen.utils.{BlockFeeInfo, ByteArrayWrapper, BytesUtils, FeePaymentsUtils, WithdrawalEpochInfo, Pair => JPair}
-import com.horizen.transaction.{BoxTransaction, RegularTransaction}
+import com.horizen.transaction.{BoxTransaction, OpenStakeTransaction, RegularTransaction}
 import org.junit.Assert._
 import org.junit._
 import org.mockito.{ArgumentMatchers, Mockito}
@@ -49,6 +50,7 @@ class SidechainStateTest
   val transactionList = new ListBuffer[RegularTransaction]()
 
   val secretList = new ListBuffer[PrivateKey25519]()
+  val vrfList = new ListBuffer[VrfPublicKey]()
 
   val params = MainNetParams()
 
@@ -101,6 +103,22 @@ class SidechainStateTest
     val fee = totalFrom - totalTo
 
     RegularTransaction.create(from, to, fee)
+  }
+
+  def getOpenStakeTransaction(boxesWithSecretToOpen: Seq[(ZenBox,PrivateKey25519)], forgerListIndex: Int): OpenStakeTransaction = {
+    val from: JList[JPair[ZenBox,PrivateKey25519]] = new JArrayList[JPair[ZenBox,PrivateKey25519]]()
+    from.addAll(boxesWithSecretToOpen.map{case (box, secret) => new JPair[ZenBox,PrivateKey25519](box, secret)}.asJava)
+    val to: JList[ZenBoxData] = new JArrayList()
+    val totalFrom = boxesWithSecretToOpen.map{case (box, _) => box.value()}.sum
+
+    val minimumFee = 5L
+    val maxTo = totalFrom - minimumFee
+
+    for(s <- getPrivateKey25519List(1).asScala) {
+      to.add(new ZenBoxData(s.publicImage(), maxTo))
+    }
+
+    OpenStakeTransaction.create(from, to, forgerListIndex, minimumFee)
   }
 
   @Test
@@ -649,6 +667,7 @@ class SidechainStateTest
 
     //Test validate(Transaction) with restrict forger enable and invalid blockSignProposition
     Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq((invalidBlockSignProposition,allowedVrfPublicKey)))
+    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(ForgerList(Array[Int](0)))})
     tryValidate = sidechainState.validate(stakeTransaction)
     assertFalse("Transaction validation must fail.",
       tryValidate.isSuccess)
@@ -664,7 +683,146 @@ class SidechainStateTest
     //Test validate(Transaction) with restrict forger enable and valid blockSignProposition and vrfPublicKey
     Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq((allowedBlockSignProposition,allowedVrfPublicKey)))
     tryValidate = sidechainState.validate(stakeTransaction)
-    assertTrue("Transaction validation must fail.",
+    assertTrue("Transaction validation must not fail.",
+      tryValidate.isSuccess)
+
+    //Test validate(Transaction) with restrict forger, invalid forger and not the majority of the allowed forgers opened the stake
+    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(ForgerList(Array[Int](1,1,0,0,0)))})
+    Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq(
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+    ))
+    tryValidate = sidechainState.validate(stakeTransaction)
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("This publicKey is not allowed to forge!"))
+
+    //Test validate(Transaction) with restrict forger, invalid forger and the majority of the allowed forgers opened the stake
+    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(ForgerList(Array[Int](1,1,1,0,0)))})
+    tryValidate = sidechainState.validate(stakeTransaction)
+    assertTrue("Transaction validation must not fail.",
+      tryValidate.isSuccess)
+  }
+
+  @Test
+  def openForgerTest(): Unit = {
+    // Set base Secrets data
+    secretList.clear()
+    secretList ++= getPrivateKey25519List(5).asScala
+    //Set vrf public key list
+    vrfList.clear()
+    for (i <-0 until 5)
+      vrfList += getVRFPublicKey
+    // Set base Box data
+    boxList.clear()
+    boxList ++= getZenBoxList(secretList.asJava).asScala.toList
+    stateVersion.clear()
+    stateVersion += getVersion
+    transactionList.clear()
+    transactionList += getRegularTransaction(1, 1, Seq(), 5)
+
+    Mockito.when(mockedStateStorage.lastVersionId).thenReturn(Some(stateVersion.last))
+
+    Mockito.when(mockedStateStorage.getBox(ArgumentMatchers.any[Array[Byte]]()))
+      .thenAnswer(answer => {
+        val boxId = answer.getArgument(0).asInstanceOf[Array[Byte]]
+        boxList.find(_.id().sameElements(boxId))
+      })
+
+    Mockito.when(mockedStateForgerBoxStorage.lastVersionId).thenReturn(Some(stateVersion.last))
+
+    Mockito.when(mockedStateUtxoMerkleTreeStorage.lastVersionId).thenReturn(Some(stateVersion.last))
+
+    val mockedParams = mock[MainNetParams]
+    Mockito.when(mockedParams.restrictForgers).thenReturn(true)
+
+    val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeStorage,
+      mockedParams, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+
+    val forgerList = Seq(
+      (secretList(0).publicImage(), vrfList(0)),
+      (secretList(1).publicImage(), vrfList(1)),
+      (secretList(2).publicImage(), vrfList(2)),
+      (secretList(3).publicImage(), vrfList(3)),
+      (secretList(4).publicImage(), vrfList(4)),
+    )
+
+    // NEGATIVE TESTS
+
+    //Test validate(Transaction) with restrict forger disabled
+    Mockito.when(mockedParams.restrictForgers).thenReturn(false)
+    Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq())
+    var openStakeTransaction = getOpenStakeTransaction(
+      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      0
+    )
+    var tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransactions are not allowed with restrictForgers=false!"))
+
+    //Test validate(Transaction) with restrict forger enabled and forgerListIndex out of bound
+    Mockito.when(mockedParams.restrictForgers).thenReturn(true)
+    Mockito.when(mockedParams.allowedForgersList).thenReturn(forgerList)
+    openStakeTransaction = getOpenStakeTransaction(
+      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      10
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("ForgerListIndex in OpenStakeTransaction is out of bound!"))
+
+
+    //Test validate(Transaction) with restrict forger enabled and forger list indexes is not present in the storage
+    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {None})
+    openStakeTransaction = getOpenStakeTransaction(
+      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      0
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("Forger list was not found in the Storage!"))
+
+
+    //Test validate(Transaction) with restrict forger enabled and try to update an existing forger index
+    var forgerListIndexes = ForgerList(Array[Int](1,1,0,0,0))
+    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(forgerListIndexes)})
+    openStakeTransaction = getOpenStakeTransaction(
+      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      0
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("Forger already opened the stake!"))
+
+    //Test validate(Transaction) with restrict forger enabled with an input proposition that doesn't match the forgerListIndex
+    forgerListIndexes = ForgerList(Array[Int](0,1,0,0,0))
+    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(forgerListIndexes)})
+    openStakeTransaction = getOpenStakeTransaction(
+      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      3
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransaction input doesn't match the forgerListIndex!"))
+
+    //POSITIVE TESTS
+
+    //Test validate(Transaction) with restrict forger enabled and correct index
+    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(forgerListIndexes)})
+    openStakeTransaction = getOpenStakeTransaction(
+      Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
+      0
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertTrue("Transaction validation must not fail.",
       tryValidate.isSuccess)
   }
 

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -622,6 +622,8 @@ class SidechainStateTest
       )
     )
 
+    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Option.empty})
+
     Mockito.when(mockedStateForgerBoxStorage.lastVersionId).thenReturn(Some(stateVersion.last))
 
     Mockito.when(mockedStateUtxoMerkleTreeProvider.lastVersionId).thenReturn(Some(stateVersion.last))

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -642,6 +642,8 @@ class SidechainStateTest
 
     Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Option.empty})
 
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Option.empty})
+
     Mockito.when(mockedStateForgerBoxStorage.lastVersionId).thenReturn(Some(stateVersion.last))
 
     Mockito.when(mockedStateUtxoMerkleTreeProvider.lastVersionId).thenReturn(Some(stateVersion.last))
@@ -667,7 +669,7 @@ class SidechainStateTest
 
     //Test validate(Transaction) with restrict forger enable and invalid blockSignProposition
     Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq((invalidBlockSignProposition,allowedVrfPublicKey)))
-    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(ForgerList(Array[Int](0)))})
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(ForgerList(Array[Int](0)))})
     tryValidate = sidechainState.validate(stakeTransaction)
     assertFalse("Transaction validation must fail.",
       tryValidate.isSuccess)
@@ -687,7 +689,7 @@ class SidechainStateTest
       tryValidate.isSuccess)
 
     //Test validate(Transaction) with restrict forger, invalid forger and not the majority of the allowed forgers opened the stake
-    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(ForgerList(Array[Int](1,1,0,0,0)))})
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(ForgerList(Array[Int](1,1,0,0,0)))})
     Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq(
       (invalidBlockSignProposition,invalidVrfPublicKey),
       (invalidBlockSignProposition,invalidVrfPublicKey),
@@ -701,7 +703,7 @@ class SidechainStateTest
     assertTrue(tryValidate.failed.get.getMessage.equals("This publicKey is not allowed to forge!"))
 
     //Test validate(Transaction) with restrict forger, invalid forger and the majority of the allowed forgers opened the stake
-    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(ForgerList(Array[Int](1,1,1,0,0)))})
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(ForgerList(Array[Int](1,1,1,0,0)))})
     tryValidate = sidechainState.validate(stakeTransaction)
     assertTrue("Transaction validation must not fail.",
       tryValidate.isSuccess)
@@ -778,7 +780,7 @@ class SidechainStateTest
 
 
     //Test validate(Transaction) with restrict forger enabled and forger list indexes is not present in the storage
-    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {None})
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {None})
     openStakeTransaction = getOpenStakeTransaction(
       Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
       0
@@ -791,7 +793,7 @@ class SidechainStateTest
 
     //Test validate(Transaction) with restrict forger enabled and try to update an existing forger index
     var forgerListIndexes = ForgerList(Array[Int](1,1,0,0,0))
-    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(forgerListIndexes)})
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
       Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
       0
@@ -803,7 +805,7 @@ class SidechainStateTest
 
     //Test validate(Transaction) with restrict forger enabled with an input proposition that doesn't match the forgerListIndex
     forgerListIndexes = ForgerList(Array[Int](0,1,0,0,0))
-    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(forgerListIndexes)})
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
       Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
       3
@@ -816,7 +818,7 @@ class SidechainStateTest
     //POSITIVE TESTS
 
     //Test validate(Transaction) with restrict forger enabled and correct index
-    Mockito.when(mockedStateStorage.getForgerListIndexes).thenAnswer(_ => {Some(forgerListIndexes)})
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
     openStakeTransaction = getOpenStakeTransaction(
       Seq((boxList.head.asInstanceOf[ZenBox], secretList.head)),
       0

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -728,12 +728,12 @@ class SidechainStateTest
 
     Mockito.when(mockedStateForgerBoxStorage.lastVersionId).thenReturn(Some(stateVersion.last))
 
-    Mockito.when(mockedStateUtxoMerkleTreeStorage.lastVersionId).thenReturn(Some(stateVersion.last))
+    Mockito.when(mockedStateUtxoMerkleTreeProvider.lastVersionId).thenReturn(Some(stateVersion.last))
 
     val mockedParams = mock[MainNetParams]
     Mockito.when(mockedParams.restrictForgers).thenReturn(true)
 
-    val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeStorage,
+    val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
       mockedParams, bytesToVersion(stateVersion.last.data), mockedApplicationState)
 
     val forgerList = Seq(

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -303,7 +303,9 @@ class SidechainStateTest
       ArgumentMatchers.any[Option[WithdrawalEpochCertificate]](),
       ArgumentMatchers.any[BlockFeeInfo](),
       ArgumentMatchers.any[Option[Array[Byte]]](),
-      ArgumentMatchers.any[Boolean]()))
+      ArgumentMatchers.any[Boolean](),
+      ArgumentMatchers.any[Array[Int]],
+      ArgumentMatchers.any[Int]))
       .thenAnswer( answer => {
         val version = answer.getArgument[ByteArrayWrapper](0)
         val withdrawalEpochInfo = answer.getArgument[WithdrawalEpochInfo](1)

--- a/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
@@ -243,6 +243,9 @@ class SidechainStateIntegrationTest
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
 
+    Mockito.when(mockedBlock.sidechainTransactions)
+      .thenReturn(Seq())
+
     Mockito.when(mockedBlock.parentId)
       .thenReturn(bytesToId(initialVersion.data))
 

--- a/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
@@ -130,7 +130,9 @@ class SidechainStateIntegrationTest
       None,
       initialBlockFeeInfo,
       None,
-      scHasCeased = false
+      scHasCeased = false,
+      new Array[Int](0),
+      0
     )
 
     // Init SidechainStateForgerBoxStorage with forger boxes

--- a/sdk/src/test/scala/com/horizen/integration/storage/SidechainStateStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/storage/SidechainStateStorageTest.scala
@@ -58,7 +58,7 @@ class SidechainStateStorageTest
     // Test insert operation (empty storage).
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(version1, withdrawalEpochInfo, (bList1 ++ bList2).toSet, Set(), Seq(),
-        consensusEpoch, None, blockFeeInfo, None, false).isSuccess)
+        consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0).isSuccess)
     assertEquals("Version in storage must be - " + version1,
       version1, sidechainStateStorage.lastVersionId.get)
     assertEquals("Storage must contain 1 version.",
@@ -75,7 +75,7 @@ class SidechainStateStorageTest
     val boxIdsToRemoveSet: Set[ByteArrayWrapper] = Set(new ByteArrayWrapper(bList1.head.id()), new ByteArrayWrapper(bList2.head.id()))
     assertTrue("Update(delete) operation must be successful.",
       sidechainStateStorage.update(version2, withdrawalEpochInfo, Set(),
-        boxIdsToRemoveSet, Seq(), consensusEpoch, None, blockFeeInfo, None, false).isSuccess)
+        boxIdsToRemoveSet, Seq(), consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0).isSuccess)
 
     assertEquals("Version in storage must be - " + version2,
       version2, sidechainStateStorage.lastVersionId.get)
@@ -126,7 +126,7 @@ class SidechainStateStorageTest
     val mod1mcBlockHashInCertificate = Option(Array.fill(32)(rnd.nextInt().toByte))
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), withdrawalRequestsList,
-        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod1mcBlockHashInCertificate)), blockFeeInfo, None, false
+        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod1mcBlockHashInCertificate)), blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -153,7 +153,7 @@ class SidechainStateStorageTest
     val mod2mcBlockHashInCertificate = Option(Array.fill(32)(rnd.nextInt().toByte))
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), newWithdrawalRequestsList,
-        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod2mcBlockHashInCertificate)), blockFeeInfo, None, false
+        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod2mcBlockHashInCertificate)), blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -181,7 +181,7 @@ class SidechainStateStorageTest
     val secondEpochWithdrawalRequestsList: List[WithdrawalRequestBox] = getWithdrawalRequestsBoxList(2).asScala.toList
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod3Version, mod3WithdrawalEpochInfo, Set(), Set(), secondEpochWithdrawalRequestsList,
-        consensusEpoch, None, blockFeeInfo, None, false
+        consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
     // Check that first epoch withdrawals still exist -> no clean-up
@@ -195,7 +195,7 @@ class SidechainStateStorageTest
     val thirdEpochWithdrawalRequestsList: List[WithdrawalRequestBox] = getWithdrawalRequestsBoxList(3).asScala.toList
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod4Version, mod4WithdrawalEpochInfo, Set(), Set(), thirdEpochWithdrawalRequestsList,
-        consensusEpoch, None, blockFeeInfo, None, false
+        consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
     // Check that first epoch withdrawals were removed.
@@ -236,7 +236,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod1BlockFeeInfo, None, false
+        consensusEpoch, None, mod1BlockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -257,7 +257,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod2BlockFeeInfo, None, false
+        consensusEpoch, None, mod2BlockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -280,7 +280,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod3Version, mod3WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod3BlockFeeInfo, None, false
+        consensusEpoch, None, mod3BlockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -328,7 +328,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod1BlockFeeInfo, Some(utxoMerkleRoot1), scHasCeased = false
+        consensusEpoch, None, mod1BlockFeeInfo, Some(utxoMerkleRoot1), scHasCeased = false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -347,7 +347,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod2BlockFeeInfo, Some(utxoMerkleRoot2), scHasCeased = true
+        consensusEpoch, None, mod2BlockFeeInfo, Some(utxoMerkleRoot2), scHasCeased = true, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -378,7 +378,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod1BlockFeeInfo, None, scHasCeased = false
+        consensusEpoch, None, mod1BlockFeeInfo, None, scHasCeased = false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -393,7 +393,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod2BlockFeeInfo, None, scHasCeased = true
+        consensusEpoch, None, mod2BlockFeeInfo, None, scHasCeased = true, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -415,6 +415,6 @@ class SidechainStateStorageTest
     //Try to remove non-existent item
     assertFalse("Remove operation of non-existent item must not throw exception.",
       sidechainStateStorage.update(version1, withdrawalEpochInfo, Set(), bList1.map(b => new ByteArrayWrapper(b.id())),
-        Seq(), intToConsensusEpochNumber(0), None, blockFeeInfo, None, false).isFailure)
+        Seq(), intToConsensusEpochNumber(0), None, blockFeeInfo, None, false, new Array[Int](0), 0).isFailure)
   }
 }

--- a/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
@@ -117,6 +117,9 @@ class SidechainStateStorageTest
     toUpdate.add(new Pair(stateStorage.consensusEpochKey, new ByteArrayWrapper(Ints.toByteArray(consensusEpoch))))
     val toRemove = java.util.Arrays.asList(storedBoxList(2).getKey)
 
+    //forger list indexes
+    toUpdate.add(new Pair(stateStorage.forgerListIndexKey, new ByteArrayWrapper(Array[Byte](0.toByte))))
+
     Mockito.when(mockedPhysicalStorage.update(
       ArgumentMatchers.any[ByteArrayWrapper](),
       ArgumentMatchers.anyList[Pair[ByteArrayWrapper, ByteArrayWrapper]](),

--- a/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
@@ -136,7 +136,7 @@ class SidechainStateStorageTest
 
     // Test 1: test successful update
     tryRes = stateStorage.update(version, withdrawalEpochInfo, Set(boxList.head),
-      Set(new ByteArrayWrapper(boxList(2).id())), Seq(), consensusEpoch, None, blockFeeInfo, None, false)
+      Set(new ByteArrayWrapper(boxList(2).id())), Seq(), consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0)
     assertTrue("StateStorage successful update expected, instead exception occurred:\n %s".format(if(tryRes.isFailure) tryRes.failed.get.getMessage else ""),
       tryRes.isSuccess)
 
@@ -144,7 +144,7 @@ class SidechainStateStorageTest
     // Test 2: test failed update, when Storage throws an exception
     val box = getZenBox
     tryRes = stateStorage.update(version, withdrawalEpochInfo, Set(box),
-      Set(new ByteArrayWrapper(boxList(3).id())), Seq(), consensusEpoch, None, blockFeeInfo, None, false)
+      Set(new ByteArrayWrapper(boxList(3).id())), Seq(), consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0)
     assertTrue("StateStorage failure expected during update.", tryRes.isFailure)
     assertEquals("StateStorage different exception expected during update.", expectedException, tryRes.failed.get)
     assertTrue("Storage should NOT contain Box that was tried to update.", stateStorage.getBox(box.id()).isEmpty)


### PR DESCRIPTION
## Description
At the moment we have the possibility to restrict the forging operation to a predefined list of forgers.
This PR includes the possibility to open the forging operation that is previously closed, to the world.

## Jira Ticket
[431](https://horizenlabs.atlassian.net/jira/software/c/projects/SCHAINS/boards/3?modal=detail&selectedIssue=SCHAINS-431)

## Changes

- Added new transaction type **OpenStakeTransaction**
- Added new endpoint **createOpenStakeTransaction**
- Added new endpoint **createOpenStakeTransactionSimplified**
- Non backward compatible changes in the consensus.

## Breaking Changes
- Non backward compatible changes in the consensus.

## Checks
- [✔] Project Builds
- [✔] Project passes tests and checks
- [✘] Updated documentation accordingly
- [✔] Breaking changes have been correctly tagged and notified

