### PR TITLE
[SDK-233] Fixed putWithLimitedPoolSize() unit test

### DIFF
--- a/sdk/src/test/scala/com/horizen/SidechainMemoryPoolTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainMemoryPoolTest.scala
@@ -238,6 +238,9 @@ class SidechainMemoryPoolTest
 
     //now the tx with lowest fee is secondLowestFeeTx: we try to add another tx with the same feerate
     var aNewTx = getRegularRandomTransaction(20, 1)
+    while (aNewTx.size() != secondLowestFeeTx.size()) {
+      aNewTx = getRegularRandomTransaction(20, 1)
+    }
     assertEquals("Put tx operation must be success.", true, memoryPool.put(aNewTx).isSuccess)
     assertEquals("MemoryPool must have correct size ", list.size-1, memoryPool.size)
     assertEquals("Old lowest fee transaction must not be present ", false, memoryPool.getTransactionById(secondLowestFeeTx.id()).isPresent)


### PR DESCRIPTION
The issue was that the transaction that we expected to include in the mempool sometimes had different size to the transaction that we expected to remove (252 compared to 250) even if they were constructed in the same way (probably due to the zig zag encoding). For this reason the new transaction wasn't included in the mempool and the test was failing.

After the fix i have runned 500 times the test and it worked fine every time.