### PR TITLE
Config files: apiKeyHash cleanup.

### DIFF
--- a/examples/simpleapp/src/main/resources/sc_settings.conf
+++ b/examples/simpleapp/src/main/resources/sc_settings.conf
@@ -12,7 +12,6 @@ scorex {
     restApi {
         bindAddress = "127.0.0.1:9085"
         timeout = 5s
-        apiKeyHash = ""
     }
 
     network {

--- a/examples/simpleapp/src/main/resources/settings_basic.conf
+++ b/examples/simpleapp/src/main/resources/settings_basic.conf
@@ -11,7 +11,6 @@ scorex {
 
   restApi {
     bindAddress = "127.0.0.1:9085"
-    api-key-hash = ""
     timeout = 5s
   }
 

--- a/sdk/src/main/resources/sidechain-sdk-settings.conf
+++ b/sdk/src/main/resources/sidechain-sdk-settings.conf
@@ -11,7 +11,6 @@ scorex {
 
   restApi {
     bindAddress = "127.0.0.1:9085"
-    apiKeyHash = ""
     timeout = 5s
   }
 


### PR DESCRIPTION
To have a possibility to disable authorization for the users by miss of apiKeyHash definition at all.
Later on Scorex we will recognize empty string as a "disabled" auth.