### PR TITLE
Mo/sdk 216 (Added BTs limit inside the certificate)

### DIFF
--- a/examples/simpleapp/src/main/java/com/horizen/examples/AppForkConfigurator.java
+++ b/examples/simpleapp/src/main/java/com/horizen/examples/AppForkConfigurator.java
@@ -6,7 +6,6 @@ import com.horizen.fork.ForkConsensusEpochNumber;
 public class AppForkConfigurator extends ForkConfigurator {
     @Override
     public ForkConsensusEpochNumber getSidechainFork1() {
-        // TODO Set activation height for SidechainFork1
-        return new ForkConsensusEpochNumber(0, 0, 0);
+        return new ForkConsensusEpochNumber(0, 3, 0);
     }
 }

--- a/qa/SidechainTestFramework/sc_boostrap_info.py
+++ b/qa/SidechainTestFramework/sc_boostrap_info.py
@@ -101,7 +101,8 @@ class SCNodeConfiguration(object):
                  mempool_max_size = 300,
                  mempool_min_fee_rate = 0,
                  api_key=DEFAULT_API_KEY,
-                 max_fee=10000000):
+                 max_fee=10000000,
+                 initial_private_keys = []):
         if submitter_private_keys_indexes is None:
             submitter_private_keys_indexes = list(range(7))
         self.mc_connection_info = mc_connection_info
@@ -116,6 +117,7 @@ class SCNodeConfiguration(object):
         self.max_fee = max_fee
         self.mempool_max_size = mempool_max_size
         self.mempool_min_fee_rate = mempool_min_fee_rate
+        self.initial_private_keys = initial_private_keys
 
 """
 The full network of many sidechain nodes connected to many mainchain nodes.

--- a/qa/SidechainTestFramework/scutil.py
+++ b/qa/SidechainTestFramework/scutil.py
@@ -375,6 +375,8 @@ def initialize_sc_datadir(dirname, n, bootstrap_info=SCBootstrapInfo, sc_node_co
     api_key_hash = ""
     if sc_node_config.api_key != "":
         api_key_hash = calculateApiKeyHash(sc_node_config.api_key)
+    genesis_secrets += sc_node_config.initial_private_keys
+
     config = tmpConfig % {
         'NODE_NUMBER': n,
         'DIRECTORY': dirname,

--- a/qa/httpCalls/block/forgingInfo.py
+++ b/qa/httpCalls/block/forgingInfo.py
@@ -1,0 +1,3 @@
+def http_block_forging_info(sidechainNode):
+      response = sidechainNode.block_forgingInfo()
+      return response['result']

--- a/qa/httpCalls/transaction/allTransactions.py
+++ b/qa/httpCalls/transaction/allTransactions.py
@@ -1,7 +1,7 @@
 import json
 
 # execute a transaction/allTransactions call (list of all mempool transactions)
-def allTransactions(sidechainNode, format):
+def allTransactions(sidechainNode, format = True):
     j = {"format": format }
     request = json.dumps(j)
     response = sidechainNode.transaction_allTransactions(request)

--- a/qa/httpCalls/transaction/makeForgerStake.py
+++ b/qa/httpCalls/transaction/makeForgerStake.py
@@ -1,6 +1,6 @@
 import json
 #execute a transaction/makeForgerStake call
-def makeForgerStake(sidechainNode, address, blockSignPublicKey, vrfPublicKey, amount, fee, api_key = None):
+def makeForgerStake(sidechainNode, address, blockSignPublicKey, vrfPublicKey, amount, fee = 0, api_key = None):
       j = {\
             "outputs": [ \
               { \

--- a/qa/httpCalls/transaction/openStake.py
+++ b/qa/httpCalls/transaction/openStake.py
@@ -1,0 +1,30 @@
+import json
+#execute a transaction/createopenStakeTransaction call
+def createOpenStakeTransaction(sidechain_node, boxid, address, forger_index, fee = 0, format = False, automatic_send = False):
+      j = { 
+            "transactionInput": 
+            { 
+                "boxId": boxid 
+            },
+            "regularOutputProposition": address,
+            "forgerIndex": forger_index,
+            "fee": fee,
+            "format": format,
+            "automaticSend": automatic_send
+      }
+      request = json.dumps(j)
+      response = sidechain_node.transaction_createOpenStakeTransaction(request)
+      return response["result"]
+
+#execute a transaction/createOpenStakeTransactionSimplified call
+def createOpenStakeTransactionSimplified(sidechain_node, forger_proposition, forger_index, fee, format = False, automatic_send = False):
+      j = {
+            "forgerProposition": forger_proposition,
+            "forgerIndex": forger_index,
+            "fee": fee,
+            "format": format,
+            "automaticSend": automatic_send
+      }
+      request = json.dumps(j)
+      response = sidechain_node.transaction_createOpenStakeTransactionSimplified(request)
+      return response["result"]

--- a/qa/httpCalls/transaction/sendCoinsToAddress.py
+++ b/qa/httpCalls/transaction/sendCoinsToAddress.py
@@ -33,3 +33,17 @@ def sendCointsToMultipleAddress(sidechainNode, addresses, amounts, fee):
     response = sidechainNode.transaction_sendCoinsToAddress(request)
     return response["result"]["transactionId"]
 
+def sendCointsToMultipleAddress(sidechainNode, addresses, amounts, fee):
+    if (len(addresses) != len(amounts)):
+        return "Addresses and amunts have differente lengths!"
+    outputs = []
+    for i in range(0, len(addresses)):
+        outputs += [{"publicKey": addresses[i], "value": amounts[i]}]
+
+    j = {
+        "outputs": outputs,
+        "fee": fee
+    }
+    request = json.dumps(j)
+    response = sidechainNode.transaction_sendCoinsToAddress(request)
+    return response["result"]["transactionId"]

--- a/qa/httpCalls/transaction/sendTransaction.py
+++ b/qa/httpCalls/transaction/sendTransaction.py
@@ -1,0 +1,11 @@
+import json
+
+
+# execute a transaction/sendTransaction call
+def sendTransaction(sidechainNode, tx_bytes):
+    j = {
+        "transactionBytes": tx_bytes
+    }
+    request = json.dumps(j)
+    response = sidechainNode.transaction_sendTransaction(request)
+    return response

--- a/qa/httpCalls/transaction/withdrawCoins.py
+++ b/qa/httpCalls/transaction/withdrawCoins.py
@@ -1,0 +1,37 @@
+import json
+#execute a transaction/withdrawCoins call
+def withdrawCoins(sidechainNode, mc_address, amount, fee = 0, api_key = None):
+      j = {\
+            "outputs": [ \
+              { \
+                "mainchainAddress": mc_address, \
+                "value": amount \
+              } \
+            ], \
+            "fee": fee \
+      }
+      request = json.dumps(j)
+      if (api_key != None):
+        response = sidechainNode.transaction_withdrawCoins(request, api_key)
+      else:
+        response = sidechainNode.transaction_withdrawCoins(request)
+      return response
+
+
+def withdrawMultiCoins(sidechainNode, mc_addresses, amounts, fee = 0, api_key = None):
+    if (len(mc_addresses) != len(amounts)):
+        return "Addresses and amunts have differente lengths!"
+    outputs = []
+    for i in range(0, len(mc_addresses)):
+        outputs += [{"mainchainAddress": mc_addresses[i], "value": amounts[i]}]
+
+    j = {
+        "outputs": outputs,
+        "fee": fee
+    }
+    request = json.dumps(j)
+    if (api_key != None):
+        response = sidechainNode.transaction_withdrawCoins(request, api_key)
+    else:
+        response = sidechainNode.transaction_withdrawCoins(request)
+    return response

--- a/qa/httpCalls/wallet/allBoxes.py
+++ b/qa/httpCalls/wallet/allBoxes.py
@@ -1,9 +1,11 @@
+import json
+
 #executes a  wallet/allBoxes call
-def http_wallet_allBoxes(sidechainNode, api_key = None):
+def http_wallet_allBoxes(sidechainNode, typeName = None, api_key = None):
       if (api_key != None):
-            response = sidechainNode.wallet_allBoxes({}, api_key)
+            response = sidechainNode.wallet_allBoxes(json.dumps({"boxTypeClass": typeName}) if typeName != None else {}, api_key)
       else:
-            response = sidechainNode.wallet_allBoxes()
+            response = sidechainNode.wallet_allBoxes(json.dumps({"boxTypeClass": typeName}) if typeName != None else {})
       return response['result']['boxes']
 
 

--- a/qa/run_sc_tests.py
+++ b/qa/run_sc_tests.py
@@ -47,6 +47,7 @@ from sc_mempool_max_size import  SCMempoolMaxSize
 from sc_mempool_min_fee_rate import SCMempoolMinFeeRate
 from sc_csw_in_fee_payment import ScCSWInFeePaymentTest
 from sc_bt_limit import ScBtLimitTest
+from sc_bt_limit_across_fork import ScBtLimitAcrossForkTest
 
 def run_test(test):
     try:
@@ -193,6 +194,9 @@ def run_tests(log_file):
 
     result = run_test(ScBtLimitTest())
     assert_equal(0, result, "sc_bt_limit test failed!")
+
+    result = run_test(ScBtLimitAcrossForkTest())
+    assert_equal(0, result, "sc_bt_limit_across_fork test failed!")
 
 if __name__ == "__main__":
     my_log_file = open("sc_test.log", "w")

--- a/qa/run_sc_tests.py
+++ b/qa/run_sc_tests.py
@@ -46,6 +46,7 @@ from sc_csw_disabled import SCCswDisabled
 from sc_mempool_max_size import  SCMempoolMaxSize
 from sc_mempool_min_fee_rate import SCMempoolMinFeeRate
 from sc_csw_in_fee_payment import ScCSWInFeePaymentTest
+from sc_bt_limit import ScBtLimitTest
 
 def run_test(test):
     try:
@@ -189,6 +190,9 @@ def run_tests(log_file):
 
     result = run_test(ScCSWInFeePaymentTest())
     assert_equal(0, result, "sc_csw_in_fee_payment test failed!")
+
+    result = run_test(ScBtLimitTest())
+    assert_equal(0, result, "sc_bt_limit test failed!")
 
 if __name__ == "__main__":
     my_log_file = open("sc_test.log", "w")

--- a/qa/sc_bt_limit.py
+++ b/qa/sc_bt_limit.py
@@ -14,6 +14,7 @@ from test_framework.util import fail, assert_equal, assert_true, start_nodes, \
 from httpCalls.block.findBlockByID import http_block_findById
 from httpCalls.transaction.withdrawCoins import withdrawMultiCoins
 from httpCalls.block.forgingInfo import http_block_forging_info
+from httpCalls.transaction.sendCoinsToAddress import sendCointsToMultipleAddress
 
 """
 Configuration:
@@ -25,13 +26,14 @@ Configuration:
 
 Test:
     For the SC node:
-        - ############## EPOCH 0 #####################
+        - ############## WITHDRAWAL EPOCH 0 #####################
         - Send 1 FT to SC node 1 on different addresses.
         - Generate 1 MC and 1 SC block to see FT in the sidechain.
+        - Split the FT box into some ZenBoxes
         - Generate a transaction that has 999 WithdrawalRequestBoxes
         - Generate a SC block and verify that it includes this transaction since we didn't reach the SC fork 1
 
-        - ############## EPOCH 1 #####################
+        - ############## WITHDRAWAL EPOCH 1 #####################
         - Reach the SC fork 1
         - Generate a transaction that has 999 WithdrawalRequestBoxes
         - Generate a SC block and verify that it doesn't include this transaction (2 MC block reference included = 798 WBs slots)
@@ -42,24 +44,27 @@ Test:
         - Generate 2 transaction that create 80 WBs each one
         - Generate a SC block and verify that it contains only one of these 2 transctions
         - Generate 2 transactions that generate 999 WBs each one
-        - Generate MC blocks until the last block of the epoch 0.
-        - Generate a SC block that inlcudes all the previous transactions (we opened up enought slots)
-        - Create a transaction that generate the reamining WBs allowed in the epoch (3999 - alreadyMinedWbs = 824 WBs)
+        - Generate MC blocks to open up enough slots
+        - Generate a SC block and verify it contains the 2 transactions of 999 WBs and the one with 80 WBs
+        - Generate MC blocks until the last block of the epoch 1.
+        - Create a transaction that produce the reamining WBs allowed per epoch
+        - Generate a SC block that inlcudes and verify that it includes this transaction
         - Generate another MC block and SC block to reach the end of the epoch
+        - Create a transaction that has 999 WBs
 
-        - ############## EPOCH 2 #####################
+        - ############## WITHDRAWAL EPOCH 2 #####################
         - Generate the first MC block of the next epoch and a SC block
-        - Verify that this SC block contains the previously generated transaction containing the remaining WBs (824)
         - Wait for certificate submission.
         - Generate 1 MC and 1 SC block including the certificate.
         - Generate a transaction that creates 300 WBs
-        - Forge a SC block and verify that it doesn't contain this transaction. We already filled remaining_wbs (824) in this epoch that only added 2 MC block references (=798 empty slots)
+        - Forge a SC block and verify that it contains this transaction and not the one with 999 WBS (we didn't open enough slots yet)
+        - Generate MC blocks to open up slots
+        - Generate a SC block and verify it contains the 999 WBs transaction
         - Generate MC blocks to reach the end of the Withdrawal epoch 1.
         - Generate a SC block that contains all of these MC blocks.
         
-        - ############## EPOCH 3 #####################
+        - ############## WITHDRAWAL EPOCH 3 #####################
         - Generate the first MC block of the next epoch and a SC block
-        - Verify that we have the 300 WBs transaction included in this SC block. We couldn't add before because we opened all the needed slots in the last block of the epoch that can't include any transactions
         - Wait for certificate submission.
 
 """
@@ -98,25 +103,8 @@ class ScBtLimitTest(SidechainTestFramework):
         is_csw_enabled = sc_node.csw_isCSWEnabled()["result"]["cswEnabled"]
         assert_true(is_csw_enabled, "Ceased Sidechain Withdrawal expected to be enabled.")
 
-        # Checks that CSW is enabled in Sidechain creation transaction on Mainchain
-        mc_block_height = mc_node.getblockcount()
-        mc_block = mc_node.getblock(str(mc_block_height))
-        mc_sc_creation_tx_id = mc_block["tx"][1]
-        mc_sc_creation_tx = mc_node.getrawtransaction(mc_sc_creation_tx_id, 1)
-
-        vsc_ccout_ = mc_sc_creation_tx["vsc_ccout"][0]
-        assert_true(vsc_ccout_["vFieldElementCertificateFieldConfig"] == certificate_field_config_csw_enabled,
-                    "Custom Field Elements Configuration in MC are wrong. Expected: " + format(certificate_field_config_csw_enabled) +
-                    ", actual: " + format(vsc_ccout_["vFieldElementCertificateFieldConfig"]))
-        assert_true("wCeasedVk" in vsc_ccout_, "CSW verification key should be present")
-
-        # Checks that Sidechain creation transaction is in SC block
-        mc_block_hash = mc_sc_creation_tx["blockhash"]
-        sc_block_id = sc_node.block_best()["result"]["block"]["id"]
-        check_mcreference_presence(mc_block_hash, sc_block_id, sc_node)
-
-        # ******************** EPOCH 0 START ********************
-        print("******************** EPOCH 0 START ********************")
+        # ******************** WITHDRAWAL EPOCH 0 START ********************
+        print("******************** WITHDRAWAL EPOCH 0 START ********************")
 
         #Verify we didn't reach the SC fork1 that includes BT limit
         consensusEpochData = http_block_forging_info(sc_node)
@@ -126,7 +114,7 @@ class ScBtLimitTest(SidechainTestFramework):
 
         # create 1 FTs in the same MC block to SC
         sc_address_1 = sc_node.wallet_createPrivateKey25519()["result"]["proposition"]["publicKey"]
-        ft_amount_1 = 100
+        ft_amount_1 = 1000
         mc_return_address_1 = mc_node.getnewaddress()
 
         forward_transfer_to_sidechain(self.sidechain_id, mc_node,
@@ -137,6 +125,10 @@ class ScBtLimitTest(SidechainTestFramework):
 
         epoch_mc_blocks_left -= 1
         # Generate 1 SC block to include FTs.
+        generate_next_blocks(sc_node, "first node", 1)[0]
+
+        #Split the UTXO
+        sendCointsToMultipleAddress(sc_node, [sc_address_1 for _ in range (10)], [10 * 1e8 for _ in range(10)], 0)
         generate_next_blocks(sc_node, "first node", 1)[0]
 
         # Create a transaction that generates 999 WBs 
@@ -162,8 +154,8 @@ class ScBtLimitTest(SidechainTestFramework):
         block_json = http_block_findById(sc_node, sc_block_id)
         check_mcreferencedata_presence(we0_end_mcblock_hash, sc_block_id, sc_node)
 
-        # ******************** EPOCH 1 START ********************
-        print("******************** EPOCH 1 START ********************")
+        # ******************** WITHDRAWAL EPOCH 1 START ********************
+        print("******************** WITHDRAWAL EPOCH 1 START ********************")
 
         # Generate first mc block of the next epoch
         we1_1_mcblock_hash = mc_node.generate(1)[0]
@@ -188,7 +180,7 @@ class ScBtLimitTest(SidechainTestFramework):
         print(consensusEpochData)
         assert_equal(consensusEpochData["bestEpochNumber"], 3)
 
-        # Based on withdrawalEpochLength = 10, maxBTsAllowedPerCertificate = 3999, we open 399 slots for WithdrawalBoxes for each MC block reference
+        # Based on withdrawalEpochLength = 11, maxBTsAllowedPerCertificate = 3999, we open 399 slots for WithdrawalBoxes for each MC block reference
         # 2 MC block mined = 399 * 2 = 798 WthdrawalBoxes allowed
 
         # Create a transaction that generates 999 WBs 
@@ -232,6 +224,7 @@ class ScBtLimitTest(SidechainTestFramework):
         block_json = http_block_findById(sc_node, sc_block_id)
         assert_equal(len(block_json["block"]["sidechainTransactions"]), 1)    
         wbs_mined += 80
+        wbs_mined += 80
 
         # Create Some WBs
 
@@ -241,9 +234,26 @@ class ScBtLimitTest(SidechainTestFramework):
         wbs_mined += 999
 
         # Generate some MC blocks to open up slots
-        mc_node.generate(epoch_mc_blocks_left - 1)
+        mc_node.generate(epoch_mc_blocks_left - 2)
         sc_block_id = generate_next_block(sc_node, "first node")
         block_json = http_block_findById(sc_node, sc_block_id)
+
+        assert_equal(len(block_json["block"]["sidechainTransactions"]), 3)
+
+        #744
+        remaining_wbs = MAX_WBS_PER_EPOCH - wbs_mined
+        wbs_left_txid = withdrawMultiCoins(sc_node, bt_addresses[:remaining_wbs], amounts[:remaining_wbs])["result"]["transactionId"]
+
+        # Generate 1 MC block. Now all the slots should be opened
+        we0_end_mcblock_hash = mc_node.generate(1)[0]
+
+        #We should be able to include the remaining WBs inside the current epoch
+        sc_block_id = generate_next_block(sc_node, "first node")
+        block_json = http_block_findById(sc_node, sc_block_id)
+        assert_equal(block_json["block"]["sidechainTransactions"][0]["id"],wbs_left_txid)
+
+        #Create another transaction that generate some WBs.
+        not_included_tx_id = withdrawMultiCoins(sc_node, bt_addresses, amounts)["result"]["transactionId"]
 
         # Generate 1 MC block to reach the end of the epoch
         we0_end_mcblock_hash = mc_node.generate(1)[0]
@@ -252,27 +262,21 @@ class ScBtLimitTest(SidechainTestFramework):
         we0_end_epoch_cum_sc_tx_comm_tree_root = we0_end_mcblock_json["scCumTreeHash"]
         print("End cum sc tx cum comm tree root hash in withdrawal epoch 0 = " + we0_end_epoch_cum_sc_tx_comm_tree_root)
 
-        #824
-        remaining_wbs = MAX_WBS_PER_EPOCH - wbs_mined
-        wbs_left_txid = withdrawMultiCoins(sc_node, bt_addresses[:remaining_wbs], amounts[:remaining_wbs])["result"]["transactionId"]
-
         sc_block_id = generate_next_block(sc_node, "first node")
         block_json = http_block_findById(sc_node, sc_block_id)
         check_mcreferencedata_presence(we0_end_mcblock_hash, sc_block_id, sc_node)
 
 
-        # ******************** EPOCH 2 START ********************
-        print("******************** EPOCH 2 START ********************")
+        # ******************** WITHDRAWAL EPOCH 2 START ********************
+        print("******************** WITHDRAWAL EPOCH 2 START ********************")
 
         # Generate first mc block of the next epoch
         we1_1_mcblock_hash = mc_node.generate(1)[0]
         epoch_mc_blocks_left = self.sc_withdrawal_epoch_length - 1
         sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
 
-        # The tx with the reamining wbs is not added to the last epoch block but it should be added to the first block of the new epoch
-        # Since we are not started to generate the certificate for the epoch 0 we still have the open slots from the previous epoch and 
-        # we are able to include the tx in the block
-        assert_equal(wbs_left_txid, http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"][0]["id"])
+        # The not_included_tx is not present because we already reached the maximum WBs allowed for this epoch
+        assert_equal(len(http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"]), 0)
 
         check_mcreference_presence(we1_1_mcblock_hash, sc_block_id, sc_node)
 
@@ -294,12 +298,17 @@ class ScBtLimitTest(SidechainTestFramework):
         sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
         check_mcreference_presence(we1_2_mcblock_hash, sc_block_id, sc_node)
 
-        # We already filled remaining_wbs (824) in this epoch that only added 2 MC block references (=798 empty slots)
-        # this new 300 wbs transactions should not be incuded in the next block
-        assert_equal(len(http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"]), 0)
+        # We didn't open enough slot for not_included_tx so we can include only this 300 tx in the next block
+        assert_equal(len(http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"]), 1)
+        assert_equal(http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"][0]["id"], wbs_txid)
 
         
         # Generate more MC blocks to finish the second withdrawal epoch, then generate 1 more SC block to sync with MC.
+        mc_node.generate(3)
+        epoch_mc_blocks_left -= 3
+        sc_block_id = generate_next_block(sc_node, "first node")
+        assert_equal(not_included_tx_id, http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"][0]["id"])
+
         we1_end_mcblock_hash = mc_node.generate(epoch_mc_blocks_left)[-1]
         print("End mc block hash in withdrawal epoch 1 = " + we1_end_mcblock_hash)
         we1_end_mcblock_json = mc_node.getblock(we1_end_mcblock_hash)
@@ -307,7 +316,7 @@ class ScBtLimitTest(SidechainTestFramework):
         print("End cum sc tx cum comm tree root hash in withdrawal epoch 1 = " + we1_end_epoch_cum_sc_tx_comm_tree_root)
 
         sc_block_id = generate_next_block(sc_node, "first node")
-
+        
         # We don't include the tx here since this is the last block of the epoch
         assert_equal(len(http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"]), 0)
 
@@ -315,16 +324,13 @@ class ScBtLimitTest(SidechainTestFramework):
 
         epoch_mc_blocks_left = self.sc_withdrawal_epoch_length
 
-        # ******************** EPOCH 3 START ********************
-        print("******************** EPOCH 3 START ********************")
+        # ******************** WITHDRAWAL EPOCH 3 START ********************
+        print("******************** WITHDRAWAL EPOCH 3 START ********************")
 
         # Generate first mc block of the next epoch
         we2_1_mcblock_hash = mc_node.generate(1)[0]
         epoch_mc_blocks_left = self.sc_withdrawal_epoch_length - 1
         sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
-
-        # Here we have the accumulated slots from the previous epoch since we didn't generate the certificate yet.
-        assert_equal(wbs_txid, http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"][0]["id"])
 
         check_mcreference_presence(we2_1_mcblock_hash, sc_block_id, sc_node)
 

--- a/qa/sc_bt_limit.py
+++ b/qa/sc_bt_limit.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+from curses import raw
+import time
+import pprint
+
+from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
+    SCNetworkConfiguration, SC_CREATION_VERSION_1
+from SidechainTestFramework.sc_forging_util import *
+from SidechainTestFramework.sc_test_framework import SidechainTestFramework
+from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, \
+    start_sc_nodes, generate_next_blocks, generate_next_block
+from test_framework.util import fail, assert_equal, assert_true, start_nodes, \
+    websocket_port_by_mc_node_index, forward_transfer_to_sidechain, certificate_field_config_csw_enabled
+from httpCalls.block.findBlockByID import http_block_findById
+from httpCalls.transaction.withdrawCoins import withdrawMultiCoins
+
+"""
+Configuration:
+    Start 1 MC node and 1 SC node (with default websocket configuration).
+    SC node connected to the first MC node.
+    SC node has ENABLED certificate submitter.
+    WithdrawalEpochLength = 11
+    WithdrawalRequestBox slots open per MC block reference = 3999 / (11 - 1) = 399
+
+Test:
+    For the SC node:
+        - ############## EPOCH 0 #####################
+        - Send 1 FT to SC node 1 on different addresses.
+        - Generate 1 MC and 1 SC block to see FT in the sidechain.
+        - Generate a transaction that has 999 WithdrawalRequestBoxes
+        - Generate a SC block and verify that it doesn't include this transaction (2 MC block reference included = 798 WBs slots)
+        - Generate a new MC block to open other 399 slots
+        - Generate a SC block that includes this transction (Slots left = 3*399 - 999 = 198)
+        - Generate a transaction that creates 98 WBs
+        - Generate a SC block that includes this transaction (verify that the slots take in account the already mined WBs) (Slots left = 100)
+        - Generate 2 transaction that create 80 WBs each one
+        - Generate a SC block and verify that it contains only one of these 2 transctions
+        - Generate 2 transactions that generate 999 WBs each one
+        - Generate MC blocks until the last block of the epoch 0.
+        - Generate a SC block that inlcudes all the previous transactions (we opened up enought slots)
+        - Create a transaction that generate the reamining WBs allowed in the epoch (3999 - alreadyMinedWbs = 824 WBs)
+        - Generate another MC block and SC block to reach the end of the epoch
+
+        - ############## EPOCH 1 #####################
+        - Generate the first MC block of the next epoch and a SC block
+        - Verify that this SC block contains the previously generated transaction containing the remaining WBs (824)
+        - Wait for certificate submission.
+        - Generate 1 MC and 1 SC block including the certificate.
+        - Generate a transaction that creates 300 WBs
+        - Forge a SC block and verify that it doesn't contain this transaction. We already filled remaining_wbs (824) in this epoch that only added 2 MC block references (=798 empty slots)
+        - Generate MC blocks to reach the end of the Withdrawal epoch 1.
+        - Generate a SC block that contains all of these MC blocks.
+        
+        - ############## EPOCH 2 #####################
+        - Generate the first MC block of the next epoch and a SC block
+        - Verify that we have the 300 WBs transaction included in this SC block. We couldn't add before because we opened all the needed slots in the last block of the epoch that can't include any transactions
+        - Wait for certificate submission.
+
+"""
+class ScBtLimitTest(SidechainTestFramework):
+
+    sidechain_id = None
+    sc_withdrawal_epoch_length = 11
+    FEE = 5
+
+    def setup_nodes(self):
+        num_nodes = 1
+        # Set MC scproofqueuesize to 0 to avoid BatchVerifier processing delays
+        return start_nodes(num_nodes, self.options.tmpdir, extra_args=[['-debug=sc', '-debug=ws',  '-logtimemicros=1', '-scproofqueuesize=0']] * num_nodes)
+
+    def sc_setup_chain(self):
+        mc_node = self.nodes[0]
+        sc_node_configuration = SCNodeConfiguration(
+            MCConnectionInfo(address="ws://{0}:{1}".format(mc_node.hostname, websocket_port_by_mc_node_index(0))),
+            cert_submitter_enabled=True,  # enable submitter
+            cert_signing_enabled=True  # enable signer
+        )
+        network = SCNetworkConfiguration(SCCreationInfo(mc_node, 1000, self.sc_withdrawal_epoch_length, sc_creation_version=SC_CREATION_VERSION_1, csw_enabled=True), sc_node_configuration)
+        self.sidechain_id = bootstrap_sidechain_nodes(self.options, network).sidechain_id
+
+    def sc_setup_nodes(self):
+        return start_sc_nodes(1, self.options.tmpdir)
+
+    def run_test(self):
+        time.sleep(0.1)
+        self.sync_all()
+        mc_node = self.nodes[0]
+        sc_node = self.sc_nodes[0]
+        MAX_WBS_PER_EPOCH = 3999
+
+        # Check CSW is enabled on SC node
+        is_csw_enabled = sc_node.csw_isCSWEnabled()["result"]["cswEnabled"]
+        assert_true(is_csw_enabled, "Ceased Sidechain Withdrawal expected to be enabled.")
+
+        # Checks that CSW is enabled in Sidechain creation transaction on Mainchain
+        mc_block_height = mc_node.getblockcount()
+        mc_block = mc_node.getblock(str(mc_block_height))
+        mc_sc_creation_tx_id = mc_block["tx"][1]
+        mc_sc_creation_tx = mc_node.getrawtransaction(mc_sc_creation_tx_id, 1)
+
+        vsc_ccout_ = mc_sc_creation_tx["vsc_ccout"][0]
+        assert_true(vsc_ccout_["vFieldElementCertificateFieldConfig"] == certificate_field_config_csw_enabled,
+                    "Custom Field Elements Configuration in MC are wrong. Expected: " + format(certificate_field_config_csw_enabled) +
+                    ", actual: " + format(vsc_ccout_["vFieldElementCertificateFieldConfig"]))
+        assert_true("wCeasedVk" in vsc_ccout_, "CSW verification key should be present")
+
+        # Checks that Sidechain creation transaction is in SC block
+        mc_block_hash = mc_sc_creation_tx["blockhash"]
+        sc_block_id = sc_node.block_best()["result"]["block"]["id"]
+        check_mcreference_presence(mc_block_hash, sc_block_id, sc_node)
+
+        # ******************** EPOCH 0 START ********************
+        print("******************** EPOCH 0 START ********************")
+        epoch_mc_blocks_left = self.sc_withdrawal_epoch_length - 1
+
+        # create 1 FTs in the same MC block to SC
+        sc_address_1 = sc_node.wallet_createPrivateKey25519()["result"]["proposition"]["publicKey"]
+        ft_amount_1 = 100
+        mc_return_address_1 = mc_node.getnewaddress()
+
+        forward_transfer_to_sidechain(self.sidechain_id, mc_node,
+                                      sc_address_1, ft_amount_1, mc_return_address_1)
+
+        # Sleep for 1 second to let MC synchronize wallet
+        time.sleep(1)
+
+        epoch_mc_blocks_left -= 1
+        # Generate 1 SC block to include FTs.
+        generate_next_blocks(sc_node, "first node", 1)[0]
+
+        # Based on withdrawalEpochLength = 10, maxBTsAllowedPerCertificate = 3999, we open 399 slots for WithdrawalBoxes for each MC block reference
+        # 2 MC block mined = 399 * 2 = 798 WthdrawalBoxes allowed
+
+        # Create a transaction that generates 999 WBs 
+        bt_address = mc_node.getnewaddress()
+        bt_addresses = [bt_address for i in range(999)]
+        amounts = [54 for i in range(999)]
+        withdrawMultiCoins(sc_node, bt_addresses, amounts)
+
+        # Try to Generate 1 SC block.
+        # Since we have only 798 slots opened, the forger should not include this transaction in the next block
+        sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
+        block_json = http_block_findById(sc_node, sc_block_id)
+        assert_equal(block_json["block"]["sidechainTransactions"], [])
+
+        #Open another 399 slots buy mining a new MC block
+        mc_node.generate(1)[0]
+        epoch_mc_blocks_left -= 1
+        # Try to Generate 1 SC block to include Tx.
+        sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
+        block_json = http_block_findById(sc_node, sc_block_id)
+        assert_equal(len(block_json["block"]["sidechainTransactions"]), 1)
+        wbs_mined = 999
+
+        # Slots left = 3*399 - 999 = 198
+        # Create a transaction that generates 98 WBs.
+        withdrawMultiCoins(sc_node, bt_addresses[:98], amounts[:98])
+        # Try to Generate 1 SC block to include Tx.
+        sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
+        block_json = http_block_findById(sc_node, sc_block_id)
+        assert_equal(len(block_json["block"]["sidechainTransactions"]), 1)
+        wbs_mined += 98
+
+        # Slot left = 100
+        # Create a transaction that generates 80 WBs
+        withdrawMultiCoins(sc_node, bt_addresses[:80], amounts[:80])
+        # Create a transaction that generates 80 WBs
+        withdrawMultiCoins(sc_node, bt_addresses[:80], amounts[:80])
+
+        # Generates 1 SC block and verify that it contains only 1 of the two transactions
+        sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
+        block_json = http_block_findById(sc_node, sc_block_id)
+        assert_equal(len(block_json["block"]["sidechainTransactions"]), 1)    
+        wbs_mined += 80
+
+        # Create Some WBs
+
+        withdrawMultiCoins(sc_node, bt_addresses, amounts)
+        wbs_mined += 999
+        withdrawMultiCoins(sc_node, bt_addresses, amounts)
+        wbs_mined += 999
+
+        # Generate some MC blocks to open up slots
+        mc_node.generate(epoch_mc_blocks_left - 1)
+        sc_block_id = generate_next_block(sc_node, "first node")
+        block_json = http_block_findById(sc_node, sc_block_id)
+
+        # Generate 1 MC block to reach the end of the epoch
+        we0_end_mcblock_hash = mc_node.generate(1)[0]
+        print("End mc block hash in withdrawal epoch 0 = " + we0_end_mcblock_hash)
+        we0_end_mcblock_json = mc_node.getblock(we0_end_mcblock_hash)
+        we0_end_epoch_cum_sc_tx_comm_tree_root = we0_end_mcblock_json["scCumTreeHash"]
+        print("End cum sc tx cum comm tree root hash in withdrawal epoch 0 = " + we0_end_epoch_cum_sc_tx_comm_tree_root)
+
+        #824
+        remaining_wbs = MAX_WBS_PER_EPOCH - wbs_mined
+        wbs_left_txid = withdrawMultiCoins(sc_node, bt_addresses[:remaining_wbs], amounts[:remaining_wbs])["result"]["transactionId"]
+
+        sc_block_id = generate_next_block(sc_node, "first node")
+        block_json = http_block_findById(sc_node, sc_block_id)
+        check_mcreferencedata_presence(we0_end_mcblock_hash, sc_block_id, sc_node)
+
+
+        # ******************** EPOCH 1 START ********************
+        print("******************** EPOCH 1 START ********************")
+
+        # Generate first mc block of the next epoch
+        we1_1_mcblock_hash = mc_node.generate(1)[0]
+        epoch_mc_blocks_left = self.sc_withdrawal_epoch_length - 1
+        sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
+
+        # The tx with the reamining wbs is not added to the last epoch block but it should be added to the first block of the new epoch
+        # Since we are not started to generate the certificate for the epoch 0 we still have the open slots from the previous epoch and 
+        # we are able to include the tx in the block
+        assert_equal(wbs_left_txid, http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"][0]["id"])
+
+        check_mcreference_presence(we1_1_mcblock_hash, sc_block_id, sc_node)
+
+        # Wait until Certificate will appear in MC node mempool
+        time.sleep(10)
+        while mc_node.getmempoolinfo()["size"] == 0 and sc_node.submitter_isCertGenerationActive()["result"]["state"]:
+            print("Wait for certificate in mc mempool...")
+            time.sleep(2)
+            sc_node.block_best()  # just a ping to SC node. For some reason, STF can't request SC node API after a while idle.
+        assert_equal(1, mc_node.getmempoolinfo()["size"], "Certificate was not added to Mc node mempool.")
+
+        # Generate MC and SC blocks with Cert
+        we1_2_mcblock_hash = mc_node.generate(1)[0]
+        epoch_mc_blocks_left -= 1
+
+        # Create 300 BTs
+        wbs_txid = withdrawMultiCoins(sc_node, bt_addresses[:300], amounts[:300])["result"]["transactionId"]
+
+        sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
+        check_mcreference_presence(we1_2_mcblock_hash, sc_block_id, sc_node)
+
+        # We already filled remaining_wbs (824) in this epoch that only added 2 MC block references (=798 empty slots)
+        # this new 300 wbs transactions should not be incuded in the next block
+        assert_equal(len(http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"]), 0)
+
+        
+        # Generate more MC blocks to finish the second withdrawal epoch, then generate 1 more SC block to sync with MC.
+        we1_end_mcblock_hash = mc_node.generate(epoch_mc_blocks_left)[-1]
+        print("End mc block hash in withdrawal epoch 1 = " + we1_end_mcblock_hash)
+        we1_end_mcblock_json = mc_node.getblock(we1_end_mcblock_hash)
+        we1_end_epoch_cum_sc_tx_comm_tree_root = we1_end_mcblock_json["scCumTreeHash"]
+        print("End cum sc tx cum comm tree root hash in withdrawal epoch 1 = " + we1_end_epoch_cum_sc_tx_comm_tree_root)
+
+        sc_block_id = generate_next_block(sc_node, "first node")
+
+        # We don't include the tx here since this is the last block of the epoch
+        assert_equal(len(http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"]), 0)
+
+        check_mcreferencedata_presence(we1_end_mcblock_hash, sc_block_id, sc_node)
+
+        epoch_mc_blocks_left = self.sc_withdrawal_epoch_length
+
+        # ******************** EPOCH 2 START ********************
+        print("******************** EPOCH 2 START ********************")
+
+        # Generate first mc block of the next epoch
+        we2_1_mcblock_hash = mc_node.generate(1)[0]
+        epoch_mc_blocks_left = self.sc_withdrawal_epoch_length - 1
+        sc_block_id = generate_next_blocks(sc_node, "first node", 1)[0]
+
+        # Here we have the accumulated slots from the previous epoch since we didn't generate the certificate yet.
+        assert_equal(wbs_txid, http_block_findById(sc_node, sc_block_id)["block"]["sidechainTransactions"][0]["id"])
+
+        check_mcreference_presence(we2_1_mcblock_hash, sc_block_id, sc_node)
+
+        # Wait until Certificate will appear in MC node mempool
+        time.sleep(10)
+        while mc_node.getmempoolinfo()["size"] == 0 and sc_node.submitter_isCertGenerationActive()["result"]["state"]:
+            print("Wait for certificate in mc mempool...")
+            time.sleep(2)
+            sc_node.block_best()  # just a ping to SC node. For some reason, STF can't request SC node API after a while idle.
+        assert_equal(1, mc_node.getmempoolinfo()["size"], "Certificate was not added to Mc node mempool.")
+ 
+if __name__ == "__main__":
+    ScBtLimitTest().main()

--- a/qa/sc_bt_limit_across_fork.py
+++ b/qa/sc_bt_limit_across_fork.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+from curses import raw
+import time
+
+from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
+    SCNetworkConfiguration, SC_CREATION_VERSION_1
+from SidechainTestFramework.sc_forging_util import *
+from SidechainTestFramework.sc_test_framework import SidechainTestFramework
+from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, \
+    start_sc_nodes, generate_next_blocks, generate_next_block
+from test_framework.util import assert_equal, assert_true, start_nodes, \
+    websocket_port_by_mc_node_index, forward_transfer_to_sidechain
+from httpCalls.block.findBlockByID import http_block_findById
+from httpCalls.transaction.withdrawCoins import withdrawMultiCoins
+from httpCalls.block.forgingInfo import http_block_forging_info
+
+"""
+Configuration:
+    Start 1 MC node and 1 SC node (with default websocket configuration).
+    SC node connected to the first MC node.
+    SC node has ENABLED certificate submitter.
+    WithdrawalEpochLength = 11
+    WithdrawalRequestBox slots open per MC block reference = 3999 / (11 - 1) = 399
+
+Test:
+    For the SC node:
+        - ############## WITHDRAWAL EPOCH 0 #####################
+        - Send 1 FT to SC node 1 on different addresses.
+        - Generate 1 MC and 1 SC block to see FT in the sidechain.
+        - Generate a transaction that has 999 WithdrawalRequestBoxes
+        - Generate a SC block that reach the SC Fork 1 and verify that it doesn't includes this transaction since we didn't open enough slots yet.
+        - Mine a new MC block in order to open up more slots
+        - Generate a SC block and verify that now it includes the transaction.
+"""
+class ScBtLimitAcrossForkTest(SidechainTestFramework):
+
+    sidechain_id = None
+    sc_withdrawal_epoch_length = 11
+    FEE = 5
+
+    def setup_nodes(self):
+        num_nodes = 1
+        # Set MC scproofqueuesize to 0 to avoid BatchVerifier processing delays
+        return start_nodes(num_nodes, self.options.tmpdir, extra_args=[['-debug=sc', '-debug=ws',  '-logtimemicros=1', '-scproofqueuesize=0']] * num_nodes)
+
+    def sc_setup_chain(self):
+        mc_node = self.nodes[0]
+        sc_node_configuration = SCNodeConfiguration(
+            MCConnectionInfo(address="ws://{0}:{1}".format(mc_node.hostname, websocket_port_by_mc_node_index(0))),
+            cert_submitter_enabled=True,  # enable submitter
+            cert_signing_enabled=True  # enable signer
+        )
+        network = SCNetworkConfiguration(SCCreationInfo(mc_node, 1000, self.sc_withdrawal_epoch_length, sc_creation_version=SC_CREATION_VERSION_1, csw_enabled=True), sc_node_configuration)
+        self.sidechain_id = bootstrap_sidechain_nodes(self.options, network, 720*120*5).sidechain_id
+
+    def sc_setup_nodes(self):
+        return start_sc_nodes(1, self.options.tmpdir)
+
+    def run_test(self):
+        time.sleep(0.1)
+        self.sync_all()
+        mc_node = self.nodes[0]
+        sc_node = self.sc_nodes[0]
+
+        # Check CSW is enabled on SC node
+        is_csw_enabled = sc_node.csw_isCSWEnabled()["result"]["cswEnabled"]
+        assert_true(is_csw_enabled, "Ceased Sidechain Withdrawal expected to be enabled.")
+
+        # ******************** WITHDRAWAL EPOCH 0 START ********************
+        print("******************** WITHDRAWAL EPOCH 0 START ********************")
+
+        #Verify we didn't reach the SC fork1 that includes BT limit
+        consensusEpochData = http_block_forging_info(sc_node)
+        assert_equal(consensusEpochData["bestEpochNumber"], 1)
+        
+        epoch_mc_blocks_left = self.sc_withdrawal_epoch_length - 1
+
+        # create 1 FTs in the same MC block to SC
+        sc_address_1 = sc_node.wallet_createPrivateKey25519()["result"]["proposition"]["publicKey"]
+        ft_amount_1 = 100
+        mc_return_address_1 = mc_node.getnewaddress()
+
+        forward_transfer_to_sidechain(self.sidechain_id, mc_node,
+                                      sc_address_1, ft_amount_1, mc_return_address_1)
+
+        # Sleep for 1 second to let MC synchronize wallet
+        time.sleep(1)
+
+        epoch_mc_blocks_left -= 1
+        # Generate 1 SC block to include FTs.
+        generate_next_blocks(sc_node, "first node", 1)[0]
+
+        # Create a transaction that generates 999 WBs 
+        bt_address = mc_node.getnewaddress()
+        bt_addresses = [bt_address for i in range(999)]
+        amounts = [54 for i in range(999)]
+        withdrawMultiCoins(sc_node, bt_addresses, amounts)
+        consensusEpochData = http_block_forging_info(sc_node)
+        assert_equal(consensusEpochData["bestEpochNumber"], 2)
+
+        # Reach the SC fork 1
+        sc_block_id = generate_next_block(sc_node, "first node", force_switch_to_next_epoch = True)
+        consensusEpochData = http_block_forging_info(sc_node)
+        assert_equal(consensusEpochData["bestEpochNumber"], 3)
+        block_json = http_block_findById(sc_node, sc_block_id)
+
+        #Verify that we didn't include the transaction since we still don't have enough open WB slots (2 MC block 799 slots)
+        assert_equal(len(block_json["block"]["sidechainTransactions"]),0)
+
+        #Mine a new MC block
+        mc_node.generate(1)
+
+        #Forge a new SC block and verify that now it includes the transaction with the WBs. 
+        sc_block_id = generate_next_block(sc_node, "first node")
+        block_json = http_block_findById(sc_node, sc_block_id)
+        assert_equal(len(block_json["block"]["sidechainTransactions"]),1)
+        
+if __name__ == "__main__":
+    ScBtLimitAcrossForkTest().main()

--- a/qa/sc_closed_forger.py
+++ b/qa/sc_closed_forger.py
@@ -1,21 +1,31 @@
 #!/usr/bin/env python3
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from test_framework.util import assert_true, initialize_chain_clean, start_nodes, connect_nodes_bi, websocket_port_by_mc_node_index, forward_transfer_to_sidechain
-from SidechainTestFramework.scutil import generate_secrets, start_sc_nodes, generate_next_blocks, bootstrap_sidechain_nodes, generate_secrets, generate_vrf_secrets
+from test_framework.util import assert_true, assert_equal, initialize_chain_clean, start_nodes, connect_nodes_bi, websocket_port_by_mc_node_index, forward_transfer_to_sidechain
+from SidechainTestFramework.scutil import generate_secrets, start_sc_nodes, generate_next_blocks, bootstrap_sidechain_nodes, generate_secrets, generate_vrf_secrets, generate_next_block
 from httpCalls.wallet.createPrivateKey25519 import http_wallet_createPrivateKey25519
 from httpCalls.transaction.makeForgerStake import makeForgerStake
 from httpCalls.wallet.createVrfSecret import http_wallet_createVrfSecret
+from httpCalls.wallet.allBoxes import http_wallet_allBoxes
+from httpCalls.transaction.sendCoinsToAddress import sendCoinsToAddress, sendCointsToMultipleAddress
+from httpCalls.transaction.openStake import createOpenStakeTransaction, createOpenStakeTransactionSimplified
+from httpCalls.transaction.sendTransaction import sendTransaction
+from httpCalls.block.best import http_block_best
+from httpCalls.block.forgingInfo import http_block_forging_info
 from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
     SCNetworkConfiguration, SCForgerConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH
+from SidechainTestFramework.sidechainauthproxy import SCAPIException
 
 """
     Setup 1 SC Node with a closed list of forger. Try to stake money with invalid forger info and verify that we are not allowed to stake.
+    After that open the stake to the world using the openStakeTransaction and verify that a generic proposition (not included in the forger list) 
+    is allowed to forge.
 """
 class SidechainClosedForgerTest(SidechainTestFramework):
     number_of_mc_nodes = 1
     number_of_sidechain_nodes = 1
-    allowed_forger_proposition = generate_secrets("seed", 1)[0].publicKey
-    allowed_forger_vrf_public_key = generate_vrf_secrets("seed", 1)[0].publicKey
+    number_of_forgers = 5
+    allowed_forger_propositions = generate_secrets("seed", number_of_forgers)
+    allowed_forger_vrf_public_keys = generate_vrf_secrets("seed", number_of_forgers)
 
     def setup_chain(self):
         initialize_chain_clean(self.options.tmpdir, self.number_of_mc_nodes)
@@ -32,21 +42,29 @@ class SidechainClosedForgerTest(SidechainTestFramework):
     def sc_setup_chain(self):
         # Bootstrap new SC, specify SC node 1 connection to MC node 1
         mc_node_1 = self.nodes[0]
-        forger_configuration  = SCForgerConfiguration(True, [
-            [self.allowed_forger_proposition, self.allowed_forger_vrf_public_key]
-        ])
-
+        allowedForgers = []
+        for i in range (0, self.number_of_forgers):
+            allowedForgers += [[self.allowed_forger_propositions[i].publicKey, self.allowed_forger_vrf_public_keys[i].publicKey]]
+        forger_configuration  = SCForgerConfiguration(True, allowedForgers)
         sc_node_1_configuration = SCNodeConfiguration(
             MCConnectionInfo(address="ws://{0}:{1}".format(mc_node_1.hostname, websocket_port_by_mc_node_index(0))),
-            forger_options = forger_configuration
+            forger_options = forger_configuration,
+            initial_private_keys=list(map(lambda forger: forger.secret,self.allowed_forger_propositions)),
+            max_fee=10000000000000
         )
         network = SCNetworkConfiguration(SCCreationInfo(mc_node_1, 600, LARGE_WITHDRAWAL_EPOCH_LENGTH),
                                          sc_node_1_configuration)
-        self.sc_nodes_bootstrap_info = bootstrap_sidechain_nodes(self.options, network)
+        self.sc_nodes_bootstrap_info = bootstrap_sidechain_nodes(self.options, network,  720*120*5)
 
     def sc_setup_nodes(self):
         # Start 1 SC node
         return start_sc_nodes(self.number_of_sidechain_nodes, self.options.tmpdir)
+
+    def find_box(self, boxes, proposition):
+        for box in boxes:
+            if (box["typeName"]=="ZenBox" and box["proposition"]["publicKey"] == proposition):
+                return box
+        return {}
 
     def run_test(self):
         self.sync_all()
@@ -57,12 +75,11 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         # Generate 1 SC block
         generate_next_blocks(sc_node1, "first node", 1)
-
         # We need regular coins (the genesis account balance is locked into forging stake), so we perform a
         # Forward transfer to sidechain for an amount equals to the genesis_account_balance
         forward_transfer_to_sidechain(self.sc_nodes_bootstrap_info.sidechain_id,
                                       mc_node1,
-                                      self.allowed_forger_proposition,
+                                      self.allowed_forger_propositions[0].publicKey,
                                       self.sc_nodes_bootstrap_info.genesis_account_balance,
                                       mc_node1.getnewaddress())
         self.sc_sync_all()
@@ -73,7 +90,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         print("Try to stake to an invalid blockSignProposition...")
         new_public_key = http_wallet_createPrivateKey25519(self.sc_nodes[0])
         new_vrf_public_key = http_wallet_createVrfSecret(sc_node1)
-        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_proposition, new_public_key, self.allowed_forger_vrf_public_key, forger_amount, sc_fee)
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, new_public_key, self.allowed_forger_vrf_public_keys[0].publicKey, forger_amount, sc_fee)
         print(result)
         assert_true('error' in result)
         assert_true('This publicKey is not allowed to forge' in result['error']['detail'])
@@ -81,7 +98,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         # Try to stake to an invalid vrfPublicKey
         print("Try to stake to an invalid vrfPublicKey...")
-        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_proposition, self.allowed_forger_proposition, new_vrf_public_key, forger_amount, sc_fee)
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, self.allowed_forger_propositions[0].publicKey, new_vrf_public_key, forger_amount, sc_fee)
         print(result)
         assert_true('error' in result)
         assert_true('This publicKey is not allowed to forge' in result['error']['detail'])
@@ -89,7 +106,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         # Try to stake with an invalid blockSignProposition and an invalid vrfPublicKey
         print("Try to stake to an invalid vrfPublicKey...")
-        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_proposition, new_public_key, new_vrf_public_key, forger_amount, sc_fee)
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, new_public_key, new_vrf_public_key, forger_amount, sc_fee)
         print(result)
         assert_true('error' in result)
         assert_true('This publicKey is not allowed to forge' in result['error']['detail'])
@@ -97,7 +114,7 @@ class SidechainClosedForgerTest(SidechainTestFramework):
 
         # Try to stake with a valid blockSignProposition and a valid vrfPublickey
         print("Try to stake with a valid blockSignProposition and a valid vrfPublickey")
-        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_proposition, self.allowed_forger_proposition, self.allowed_forger_vrf_public_key, forger_amount, sc_fee)
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, self.allowed_forger_propositions[0].publicKey, self.allowed_forger_vrf_public_keys[0].publicKey, forger_amount, sc_fee)
         print(result)
         assert_true('result' in result)
         assert_true('transactionId' in result['result'])
@@ -106,6 +123,196 @@ class SidechainClosedForgerTest(SidechainTestFramework):
         generate_next_blocks(sc_node1, "first node", 1)
         self.sc_sync_all()
 
+        # Create some ZenBoxes
+        print("Create some ZenBoxes")
+        sendCointsToMultipleAddress(sc_node1, list(map(lambda forger: forger.publicKey, self.allowed_forger_propositions)), [1000]*len(self.allowed_forger_propositions), 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        sendCoinsToAddress(sc_node1, new_public_key, 1500, 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        allBoxes = http_wallet_allBoxes(sc_node1)
+        new_public_key_box = self.find_box(allBoxes, new_public_key)
+        assert_true(new_public_key_box != {})
+
+        forging_info = http_block_forging_info(sc_node1)
+        assert_equal(forging_info["bestEpochNumber"], 2)
+
+        #Try to send an openStake transaction without had reach the SC Fork 1
+        tx_bytes = createOpenStakeTransaction(sc_node1, new_public_key_box["id"],new_public_key,0,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
+        assert_true(res["error"]["detail"], "OpenStakeTransaction is still not allowed in this consensus epoch!")
+        print("Ok!")
+
+        #Reach the SC Fork 1
+        generate_next_block(sc_node1, "first node", force_switch_to_next_epoch=True)
+        forging_info = http_block_forging_info(sc_node1)
+        assert_equal(forging_info["bestEpochNumber"], 3)
+
+        #Try to send an openStake transaction with negative forgerIndex
+        print("Try to send an openStake transaction with negative forgerIndex")
+        error_occur = False
+        try:
+            createOpenStakeTransaction(sc_node1, new_public_key_box["id"],new_public_key,-1,sc_fee)
+        except SCAPIException as e:
+            print("Expected SCAPIException: " + e.error)
+            error_occur = True
+        assert_true(error_occur, "Try to send an openStake transaction with negative forgerIndex")
+        print("Ok!")
+
+        #Try to send an openStake transaction with empty output proposition
+        print("Try to send an openStake transaction with empty output proposition")
+        error_occur = False
+        try:
+            createOpenStakeTransaction(sc_node1, new_public_key_box["id"],"",0,sc_fee)
+        except SCAPIException as e:
+            print("Expected SCAPIException: " + e.error)
+            error_occur = True
+        assert_true(error_occur, "Try to send an openStake transaction with empty output proposition")
+        print("Ok!")
+
+        #Try to send an openStake transaction with empty boxid
+        print("Try to send an openStake transaction with empty boxid")
+        error_occur = False
+        try:
+            createOpenStakeTransaction(sc_node1, "",new_public_key,0,sc_fee)
+        except SCAPIException as e:
+            print("Expected SCAPIException: " + e.error)
+            error_occur = True         
+            assert_true(error_occur, "Try to send an openStake transaction with empty output proposition")
+        print("Ok!")
+
+        #Try to send an openStake transaction with forgerIndex out of bounds
+        print("Try to send an openStake transaction with forgerIndex out of bounds")
+        tx_bytes = createOpenStakeTransaction(sc_node1, new_public_key_box["id"],new_public_key,self.number_of_forgers,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
+        assert_true("ForgerIndex in OpenStakeTransaction is out of bound" in res["error"]["detail"])
+        print("Ok!")
+
+        #Try to send openStake transaction with forgerIndex doesn't match the input proposition
+        print("Try to send openStake transaction with forgerIndex doesn't match the input proposition")
+        forger0_box = self.find_box(allBoxes, self.allowed_forger_propositions[0].publicKey)
+        assert_true(forger0_box != {})
+        tx_bytes = createOpenStakeTransaction(sc_node1, forger0_box["id"],new_public_key,2,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
+        assert_true("OpenStakeTransaction input doesn't match the forgerIndex" in res["error"]["detail"])
+        print("Ok!")
+
+        #Forger 0 opens the stake
+        print("Forger 0 opens the stake")
+        tx_bytes = createOpenStakeTransaction(sc_node1, forger0_box["id"],new_public_key,0,forger0_box["value"])
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true("error" not in res)
+        self.sc_sync_all()
+        print("Ok!")
+
+        #Try to send an openStakeTransaction with the same forgerIndex of the previous one (in mempool)
+        print("Try to send an openStakeTransaction with the same forgerIndex of the previous one (in mempool)")
+        allBoxes = http_wallet_allBoxes(sc_node1)
+        forger0_box2 = self.find_box(allBoxes, self.allowed_forger_propositions[0].publicKey)
+        assert_true(forger0_box2 != {})
+        tx_bytes = createOpenStakeTransaction(sc_node1, forger0_box2["id"],new_public_key,0,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true("Transaction is incompatible" in res["error"]["detail"])
+        print("Ok!")
+
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        #Verify that if we use fee = inputBox.value we don't generate new boxes.
+        print("Verify that if we use fee = inputBox.value we don't generate new boxes.")
+        bestBlock = http_block_best(sc_node1)
+        assert_equal(bestBlock["sidechainTransactions"][0]["newBoxes"], [])
+        print("Ok!")
+
+        #Try to send an openStakeTransaction with the same forgerIndex of the previous one
+        print("Try to send an openStakeTransaction with the same forgerIndex of the previous one")
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true("Forger already opened the stake" in res["error"]["detail"])
+        print("Ok!")
+
+        #Forger 1 opens the stake
+        print("Forger 1 opens the stake")
+        sendCoinsToAddress(sc_node1, self.allowed_forger_propositions[1].publicKey, 1500, 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        allBoxes = http_wallet_allBoxes(sc_node1)
+        forger1_box = self.find_box(allBoxes, self.allowed_forger_propositions[1].publicKey)
+        assert_true(forger1_box != {})
+        #Try with automaticSend = True
+        res = createOpenStakeTransaction(sc_node1, forger1_box["id"],new_public_key,1,sc_fee, True, True)
+        assert_true("error" not in res)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+        print("Ok!")
+
+        # Try to stake with an invalid blockSignProposition and an invalid vrfPublicKey.
+        # It should be fail because the majority of the allowed forgers didn't opened the stake yet.
+        # (At this time only 2/5 of the allowed forgers opened the stake).
+        print("Try to stake to an invalid vrfPublicKey...")
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, new_public_key, new_vrf_public_key, forger_amount, sc_fee)
+        print(result)
+        assert_true('error' in result)
+        assert_true('This publicKey is not allowed to forge' in result['error']['detail'])
+        print("Ok!")
+
+        #Forger 2 opens the stake
+        print("Forger 2 opens the stake")
+        sendCoinsToAddress(sc_node1, self.allowed_forger_propositions[2].publicKey, 1500, 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+
+        allBoxes = http_wallet_allBoxes(sc_node1)
+        forger2_box = self.find_box(allBoxes, self.allowed_forger_propositions[2].publicKey)
+        assert_true(forger2_box != {})         
+        #Try the createOpenStakeTransactionSimplified endpoint
+        tx_bytes = createOpenStakeTransactionSimplified(sc_node1, self.allowed_forger_propositions[2].publicKey,2,forger2_box["value"])
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])
+        assert_true("error" not in res)
+        print("Ok!")
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)[0]
+        self.sc_sync_all()
+     
+        #Verify that we have created an openStakeTransaction with fee = inputBox.value. We should have newBoxes empty.
+        print("Verify that we have created an openStakeTransaction with fee = inputBox.value. We should have newBoxes empty.")
+        block = http_block_best(sc_node1)
+        assert_equal(block["sidechainTransactions"][0]["newBoxes"], [])
+        print("Ok!")
+
+        # Now the majority of the allowed forgers opened the stake (3/5) and we should be able to stake to a new forger
+        print("Now the majority of the allowed forgers opened the stake (3/5) and we should be able to stake to a new forger")
+        result = makeForgerStake(self.sc_nodes[0], self.allowed_forger_propositions[0].publicKey, new_public_key, new_vrf_public_key, forger_amount, sc_fee)
+        print(result) 
+        assert_true('result' in result)
+        assert_true('transactionId' in result['result'])
+        print("Ok!")
+
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        # Try to create an openStake transaction with the forge operation already opened. The transaction should be rejected.
+        print("Try to create an openStake transaction with the forge operation already opened. The transaction should be rejected.")
+        sendCoinsToAddress(sc_node1, self.allowed_forger_propositions[3].publicKey, 1500, 0)
+        self.sc_sync_all()
+        generate_next_blocks(sc_node1, "first node", 1)
+        self.sc_sync_all()
+
+        tx_bytes = createOpenStakeTransactionSimplified(sc_node1, self.allowed_forger_propositions[3].publicKey,3,sc_fee)
+        res = sendTransaction(sc_node1, tx_bytes["transactionBytes"])  
+        assert_true('error' in res)
+        assert_true('OpenStakeTransactions are not allowed because the forger operation has already been opened' in res['error']['detail'])
+        print("Ok!")
 
 if __name__ == "__main__":
     SidechainClosedForgerTest().main()

--- a/sdk/src/main/java/com/horizen/transaction/BoxTransaction.java
+++ b/sdk/src/main/java/com/horizen/transaction/BoxTransaction.java
@@ -30,6 +30,7 @@ public abstract class BoxTransaction<P extends Proposition, B extends Box<P>> ex
     public final static int MAX_TRANSACTION_SIZE = 500000; // size in bytes
     public final static int MAX_TRANSACTION_UNLOCKERS = 1000;
     public final static int MAX_TRANSACTION_NEW_BOXES = 1000;
+    public final static int MAX_WITHDRAWAL_BOXES_ALLOWED = 3999;
 
     @JsonProperty("unlockers")
     public abstract List<BoxUnlocker<P>> unlockers();

--- a/sdk/src/main/java/com/horizen/transaction/CoreTransactionsIdsEnum.java
+++ b/sdk/src/main/java/com/horizen/transaction/CoreTransactionsIdsEnum.java
@@ -3,7 +3,8 @@ package com.horizen.transaction;
 public enum CoreTransactionsIdsEnum {
     SidechainCoreTransactionId((byte)1),
     MC2SCAggregatedTransactionId((byte)2),
-    FeePaymentsTransactionId((byte)3);
+    FeePaymentsTransactionId((byte)3),
+    OpenStakeTransactionId((byte)4);
 
     private final byte id;
 

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransaction.java
@@ -1,0 +1,174 @@
+package com.horizen.transaction;
+
+import com.google.common.primitives.Ints;
+import com.horizen.box.BoxUnlocker;
+import com.horizen.box.ZenBox;
+import com.horizen.box.data.ZenBoxData;
+import com.horizen.proof.Proof;
+import com.horizen.proof.Signature25519;
+import com.horizen.proposition.PublicKey25519Proposition;
+import com.horizen.secret.PrivateKey25519;
+import com.horizen.secret.Secret;
+import com.horizen.transaction.exception.TransactionSemanticValidityException;
+import com.horizen.utils.Pair;
+import scala.Array;
+
+import java.util.*;
+
+import static com.horizen.transaction.CoreTransactionsIdsEnum.OpenStakeTransactionId;
+
+/**
+ * OpenStakeTransaction is used to open the forging stake to the world.
+ * It can be used when the flag "restrictForger" is enabled and can be fired only by the allowed forgers inside the "allowedForgers" list.
+ * This transaction has 1 input and 0 or 1 output. It contains a custom field "forgerIndex" that identify a specific forger inside the "allowedForgers" list.
+ * The input must be locked by the corresponding proposition indexed by "forgerIndex" inside the "allowedForgers" list.
+ */
+public class OpenStakeTransaction extends SidechainNoncedTransaction<PublicKey25519Proposition, ZenBox, ZenBoxData>{
+    public final static byte OPEN_STAKE_TRANSACTION_VERSION = 1;
+
+    final byte[] inputId;
+    private final Optional<ZenBoxData> outputData;
+    final Signature25519 proof;
+
+    private final long fee;
+
+    private final byte version;
+
+    private List<BoxUnlocker<PublicKey25519Proposition>> unlockers;
+
+    private final int forgerIndex;
+
+    public OpenStakeTransaction(byte[] inputId,
+                                Optional<ZenBoxData> outputData,
+                                Signature25519 proof,
+                                int forgerIndex,
+                                long fee,
+                                byte version) {
+
+        this.inputId = inputId;
+        this.outputData = outputData;
+        this.proof = proof;
+        this.forgerIndex = forgerIndex;
+        this.fee = fee;
+        this.version = version;
+    }
+
+    @Override
+    public TransactionSerializer serializer() {
+        return OpenStakeTransactionSerializer.getSerializer();
+    }
+
+    @Override
+    public synchronized List<BoxUnlocker<PublicKey25519Proposition>> unlockers() {
+        if(unlockers == null) {
+            unlockers = new ArrayList<>();
+            BoxUnlocker<PublicKey25519Proposition> unlocker = new BoxUnlocker() {
+                @Override
+                public byte[] closedBoxId() {
+                    return inputId;
+                }
+
+                @Override
+                public Proof boxKey() {
+                    return proof;
+                }
+            };
+            unlockers.add(unlocker);
+        }
+
+        return Collections.unmodifiableList(unlockers);
+    }
+
+    @Override
+    protected List<ZenBoxData> getOutputData(){
+        ArrayList<ZenBoxData> output = new ArrayList();
+        outputData.ifPresent(output::add);
+        return output;
+    }
+
+    @Override
+    public long fee() {
+        return this.fee;
+    }
+
+    @Override
+    public void transactionSemanticValidity() throws TransactionSemanticValidityException {
+        if (version != OPEN_STAKE_TRANSACTION_VERSION) {
+            throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
+                    "unsupported version number.", id()));
+        }
+
+        if (inputId == null)
+            throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
+                    "no input data present.", id()));
+
+        if (proof == null)
+            throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
+                    "no proof data present.", id()));
+
+        if (forgerIndex < 0) {
+            throw new TransactionSemanticValidityException(String.format("Transaction [%s] is semantically invalid: " +
+                    "forgerList index negative.", id()));
+        }
+    }
+
+    @Override
+    public byte transactionTypeId() {
+        return OpenStakeTransactionId.id();
+    }
+
+    @Override
+    public byte version() {
+        return version;
+    }
+
+    @Override
+    public Boolean isCustom() { return false; }
+
+    @Override
+    public byte[] customFieldsData() {
+        return Array.emptyByteArray();
+    }
+
+    @Override
+    public byte[] customDataMessageToSign() {
+        return Ints.toByteArray(this.forgerIndex);
+    }
+
+    public int getForgerIndex() { return this.forgerIndex; }
+
+    public byte[] getInputId() { return this.inputId; }
+
+    public Optional<ZenBoxData> getOutputBox() {
+        return this.outputData;
+    }
+
+    public TransactionIncompatibilityChecker incompatibilityChecker() {
+        return new OpenStakeTransactionIncompatibilityChecker();
+    }
+
+
+    public static OpenStakeTransaction create(Pair<ZenBox, PrivateKey25519> from,
+                                              PublicKey25519Proposition changeAddress,
+                                              int forgerIndex,
+                                              long fee) throws TransactionSemanticValidityException {
+        if(from == null)
+            throw new IllegalArgumentException("Parameters can't be null.");
+        if(from.getKey().value() < fee )
+            throw new IllegalArgumentException("Fee can't be greater than the input!");
+
+        Optional<ZenBoxData> output = Optional.empty();
+        if(from.getKey().value() > fee) {
+            output = Optional.of(new ZenBoxData(changeAddress, from.getKey().value() - fee));
+        }
+        OpenStakeTransaction unsignedTransaction = new OpenStakeTransaction(from.getKey().id(), output, null, forgerIndex, fee, OPEN_STAKE_TRANSACTION_VERSION);
+
+        byte[] messageToSign = unsignedTransaction.messageToSign();
+        Secret secret = from.getValue();
+
+        OpenStakeTransaction transaction = new OpenStakeTransaction(from.getKey().id(), output, (Signature25519) secret.sign(messageToSign), forgerIndex, fee, OPEN_STAKE_TRANSACTION_VERSION);
+        transaction.transactionSemanticValidity();
+
+        return transaction;
+    }
+}

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionIncompatibilityChecker.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionIncompatibilityChecker.java
@@ -1,0 +1,22 @@
+package com.horizen.transaction;
+
+import java.util.List;
+
+public class OpenStakeTransactionIncompatibilityChecker extends DefaultTransactionIncompatibilityChecker{
+    @Override
+    public <T extends BoxTransaction> boolean isTransactionCompatible(T newTx, List<T> currentTxs) {
+        if (!super.isTransactionCompatible(newTx, currentTxs)) {
+            return false;
+        } else if (newTx instanceof OpenStakeTransaction) {
+            OpenStakeTransaction openStakeTransaction = (OpenStakeTransaction) newTx;
+            for (T mempoolTx: currentTxs) {
+                if (mempoolTx instanceof OpenStakeTransaction) {
+                    if (openStakeTransaction.getForgerIndex() == ((OpenStakeTransaction) mempoolTx).getForgerIndex()) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionSerializer.java
+++ b/sdk/src/main/java/com/horizen/transaction/OpenStakeTransactionSerializer.java
@@ -1,0 +1,68 @@
+package com.horizen.transaction;
+
+import com.horizen.box.data.ZenBoxData;
+import com.horizen.box.data.ZenBoxDataSerializer;
+import com.horizen.proof.Signature25519;
+import com.horizen.proof.Signature25519Serializer;
+import scorex.core.NodeViewModifier$;
+import scorex.util.serialization.Reader;
+import scorex.util.serialization.Writer;
+
+import java.util.Optional;
+
+import static com.horizen.transaction.OpenStakeTransaction.OPEN_STAKE_TRANSACTION_VERSION;
+
+public class OpenStakeTransactionSerializer implements TransactionSerializer<OpenStakeTransaction>
+{
+    private static OpenStakeTransactionSerializer serializer;
+
+    static {
+        serializer = new OpenStakeTransactionSerializer();
+    }
+
+    private OpenStakeTransactionSerializer() {
+        super();
+    }
+
+    public static OpenStakeTransactionSerializer getSerializer() {
+        return serializer;
+    }
+
+    @Override
+    public void serialize(OpenStakeTransaction transaction, Writer writer) {
+        writer.put(transaction.version());
+        writer.putLong(transaction.fee());
+        writer.putBytes(transaction.inputId);
+        if(transaction.getOutputBox().isPresent()) {
+            writer.putInt(1);
+            ZenBoxDataSerializer.getSerializer().serialize(transaction.getOutputBox().get(), writer);
+        } else {
+            writer.putInt(0);
+        }
+        Signature25519Serializer.getSerializer().serialize(transaction.proof, writer);
+        writer.putInt(transaction.getForgerIndex());
+    }
+
+    @Override
+    public OpenStakeTransaction parse(Reader reader) {
+        byte version = reader.getByte();
+        if (version != OPEN_STAKE_TRANSACTION_VERSION) {
+            throw new IllegalArgumentException(String.format("Unsupported transaction version[%d].", version));
+        }
+
+        long fee = reader.getLong();
+
+        byte[] inputsId = reader.getBytes(NodeViewModifier$.MODULE$.ModifierIdSize());
+
+        int outputDataIsPresent = reader.getInt();
+        java.util.Optional<ZenBoxData> output = Optional.empty();
+        if (outputDataIsPresent == 1) {
+            output = Optional.of(ZenBoxDataSerializer.getSerializer().parse(reader));
+        }
+
+        Signature25519 proof = Signature25519Serializer.getSerializer().parse(reader);
+        int forgerIndex = reader.getInt();
+
+        return new OpenStakeTransaction(inputsId, output, proof, forgerIndex, fee, version);
+    }
+}

--- a/sdk/src/main/scala/com/horizen/SidechainApp.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainApp.scala
@@ -262,6 +262,13 @@ class SidechainApp @Inject()
     log.warn("******** Ceased Sidechain Withdrawal (CSW) is DISABLED ***********")
   }
 
+  // Init ForkManager
+  // We need to have it initializes before the creation of the SidechainState
+  ForkManager.init(forkConfigurator, sidechainSettings.genesisData.mcNetwork) match {
+    case Success(_) =>
+    case Failure(exception) => throw exception
+  }
+
   // Init all storages
   protected val sidechainSecretStorage = new SidechainSecretStorage(
     //openStorage(new JFile(s"${sidechainSettings.scorexSettings.dataDir.getAbsolutePath}/secret")),
@@ -371,12 +378,6 @@ class SidechainApp @Inject()
   //Websocket server for the Explorer
   if(sidechainSettings.websocket.wsServer) {
     val webSocketServerActor: ActorRef = WebSocketServerRef(nodeViewHolderRef,sidechainSettings.websocket.wsServerPort)
-  }
-
-  // Init ForkManager
-  ForkManager.init(forkConfigurator, sidechainSettings.genesisData.mcNetwork) match {
-    case Success(_) =>
-    case Failure(exception) => throw exception
   }
 
   // Init API

--- a/sdk/src/main/scala/com/horizen/SidechainMemoryPool.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainMemoryPool.scala
@@ -59,10 +59,10 @@ class SidechainMemoryPool private(unconfirmed: MempoolMap, mempoolSettings: Memp
     unconfirmed.values.toSeq.sortWith(sortFunc).take(limit).map(tx => tx.getUnconfirmedTx())
   }
 
-  def takeWithWithdrawalBoxesLimit(limit: Int, allowedWithdrawalBoxes: Int): Iterable[SidechainTypes#SCBT] = {
+  def takeWithWithdrawalBoxesLimit(allowedWithdrawalBoxes: Int): Iterable[SidechainTypes#SCBT] = {
     val filteredTxs: JArrayList[SidechainTypes#SCBT] = new JArrayList[SidechainTypes#SCBT]()
     var newWithdrawalBoxes = 0
-    take(limit).foreach( tx => {
+    take(size).foreach( tx => {
       val txWithdrawalBoxes = tx.newBoxes().asScala.count(box => box.isInstanceOf[WithdrawalRequestBox])
       if( txWithdrawalBoxes + newWithdrawalBoxes <= allowedWithdrawalBoxes) {
         newWithdrawalBoxes += txWithdrawalBoxes

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -194,11 +194,11 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
     })
   }
 
-  def getOrElseWithdrawalEpochInfo(): WithdrawalEpochInfo = {
+  private def getOrElseWithdrawalEpochInfo(): WithdrawalEpochInfo = {
     stateStorage.getWithdrawalEpochInfo.getOrElse(WithdrawalEpochInfo(0,0))
   }
 
-  def getAllowedWithdrawalRequestBoxesPerBlock: Int = {
+  private def getAllowedWithdrawalRequestBoxesPerBlock: Int = {
     params.maxWBsAllowed / (params.withdrawalEpochLength - 1)
   }
 

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -13,7 +13,7 @@ import com.horizen.params.NetworkParams
 import com.horizen.proposition.{Proposition, PublicKey25519Proposition, VrfPublicKey}
 import com.horizen.state.ApplicationState
 import com.horizen.storage.{BackupStorage, SidechainStateForgerBoxStorage, SidechainStateStorage}
-import com.horizen.transaction.MC2SCAggregatedTransaction
+import com.horizen.transaction.{MC2SCAggregatedTransaction, OpenStakeTransaction, SidechainTransaction}
 import com.horizen.utils.{BlockFeeInfo, ByteArrayWrapper, BytesUtils, FeePaymentsUtils, MerkleTree, TimeToEpochUtils, WithdrawalEpochInfo, WithdrawalEpochUtils}
 import scorex.core._
 import scorex.core.transaction.state._
@@ -24,9 +24,14 @@ import java.io.File
 import java.math.{BigDecimal, MathContext}
 import java.util
 import java.util.{Optional => JOptional}
+import com.horizen.box.data.ZenBoxData
+import com.horizen.cryptolibprovider.CryptoLibProvider
+import com.horizen.forge.ForgerList
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Success, Try}
+import java.util.{ArrayList => JArrayList}
 
 
 class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
@@ -179,6 +184,19 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
       throw new IllegalArgumentException(s"Block ${mod.id} contains duplicated input boxes to open")
     }
 
+    //Check that we don't have multiple openStake transactions with the same forgerIndex
+    if (openStakeTransactionEnabled) {
+      val forgerListIndexes = new JArrayList[Int]()
+      mod.transactions.foreach(tx => {
+        if (tx.isInstanceOf[OpenStakeTransaction]) {
+          val openStakeTransaction = tx.asInstanceOf[OpenStakeTransaction]
+          if (forgerListIndexes.contains(openStakeTransaction.getForgerIndex))
+            throw new IllegalArgumentException(s"Block ${mod.id} contains OpenStakeTransactions with duplicated forgerIndex")
+          forgerListIndexes.add(openStakeTransaction.getForgerIndex)
+        }
+      })
+    }
+
     if (ForkManager.getSidechainConsensusEpochFork(TimeToEpochUtils.timeStampToEpochNumber(params, mod.timestamp)).backwardTransferLimitEnabled())
       checkWithdrawalBoxesAllowed(mod)
   }
@@ -203,6 +221,15 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
   def getAllowedWithdrawalRequestBoxes(numberOfMainchainBlockReferenceInBlock: Int): Int = {
     Math.min(params.maxWBsAllowed,
             (params.maxWBsAllowed * (getWithdrawalEpochInfo.lastEpochIndex + numberOfMainchainBlockReferenceInBlock)) / (params.withdrawalEpochLength - 1))
+  }
+
+  def openStakeTransactionEnabled: Boolean = {
+    stateStorage.getConsensusEpochNumber match {
+      case Some(consensusEpochNumber) =>
+        ForkManager.getSidechainConsensusEpochFork(consensusEpochNumber).openStakeTransactionEnabled()
+      case None =>
+        false
+    }
   }
 
   private def validateTopQualityCertificate(topQualityCertificate: WithdrawalEpochCertificate, certReferencedEpochNumber: Int): Unit = {
@@ -268,6 +295,37 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
 
     if (!tx.isInstanceOf[MC2SCAggregatedTransaction]) {
 
+      if (tx.isInstanceOf[OpenStakeTransaction]) {
+        if (!openStakeTransactionEnabled)
+          throw new Exception("OpenStakeTransaction is still not allowed in this consensus epoch!")
+        if (isForgingOpen())
+          throw new Exception("OpenStakeTransactions are not allowed because the forger operation has already been opened!")
+        val openStakeTransaction = tx.asInstanceOf[OpenStakeTransaction]
+        if (openStakeTransaction.getForgerIndex >= params.allowedForgersList.size || openStakeTransaction.getForgerIndex < 0) {
+          throw new Exception("ForgerIndex in OpenStakeTransaction is out of bound!")
+        }
+        stateStorage.getForgerList match {
+          case Some(forgerList) =>
+            if (openStakeTransaction.getForgerIndex >= forgerList.forgerIndexes.length) {
+              throw new Exception("OpenStakeTransaction forgerIndex out of bound!")
+            }
+            if (forgerList.forgerIndexes(openStakeTransaction.getForgerIndex) == 1) {
+              throw new Exception("Forger already opened the stake!")
+            }
+          case None =>
+            throw new Exception("Forger list was not found in the Storage!")
+        }
+        stateStorage.getBox(openStakeTransaction.getInputId) match {
+          case Some(closedBox) =>
+            if (!closedBox.proposition().asInstanceOf[PublicKey25519Proposition]
+              .equals(params.allowedForgersList(openStakeTransaction.getForgerIndex)._1)) {
+              throw new Exception("OpenStakeTransaction input doesn't match the forgerIndex!")
+            }
+          case None =>
+            throw new Exception("Input box not found!")
+        }
+      }
+
       for (u <- tx.unlockers().asScala) {
         closedBox(u.closedBoxId()) match {
           case Some(box) => {
@@ -291,10 +349,11 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
         throw new Exception("Amounts sum of CoinsBoxes is incorrect. " +
           s"ClosedBox amount - $closedCoinsBoxesAmount, NewBoxesAmount - $newCoinsBoxesAmount, Fee - ${tx.fee()}")
 
+      lazy val isForgerOpen = isForgingOpen()
       newBoxes
         .filter(box => box.isInstanceOf[ForgerBox])
         .foreach(forgerBox => {
-          if (params.restrictForgers) {
+          if (!isForgerOpen) {
             val vrfPublicKey: VrfPublicKey = forgerBox.vrfPubKey()
             val blockSignProposition: PublicKey25519Proposition = forgerBox.blockSignProposition()
             if (!params.allowedForgersList.contains((blockSignProposition, vrfPublicKey))) {
@@ -307,6 +366,22 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
     applicationState.validate(this, tx)
   }
 
+  //Check if the majority of the allowed forgers opened the stake to everyone
+  def isForgingOpen(): Boolean = {
+    if (!params.restrictForgers)
+      true
+    else {
+      val nOpenForger: Int = stateStorage.getForgerList match {
+        case Some(forgerList: ForgerList) =>
+          forgerList.forgerIndexes.sum
+        case None =>
+          log.error("No forgerList found in the Storage!")
+          0
+      }
+      nOpenForger > params.allowedForgersList.size / 2
+    }
+  }
+
   override def applyModifier(mod: SidechainBlock): Try[SidechainState] = {
     validate(mod).flatMap { _ =>
       changes(mod).flatMap(cs => {
@@ -316,10 +391,23 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
           WithdrawalEpochUtils.getWithdrawalEpochInfo(mod, stateStorage.getWithdrawalEpochInfo.getOrElse(WithdrawalEpochInfo(0,0)), params),
           TimeToEpochUtils.timeStampToEpochNumber(params, mod.timestamp),
           mod.topQualityCertificateOpt,
-          mod.feeInfo
+          mod.feeInfo,
+          getRestrictForgerIndexToUpdate(mod.sidechainTransactions)
         )
       })
     }
+  }
+
+  //Take the list of transactions inside a block and calculate the forgerList indexes to update
+  def getRestrictForgerIndexToUpdate(txs:  Seq[SidechainTransaction[Proposition, Box[Proposition]]]): Array[Int] = {
+      txs.flatMap(tx => {
+        if (tx.isInstanceOf[OpenStakeTransaction]) {
+          val openStakeTransaction: OpenStakeTransaction = tx.asInstanceOf[OpenStakeTransaction]
+          Some(openStakeTransaction.getForgerIndex)
+        } else {
+          None
+        }
+      }).toArray
   }
 
   // apply global changes and delegate SDK unknown part to Sidechain.applyChanges(...)
@@ -333,7 +421,9 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
                             withdrawalEpochInfo: WithdrawalEpochInfo,
                             consensusEpoch: ConsensusEpochNumber,
                             topQualityCertificateOpt: Option[WithdrawalEpochCertificate],
-                            blockFeeInfo: BlockFeeInfo): Try[SidechainState] = Try {
+                            blockFeeInfo: BlockFeeInfo,
+                            forgerListIndexes: Array[Int]
+                  ): Try[SidechainState] = Try {
     val version = new ByteArrayWrapper(versionToBytes(newVersion))
     var boxesToAppend = changes.toAppend.map(_.box)
 
@@ -380,7 +470,7 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
 
         new SidechainState(
           stateStorage.update(version, withdrawalEpochInfo, otherBoxesToAppend.toSet, boxIdsToRemoveSet,
-            withdrawalRequestsToAppend, consensusEpoch, topQualityCertificateOpt, blockFeeInfo, utxoMerkleTreeRootOpt, scHasCeased).get,
+            withdrawalRequestsToAppend, consensusEpoch, topQualityCertificateOpt, blockFeeInfo, utxoMerkleTreeRootOpt, scHasCeased, forgerListIndexes, params.allowedForgersList.size).get,
           forgerBoxStorage.update(version, forgerBoxesToAppend, boxIdsToRemoveSet).get,
           updatedUtxoMerkleTreeProvider,
           params,

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -197,12 +197,12 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
   }
 
   def getAlreadyMinedWithdrawalRequestBoxesInCurrentEpoch: Int = {
-    stateStorage.getWithdrawalRequests(stateStorage.getWithdrawalEpochInfo.getOrElse(WithdrawalEpochInfo(0,0)).epoch).size
+    stateStorage.getWithdrawalRequests(getWithdrawalEpochInfo.epoch).size
   }
 
   def getAllowedWithdrawalRequestBoxes(numberOfMainchainBlockReferenceInBlock: Int): Int = {
     Math.min(params.maxWBsAllowed,
-            (params.maxWBsAllowed * (stateStorage.getWithdrawalEpochInfo.getOrElse(WithdrawalEpochInfo(0,0)).lastEpochIndex + numberOfMainchainBlockReferenceInBlock)) / (params.withdrawalEpochLength - 1))
+            (params.maxWBsAllowed * (getWithdrawalEpochInfo.lastEpochIndex + numberOfMainchainBlockReferenceInBlock)) / (params.withdrawalEpochLength - 1))
   }
 
   private def validateTopQualityCertificate(topQualityCertificate: WithdrawalEpochCertificate, certReferencedEpochNumber: Int): Unit = {
@@ -302,18 +302,6 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
             }
           }
         })
-
-      lazy val numberOfWithdrawalRequestBoxes = newBoxes.count(box => box.isInstanceOf[WithdrawalRequestBox])
-      val backwardTransferLimitEnabled = stateStorage.getConsensusEpochNumber match {
-        case Some(consensusEpochNumber) =>
-          ForkManager.getSidechainConsensusEpochFork(consensusEpochNumber).backwardTransferLimitEnabled()
-        case None =>
-          false
-      }
-      if (backwardTransferLimitEnabled &&
-        numberOfWithdrawalRequestBoxes > params.maxWBsAllowed) {
-        throw new Exception(s"Exceed the maximum withdrawal request boxes per epoch (${numberOfWithdrawalRequestBoxes} out of ${params.maxWBsAllowed})")
-      }
     }
 
     applicationState.validate(this, tx)

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainTransactionApiRoute.scala
@@ -505,7 +505,7 @@ case class SidechainTransactionApiRoute(override val settings: RESTApiSettings,
 
     withdrawalRequestBoxDataList.foreach(element => {
       if(element.value < ZenCoinsUtils.getMinDustThreshold(ZenCoinsUtils.MC_DEFAULT_FEE_RATE))
-        throw new IllegalArgumentException("Withdrawal transaction amount is below the MC dust threshold value.")
+        throw new IllegalArgumentException(s"Withdrawal transaction amount ${element.value} is below the MC dust threshold value: ${ZenCoinsUtils.getMinDustThreshold(ZenCoinsUtils.MC_DEFAULT_FEE_RATE)}")
 
       outputs.add(new WithdrawalRequestBoxData(
         // Keep in mind that check MC rpc `getnewaddress` returns standard address with hash inside in LE

--- a/sdk/src/main/scala/com/horizen/companion/SidechainTransactionsCompanion.scala
+++ b/sdk/src/main/scala/com/horizen/companion/SidechainTransactionsCompanion.scala
@@ -14,5 +14,6 @@ case class SidechainTransactionsCompanion(customTransactionSerializers: JHashMap
     new JHashMap[JByte, TransactionSerializer[SidechainTypes#SCBT]]() {{
       put(MC2SCAggregatedTransactionId.id(), MC2SCAggregatedTransactionSerializer.getSerializer.asInstanceOf[TransactionSerializer[SidechainTypes#SCBT]])
       put(SidechainCoreTransactionId.id(), SidechainCoreTransactionSerializer.getSerializer.asInstanceOf[TransactionSerializer[SidechainTypes#SCBT]])
+      put(OpenStakeTransactionId.id(), OpenStakeTransactionSerializer.getSerializer.asInstanceOf[TransactionSerializer[SidechainTypes#SCBT]])
     }},
     customTransactionSerializers)

--- a/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
@@ -314,7 +314,8 @@ class ForgeMessageBuilder(mainchainSynchronizer: MainchainSynchronizer,
       } else { // SC block is in the middle of the epoch
         var txsCounter: Int = 0
         val allowedWithdrawalRequestBoxes = nodeView.state.getAllowedWithdrawalRequestBoxes(mainchainBlockReferenceDataToRetrieve.size) - nodeView.state.getAlreadyMinedWithdrawalRequestBoxesInCurrentEpoch
-        val mempoolTx = if (nodeView.state.backwardTransferLimitEnabled)  nodeView.pool.takeWithWithdrawalBoxesLimit(allowedWithdrawalRequestBoxes) else nodeView.pool.take(nodeView.pool.size)
+        //In case we reached the Sidechain Fork1 we filter the mempool txs considering also the WithdrawalBoxes allowed to be mined in the current block.
+        val mempoolTx = if (ForkManager.getSidechainConsensusEpochFork(TimeToEpochUtils.timeStampToEpochNumber(params, timestamp))backwardTransferLimitEnabled())  nodeView.pool.takeWithWithdrawalBoxesLimit(allowedWithdrawalRequestBoxes) else nodeView.pool.take(nodeView.pool.size)
         mempoolTx.filter(tx => {
           val txSize = tx.bytes.length + 4 // placeholder for Tx length
           txsCounter += 1

--- a/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
@@ -315,7 +315,7 @@ class ForgeMessageBuilder(mainchainSynchronizer: MainchainSynchronizer,
         var txsCounter: Int = 0
         val allowedWithdrawalRequestBoxes = nodeView.state.getAllowedWithdrawalRequestBoxes(mainchainBlockReferenceDataToRetrieve.size) - nodeView.state.getAlreadyMinedWithdrawalRequestBoxesInCurrentEpoch
         //In case we reached the Sidechain Fork1 we filter the mempool txs considering also the WithdrawalBoxes allowed to be mined in the current block.
-        val mempoolTx = if (ForkManager.getSidechainConsensusEpochFork(TimeToEpochUtils.timeStampToEpochNumber(params, timestamp))backwardTransferLimitEnabled())  nodeView.pool.takeWithWithdrawalBoxesLimit(allowedWithdrawalRequestBoxes) else nodeView.pool.take(nodeView.pool.size)
+        val mempoolTx = if (ForkManager.getSidechainConsensusEpochFork(TimeToEpochUtils.timeStampToEpochNumber(params, timestamp)).backwardTransferLimitEnabled())  nodeView.pool.takeWithWithdrawalBoxesLimit(allowedWithdrawalRequestBoxes) else nodeView.pool.take(nodeView.pool.size)
         mempoolTx.filter(tx => {
           val txSize = tx.bytes.length + 4 // placeholder for Tx length
           txsCounter += 1

--- a/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
@@ -313,7 +313,7 @@ class ForgeMessageBuilder(mainchainSynchronizer: MainchainSynchronizer,
       } else { // SC block is in the middle of the epoch
         var txsCounter: Int = 0
         val allowedWithdrawalRequestBoxes = nodeView.state.getAllowedWithdrawalRequestBoxes(mainchainBlockReferenceDataToRetrieve.size) - nodeView.state.getAlreadyMinedWithdrawalRequestBoxesInCurrentEpoch
-        nodeView.pool.takeWithWithdrawalBoxesLimit(nodeView.pool.size, allowedWithdrawalRequestBoxes).filter(tx => {
+        nodeView.pool.takeWithWithdrawalBoxesLimit(allowedWithdrawalRequestBoxes).filter(tx => {
           val txSize = tx.bytes.length + 4 // placeholder for Tx length
           txsCounter += 1
           if(txsCounter > SidechainBlock.MAX_SIDECHAIN_TXS_NUMBER || blockSize + txSize > SidechainBlock.MAX_BLOCK_SIZE)

--- a/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
@@ -299,7 +299,6 @@ class ForgeMessageBuilder(mainchainSynchronizer: MainchainSynchronizer,
     })
 
     val isWithdrawalEpochLastBlock: Boolean = mainchainReferenceData.size == withdrawalEpochMcBlocksLeft
-
     // Collect transactions if possible
     val transactions: Seq[SidechainTransaction[Proposition, Box[Proposition]]] =
       if (isWithdrawalEpochLastBlock) {
@@ -313,7 +312,8 @@ class ForgeMessageBuilder(mainchainSynchronizer: MainchainSynchronizer,
         Seq()
       } else { // SC block is in the middle of the epoch
         var txsCounter: Int = 0
-        nodeView.pool.take(nodeView.pool.size).filter(tx => {
+        val allowedWithdrawalRequestBoxes = nodeView.state.getAllowedWithdrawalRequestBoxes(mainchainBlockReferenceDataToRetrieve.size) - nodeView.state.getAlreadyMinedWithdrawalRequestBoxesInCurrentEpoch
+        nodeView.pool.takeWithWithdrawalBoxesLimit(nodeView.pool.size, allowedWithdrawalRequestBoxes).filter(tx => {
           val txSize = tx.bytes.length + 4 // placeholder for Tx length
           txsCounter += 1
           if(txsCounter > SidechainBlock.MAX_SIDECHAIN_TXS_NUMBER || blockSize + txSize > SidechainBlock.MAX_BLOCK_SIZE)

--- a/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
@@ -314,7 +314,7 @@ class ForgeMessageBuilder(mainchainSynchronizer: MainchainSynchronizer,
       } else { // SC block is in the middle of the epoch
         var txsCounter: Int = 0
         val allowedWithdrawalRequestBoxes = nodeView.state.getAllowedWithdrawalRequestBoxes(mainchainBlockReferenceDataToRetrieve.size) - nodeView.state.getAlreadyMinedWithdrawalRequestBoxesInCurrentEpoch
-        val mempoolTx = if (nodeView.state.BackwardTransferLimitEnabled)  nodeView.pool.takeWithWithdrawalBoxesLimit(allowedWithdrawalRequestBoxes) else nodeView.pool.take(nodeView.pool.size)
+        val mempoolTx = if (nodeView.state.backwardTransferLimitEnabled)  nodeView.pool.takeWithWithdrawalBoxesLimit(allowedWithdrawalRequestBoxes) else nodeView.pool.take(nodeView.pool.size)
         mempoolTx.filter(tx => {
           val txSize = tx.bytes.length + 4 // placeholder for Tx length
           txsCounter += 1

--- a/sdk/src/main/scala/com/horizen/forge/ForgerList.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgerList.scala
@@ -1,0 +1,39 @@
+package com.horizen.forge
+
+import scorex.core.serialization.{BytesSerializable, ScorexSerializer}
+import scorex.util.serialization.{Reader, Writer}
+
+case class ForgerList(forgerIndexes: Array[Int]) extends BytesSerializable {
+  override type M = ForgerList
+
+  def updateIndexes(indexToUpdate: Array[Int]): ForgerList = {
+    indexToUpdate.foreach(toUpdate => {
+      if (toUpdate < forgerIndexes.length) {
+        forgerIndexes(toUpdate) = 1
+      } else {
+        throw new IndexOutOfBoundsException("Forger index to update is out of bound!")
+      }
+    })
+    ForgerList(forgerIndexes)
+  }
+
+  override def serializer: ScorexSerializer[ForgerList] = ForgerListSerializer
+}
+
+object ForgerListSerializer extends ScorexSerializer[ForgerList] {
+  override def serialize(obj: ForgerList, w: Writer): Unit = {
+    w.putInt(obj.forgerIndexes.size)
+    obj.forgerIndexes.foreach(index => {
+      w.putInt(index)
+    })
+  }
+
+  override def parse(r: Reader): ForgerList = {
+    val nElement = r.getInt()
+    val indexes: Array[Int] = new Array[Int](nElement)
+    for (i <- 0 until nElement) {
+      indexes(i) = r.getInt()
+    }
+    ForgerList(indexes)
+  }
+}

--- a/sdk/src/main/scala/com/horizen/fork/BaseConsensusEpochFork.scala
+++ b/sdk/src/main/scala/com/horizen/fork/BaseConsensusEpochFork.scala
@@ -2,6 +2,7 @@ package com.horizen.fork
 
 class BaseConsensusEpochFork (val epochNumber: ForkConsensusEpochNumber) {
   def backwardTransferLimitEnabled(): Boolean = false
+  def openStakeTransactionEnabled(): Boolean = false
 }
 
 case class ForkConsensusEpochNumber(mainnetEpochNumber: Int, regtestEpochNumber: Int, testnetEpochNumber: Int) {}

--- a/sdk/src/main/scala/com/horizen/fork/BaseConsensusEpochFork.scala
+++ b/sdk/src/main/scala/com/horizen/fork/BaseConsensusEpochFork.scala
@@ -1,5 +1,7 @@
 package com.horizen.fork
 
-class BaseConsensusEpochFork (val epochNumber: ForkConsensusEpochNumber) {}
+class BaseConsensusEpochFork (val epochNumber: ForkConsensusEpochNumber) {
+  def BackwardTransferLimitEnabled(): Boolean = false
+}
 
 case class ForkConsensusEpochNumber(mainnetEpochNumber: Int, regtestEpochNumber: Int, testnetEpochNumber: Int) {}

--- a/sdk/src/main/scala/com/horizen/fork/BaseConsensusEpochFork.scala
+++ b/sdk/src/main/scala/com/horizen/fork/BaseConsensusEpochFork.scala
@@ -1,7 +1,7 @@
 package com.horizen.fork
 
 class BaseConsensusEpochFork (val epochNumber: ForkConsensusEpochNumber) {
-  def BackwardTransferLimitEnabled(): Boolean = false
+  def backwardTransferLimitEnabled(): Boolean = false
 }
 
 case class ForkConsensusEpochNumber(mainnetEpochNumber: Int, regtestEpochNumber: Int, testnetEpochNumber: Int) {}

--- a/sdk/src/main/scala/com/horizen/fork/ForkConfigurator.scala
+++ b/sdk/src/main/scala/com/horizen/fork/ForkConfigurator.scala
@@ -13,6 +13,7 @@ abstract class ForkConfigurator {
     val baseConsensusEpochNumbers = getBaseSidechainConsensusEpochNumbers()
     val fork1EpochNumbers = getSidechainFork1()
 
+    //Fork 1
     if ((fork1EpochNumbers.mainnetEpochNumber < baseConsensusEpochNumbers.mainnetEpochNumber) ||
                  (fork1EpochNumbers.testnetEpochNumber < baseConsensusEpochNumbers.testnetEpochNumber) ||
                  (fork1EpochNumbers.regtestEpochNumber < baseConsensusEpochNumbers.regtestEpochNumber))

--- a/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
+++ b/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
@@ -1,5 +1,18 @@
 package com.horizen.fork
 
+/*
+1- In the mainchain we have a limitation on the amount of BTs that we can have inside a certificate.
+   This limitation is not handled inside the Sidechain SDK and this may lead in the creation of an invalid certificate.
+   For this reason in the SidechainFork1 we add some restrictions on the amount of BT that can mined inside a withdrawal epoch.
+   The maximum amount of BT allowed in a certificate is 3999, the idea is that for every MC block reference that we sync we open up
+   the possibility to mine some WithdrawalBoxes until we reach the limit of 3999 in the last block of the withdrawal epoch.
+
+2- We have the possibility to restrict the forging operation to a predefined set of forgers "closed forging state" and there is no way to
+   change from this state to an "open forging state" where everyone are allowed to forge.
+   Inside this SidechainFork1 we give this opportunity by adding a new kind of transaction "OpenStakeTransaction"
+   that let the current allowed forgers to vote for the forge opening.
+   If the majority of the allowed forgers send this transactions, the forging operation is then opened to everyone.
+ */
 class SidechainFork1(override val epochNumber: ForkConsensusEpochNumber) extends BaseConsensusEpochFork(epochNumber) {
   override def backwardTransferLimitEnabled(): Boolean = true
 }

--- a/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
+++ b/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
@@ -1,5 +1,5 @@
 package com.horizen.fork
 
 class SidechainFork1(override val epochNumber: ForkConsensusEpochNumber) extends BaseConsensusEpochFork(epochNumber) {
-  override def BackwardTransferLimitEnabled(): Boolean = true
+  override def backwardTransferLimitEnabled(): Boolean = true
 }

--- a/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
+++ b/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
@@ -15,4 +15,5 @@ package com.horizen.fork
  */
 class SidechainFork1(override val epochNumber: ForkConsensusEpochNumber) extends BaseConsensusEpochFork(epochNumber) {
   override def backwardTransferLimitEnabled(): Boolean = true
+  override def openStakeTransactionEnabled(): Boolean = true
 }

--- a/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
+++ b/sdk/src/main/scala/com/horizen/fork/SidechainFork1.scala
@@ -1,5 +1,5 @@
 package com.horizen.fork
 
 class SidechainFork1(override val epochNumber: ForkConsensusEpochNumber) extends BaseConsensusEpochFork(epochNumber) {
-  // TODO This is a blank fork. Put implementation for the first fork here.
+  override def BackwardTransferLimitEnabled(): Boolean = true
 }

--- a/sdk/src/main/scala/com/horizen/params/NetworkParams.scala
+++ b/sdk/src/main/scala/com/horizen/params/NetworkParams.scala
@@ -62,4 +62,7 @@ trait NetworkParams {
   // Sidechain forger restriction
   val restrictForgers: Boolean = false
   val allowedForgersList: Seq[(PublicKey25519Proposition, VrfPublicKey)] = Seq()
+
+  //Max Withdrawal Boxes per certificate
+  final val maxWBsAllowed: Int = 3999
 }

--- a/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
+++ b/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
@@ -8,6 +8,7 @@ import com.horizen.block.{WithdrawalEpochCertificate, WithdrawalEpochCertificate
 import com.horizen.box.{WithdrawalRequestBox, WithdrawalRequestBoxSerializer}
 import com.horizen.companion.SidechainBoxesCompanion
 import com.horizen.consensus._
+import com.horizen.forge.{ForgerList, ForgerListSerializer}
 import com.horizen.utils.{ByteArrayWrapper, ListSerializer, WithdrawalEpochInfo, WithdrawalEpochInfoSerializer, Pair => JPair, _}
 import scorex.util.ScorexLogging
 
@@ -34,6 +35,8 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
   private[horizen] val consensusEpochKey = Utils.calculateKey("consensusEpoch".getBytes)
 
   private[horizen] val ceasingStateKey = Utils.calculateKey("ceasingStateKey".getBytes)
+
+  private[horizen] val forgerListIndexKey = Utils.calculateKey("forgerListIndexKey".getBytes)
 
   private val undefinedWithdrawalEpochCounter: Int = -1
   private[horizen] def getWithdrawalEpochCounterKey(withdrawalEpoch: Int): ByteArrayWrapper = {
@@ -181,6 +184,25 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
     }
   }
 
+  def getForgerList: Option[ForgerList] = {
+    storage.get(forgerListIndexKey).asScala match {
+      case Some(baw) => {
+        Try {
+          ForgerListSerializer.parseBytesTry(baw.data)
+        } match {
+          case Success(Success(forgerIndexes)) => Some(forgerIndexes)
+          case Success(Failure(_)) =>
+            log.error("Error while forger list indexes information parsing.")
+            Option.empty
+          case Failure(exception) =>
+            log.error("Error while forger list indexes information parsing.", exception)
+            Option.empty
+        }
+      }
+      case None => Option.empty
+    }
+  }
+
   def update(version: ByteArrayWrapper,
              withdrawalEpochInfo: WithdrawalEpochInfo,
              boxUpdateList: Set[SidechainTypes#SCB],
@@ -190,7 +212,9 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
              topQualityCertificateOpt: Option[WithdrawalEpochCertificate],
              blockFeeInfo: BlockFeeInfo,
              utxoMerkleTreeRootOpt: Option[Array[Byte]],
-             scHasCeased: Boolean): Try[SidechainStateStorage] = Try {
+             scHasCeased: Boolean,
+             forgerListIndexes: Array[Int],
+             forgerListSize: Int): Try[SidechainStateStorage] = Try {
     require(withdrawalEpochInfo != null, "WithdrawalEpochInfo must be NOT NULL.")
     require(boxUpdateList != null, "List of Boxes to add/update must be NOT NULL. Use empty List instead.")
     require(boxIdsRemoveSet != null, "List of Box IDs to remove must be NOT NULL. Use empty List instead.")
@@ -280,6 +304,18 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
     // If sidechain has ceased set the flag
     if(scHasCeased)
       updateList.add(new JPair(ceasingStateKey, new ByteArrayWrapper(Array.emptyByteArray)))
+
+    //Set ForgerList indexes
+    getForgerList match {
+      case Some(forgerList) =>
+        if (forgerListIndexes.length != 0) {
+          val updatedForgerList = forgerList.updateIndexes(forgerListIndexes)
+          updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(updatedForgerList)))
+        }
+      case None =>
+        val emptyForgerListIndex = ForgerList(new Array[Int](forgerListSize))
+        updateList.add(new JPair(forgerListIndexKey, ForgerListSerializer.toBytes(emptyForgerListIndex)))
+    }
 
     storage.update(version, updateList, removeList)
     this

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -1,6 +1,6 @@
 package com.horizen
 
-import java.util.{ArrayList => JArrayList, List => JList}
+import java.util.{Optional => JOptional, ArrayList => JArrayList, List => JList}
 import com.horizen.block.{MainchainBlockReferenceData, SidechainBlock, WithdrawalEpochCertificate}
 import com.horizen.box.data.{BoxData, ForgerBoxData, WithdrawalRequestBoxData, ZenBoxData}
 import com.horizen.box._
@@ -8,14 +8,15 @@ import com.horizen.consensus.{ConsensusEpochNumber, intToConsensusEpochNumber}
 import com.horizen.cryptolibprovider.FieldElementUtils
 import com.horizen.fixtures.{SecretFixture, SidechainTypesTestsExtension, StoreFixture, TransactionFixture}
 import com.horizen.fork.{ForkManagerUtil, SimpleForkConfigurator}
+import com.horizen.forge.ForgerList
 import com.horizen.params.MainNetParams
-import com.horizen.proposition.Proposition
+import com.horizen.proposition.{Proposition, VrfPublicKey}
 import com.horizen.secret.PrivateKey25519
 import com.horizen.storage.{SidechainStateForgerBoxStorage, SidechainStateStorage}
 import com.horizen.state.{ApplicationState, SidechainStateReader}
 import com.horizen.transaction.exception.TransactionSemanticValidityException
 import com.horizen.utils.{BlockFeeInfo, ByteArrayWrapper, BytesUtils, FeePaymentsUtils, WithdrawalEpochInfo, Pair => JPair}
-import com.horizen.transaction.{BoxTransaction, RegularTransaction}
+import com.horizen.transaction.{BoxTransaction, OpenStakeTransaction, RegularTransaction}
 import org.junit.Assert._
 import org.junit._
 import org.mockito.{ArgumentMatchers, Mockito}
@@ -49,6 +50,7 @@ class SidechainStateTest
   val transactionList = new ListBuffer[RegularTransaction]()
 
   val secretList = new ListBuffer[PrivateKey25519]()
+  val vrfList = new ListBuffer[VrfPublicKey]()
 
   val params = MainNetParams()
 
@@ -101,6 +103,11 @@ class SidechainStateTest
     val fee = totalFrom - totalTo
 
     RegularTransaction.create(from, to, fee)
+  }
+
+  def getOpenStakeTransaction(boxesWithSecretToOpen: (ZenBox,PrivateKey25519), forgerIndex: Int, fee: JOptional[Long]): OpenStakeTransaction = {
+    val from: JPair[ZenBox,PrivateKey25519] =  new JPair[ZenBox,PrivateKey25519](boxesWithSecretToOpen._1, boxesWithSecretToOpen._2)
+    OpenStakeTransaction.create(from, getPrivateKey25519List(1).get(0).publicImage(), forgerIndex, fee.orElseGet(() => 5L))
   }
 
   @Test
@@ -305,7 +312,9 @@ class SidechainStateTest
       ArgumentMatchers.any[Option[WithdrawalEpochCertificate]](),
       ArgumentMatchers.any[BlockFeeInfo](),
       ArgumentMatchers.any[Option[Array[Byte]]](),
-      ArgumentMatchers.any[Boolean]()))
+      ArgumentMatchers.any[Boolean](),
+      ArgumentMatchers.any[Array[Int]],
+      ArgumentMatchers.any[Int]))
       .thenAnswer( answer => {
         val version = answer.getArgument[ByteArrayWrapper](0)
         val withdrawalEpochInfo = answer.getArgument[WithdrawalEpochInfo](1)
@@ -402,6 +411,9 @@ class SidechainStateTest
 
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
+
+    Mockito.when(mockedBlock.sidechainTransactions)
+      .thenReturn(Seq())
 
     Mockito.when(mockedBlock.parentId)
       .thenReturn(bytesToId(stateVersion.last.data))
@@ -622,6 +634,8 @@ class SidechainStateTest
       )
     )
 
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Option.empty})
+
     Mockito.when(mockedStateForgerBoxStorage.lastVersionId).thenReturn(Some(stateVersion.last))
 
     Mockito.when(mockedStateUtxoMerkleTreeProvider.lastVersionId).thenReturn(Some(stateVersion.last))
@@ -647,6 +661,7 @@ class SidechainStateTest
 
     //Test validate(Transaction) with restrict forger enable and invalid blockSignProposition
     Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq((invalidBlockSignProposition,allowedVrfPublicKey)))
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(ForgerList(Array[Int](0)))})
     tryValidate = sidechainState.validate(stakeTransaction)
     assertFalse("Transaction validation must fail.",
       tryValidate.isSuccess)
@@ -662,7 +677,182 @@ class SidechainStateTest
     //Test validate(Transaction) with restrict forger enable and valid blockSignProposition and vrfPublicKey
     Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq((allowedBlockSignProposition,allowedVrfPublicKey)))
     tryValidate = sidechainState.validate(stakeTransaction)
-    assertTrue("Transaction validation must fail.",
+    assertTrue("Transaction validation must not fail.",
+      tryValidate.isSuccess)
+
+    //Test validate(Transaction) with restrict forger, invalid forger and not the majority of the allowed forgers opened the stake
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(ForgerList(Array[Int](1,1,0,0,0)))})
+    Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq(
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+      (invalidBlockSignProposition,invalidVrfPublicKey),
+    ))
+    tryValidate = sidechainState.validate(stakeTransaction)
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("This publicKey is not allowed to forge!"))
+
+    //Test validate(Transaction) with restrict forger, invalid forger and the majority of the allowed forgers opened the stake
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(ForgerList(Array[Int](1,1,1,0,0)))})
+    tryValidate = sidechainState.validate(stakeTransaction)
+    assertTrue("Transaction validation must not fail.",
+      tryValidate.isSuccess)
+  }
+
+  @Test
+  def openForgerTest(): Unit = {
+    // Set base Secrets data
+    secretList.clear()
+    secretList ++= getPrivateKey25519List(5).asScala
+    //Set vrf public key list
+    vrfList.clear()
+    for (i <-0 until 5)
+      vrfList += getVRFPublicKey
+    // Set base Box data
+    boxList.clear()
+    boxList ++= getZenBoxList(secretList.asJava).asScala.toList
+    stateVersion.clear()
+    stateVersion += getVersion
+    transactionList.clear()
+    transactionList += getRegularTransaction(1, 1, 0, Seq(), 5)
+
+    Mockito.when(mockedStateStorage.lastVersionId).thenReturn(Some(stateVersion.last))
+
+    Mockito.when(mockedStateStorage.getBox(ArgumentMatchers.any[Array[Byte]]()))
+      .thenAnswer(answer => {
+        val boxId = answer.getArgument(0).asInstanceOf[Array[Byte]]
+        boxList.find(_.id().sameElements(boxId))
+      })
+
+    Mockito.when(mockedStateForgerBoxStorage.lastVersionId).thenReturn(Some(stateVersion.last))
+
+    Mockito.when(mockedStateUtxoMerkleTreeProvider.lastVersionId).thenReturn(Some(stateVersion.last))
+
+    val mockedParams = mock[MainNetParams]
+    Mockito.when(mockedParams.restrictForgers).thenReturn(true)
+
+    val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
+      mockedParams, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+
+    val forgerList = Seq(
+      (secretList(0).publicImage(), vrfList(0)),
+      (secretList(1).publicImage(), vrfList(1)),
+      (secretList(2).publicImage(), vrfList(2)),
+      (secretList(3).publicImage(), vrfList(3)),
+      (secretList(4).publicImage(), vrfList(4)),
+    )
+    var forgerListIndexes = ForgerList(Array[Int](1,1,0,0,0))
+    // NEGATIVE TESTS
+
+    //Test validate(Transaction) without reach the Fork1
+    var openStakeTransaction = getOpenStakeTransaction(
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
+      0,
+      JOptional.empty()
+    )
+
+    Mockito.when(mockedStateStorage.getConsensusEpochNumber).thenReturn(Some(intToConsensusEpochNumber(1)))
+
+    var tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransaction is still not allowed in this consensus epoch!"))
+
+    //Test validate(Transaction) with restrict forger disabled
+    Mockito.when(mockedStateStorage.getConsensusEpochNumber).thenReturn(Some(intToConsensusEpochNumber(11)))
+
+    Mockito.when(mockedParams.restrictForgers).thenReturn(false)
+    Mockito.when(mockedParams.allowedForgersList).thenReturn(Seq())
+    openStakeTransaction = getOpenStakeTransaction(
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
+      0,
+      JOptional.empty()
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransactions are not allowed because the forger operation has already been opened!"))
+
+    //Test validate(Transaction) with restrict forger enabled and forgerListIndex out of bound
+    Mockito.when(mockedParams.restrictForgers).thenReturn(true)
+    Mockito.when(mockedParams.allowedForgersList).thenReturn(forgerList)
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
+    openStakeTransaction = getOpenStakeTransaction(
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
+      10,
+      JOptional.empty()
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("ForgerIndex in OpenStakeTransaction is out of bound!"))
+
+
+    //Test validate(Transaction) with restrict forger enabled and forger list indexes is not present in the storage
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {None})
+    openStakeTransaction = getOpenStakeTransaction(
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
+      0,
+      JOptional.empty()
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("Forger list was not found in the Storage!"))
+
+
+    //Test validate(Transaction) with restrict forger enabled and try to update an existing forger index
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
+    openStakeTransaction = getOpenStakeTransaction(
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
+      0,
+      JOptional.empty()
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("Forger already opened the stake!"))
+
+    //Test validate(Transaction) with restrict forger enabled with an input proposition that doesn't match the forgerListIndex
+    forgerListIndexes = ForgerList(Array[Int](0,1,0,0,0))
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
+    openStakeTransaction = getOpenStakeTransaction(
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
+      3,
+      JOptional.empty()
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransaction input doesn't match the forgerIndex!"))
+
+    //Test validate(Transaction) with the forge operation already opened.
+    forgerListIndexes = ForgerList(Array[Int](1,1,1,0,0))
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
+    openStakeTransaction = getOpenStakeTransaction(
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
+      3,
+      JOptional.empty()
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertFalse("Transaction validation must fail.",
+      tryValidate.isSuccess)
+    assertTrue(tryValidate.failed.get.getMessage.equals("OpenStakeTransactions are not allowed because the forger operation has already been opened!"))
+
+    //POSITIVE TESTS
+
+    //Test validate(Transaction) with restrict forger enabled and correct index
+    forgerListIndexes = ForgerList(Array[Int](0,1,0,0,0))
+    Mockito.when(mockedStateStorage.getForgerList).thenAnswer(_ => {Some(forgerListIndexes)})
+    openStakeTransaction = getOpenStakeTransaction(
+      (boxList.head.asInstanceOf[ZenBox], secretList.head),
+      0,
+      JOptional.empty()
+    )
+    tryValidate = sidechainState.validate(openStakeTransaction.asInstanceOf[SidechainTypes#SCBT])
+    assertTrue("Transaction validation must not fail.",
       tryValidate.isSuccess)
   }
 

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -7,7 +7,7 @@ import com.horizen.box._
 import com.horizen.consensus.{ConsensusEpochNumber, intToConsensusEpochNumber}
 import com.horizen.cryptolibprovider.FieldElementUtils
 import com.horizen.fixtures.{SecretFixture, SidechainTypesTestsExtension, StoreFixture, TransactionFixture}
-import com.horizen.fork.{ForkManager, ForkManagerUtil, SimpleForkConfigurator}
+import com.horizen.fork.{ForkManagerUtil, SimpleForkConfigurator}
 import com.horizen.params.MainNetParams
 import com.horizen.proposition.Proposition
 import com.horizen.secret.PrivateKey25519
@@ -193,6 +193,7 @@ class SidechainStateTest
       .thenReturn(bytesToId(stateVersion.last.data))
       .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
 
+    Mockito.when(mockedBlock.timestamp).thenReturn(86401)
 
     Mockito.doNothing().when(mockedApplicationState).validate(ArgumentMatchers.any[SidechainStateReader](),
       ArgumentMatchers.any[SidechainBlock]())
@@ -246,6 +247,7 @@ class SidechainStateTest
     Mockito.when(doubleSpendTransactionMockedBlock.mainchainBlockReferencesData).thenReturn(Seq())
     Mockito.when(doubleSpendTransactionMockedBlock.parentId).thenReturn(bytesToId(stateVersion.last.data))
     Mockito.when(doubleSpendTransactionMockedBlock.id).thenReturn(ModifierId @@ "testBlock")
+    Mockito.when(doubleSpendTransactionMockedBlock.timestamp).thenReturn(86401)
 
     val boxAndSecret2: Seq[(ZenBox,PrivateKey25519)] = Seq((boxList.last.asInstanceOf[ZenBox], secretList.last))
 
@@ -741,6 +743,8 @@ class SidechainStateTest
     val mockedParams = mock[MainNetParams]
     Mockito.when(mockedParams.maxWBsAllowed).thenReturn(100)
     Mockito.when(mockedParams.withdrawalEpochLength).thenReturn(11)
+    Mockito.when(mockedParams.consensusSlotsInEpoch).thenReturn(1)
+    Mockito.when(mockedParams.consensusSecondsInSlot).thenReturn(1)
 
     Mockito.when(mockedStateStorage.lastVersionId).thenReturn(Some(stateVersion.last))
 
@@ -784,6 +788,7 @@ class SidechainStateTest
       .thenReturn(bytesToId(stateVersion.last.data))
       .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
 
+    Mockito.when(mockedBlock.timestamp).thenReturn(86401)
 
     Mockito.doNothing().when(mockedApplicationState).validate(ArgumentMatchers.any[SidechainStateReader](),
       ArgumentMatchers.any[SidechainBlock]())
@@ -911,6 +916,7 @@ class SidechainStateTest
 
     //Test BTs limit before the Fork1
     Mockito.when(mockedStateStorage.getConsensusEpochNumber).thenReturn(Some(intToConsensusEpochNumber(1)))
+    Mockito.when(mockedParams.consensusSlotsInEpoch).thenReturn(86400)
 
     transactionList.clear()
     transactionList += getRegularTransaction(1, 0, 100, Seq(), 100)

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -678,7 +678,6 @@ class SidechainStateTest
     stateVersion += getVersion
     val belowTresholdTransaction = getRegularTransaction(1, 0, 98, Seq(), 10)
     val tresholdTransaction = getRegularTransaction(1, 0, 99, Seq(), 10)
-    val aboveTresholdTransaction = getRegularTransaction(1, 0, 100, Seq(), 10)
 
     Mockito.when(mockedStateStorage.lastVersionId).thenReturn(Some(stateVersion.last))
 
@@ -717,11 +716,6 @@ class SidechainStateTest
     assertTrue("Transaction validation must be successful.",
       tryValidate.isSuccess)
 
-    //Test validate(Transaction) with a number of WithdrawalBoxes > maxWBsAllowed
-    tryValidate = sidechainState.validate(aboveTresholdTransaction)
-    assertFalse("Transaction validation must fail.",
-      tryValidate.isSuccess)
-    assertTrue(tryValidate.failed.get.getMessage.equals("Exceed the maximum withdrawal request boxes per epoch (100 out of 99)"))
   }
 
   @Test

--- a/sdk/src/test/scala/com/horizen/fixtures/BoxFixture.scala
+++ b/sdk/src/test/scala/com/horizen/fixtures/BoxFixture.scala
@@ -60,7 +60,7 @@ trait BoxFixture
     val boxList: JList[ZenBox] = new JArrayList[ZenBox]()
 
     for (s <- secretList.asScala)
-      boxList.add(getZenBox(s.publicImage(), 1, Random.nextInt(100)))
+      boxList.add(getZenBox(s.publicImage(), 1, Random.nextInt(10000)))
 
     boxList
   }

--- a/sdk/src/test/scala/com/horizen/fixtures/SidechainNodeViewHolderFixture.scala
+++ b/sdk/src/test/scala/com/horizen/fixtures/SidechainNodeViewHolderFixture.scala
@@ -12,6 +12,7 @@ import com.horizen.companion.{SidechainBoxesCompanion, SidechainSecretsCompanion
 import com.horizen.consensus.ConsensusDataStorage
 import com.horizen.customconfig.CustomAkkaConfiguration
 import com.horizen.customtypes.{DefaultApplicationState, DefaultApplicationWallet}
+import com.horizen.fork.{ForkManagerUtil, SimpleForkConfigurator}
 import com.horizen.params.{MainNetParams, NetworkParams, RegTestParams, TestNetParams}
 import com.horizen.secret.{PrivateKey25519Serializer, SecretSerializer}
 import com.horizen.state.ApplicationState
@@ -32,6 +33,10 @@ trait SidechainNodeViewHolderFixture
   val classLoader: ClassLoader = getClass.getClassLoader
 
   val sidechainSettings: SidechainSettings = SidechainSettingsReader.read(classLoader.getResource("sc_node_holder_fixter_settings.conf").getFile, None)
+
+  val simpleForkConfigurator = new SimpleForkConfigurator
+  val forkManagerUtil = new ForkManagerUtil()
+  forkManagerUtil.initializeForkManager(simpleForkConfigurator, "regtest")
 
   implicit def exceptionHandler: ExceptionHandler = SidechainApiErrorHandler.exceptionHandler
   implicit def rejectionHandler: RejectionHandler = ApiRejectionHandler.rejectionHandler

--- a/sdk/src/test/scala/com/horizen/fork/ForkManagerTest.scala
+++ b/sdk/src/test/scala/com/horizen/fork/ForkManagerTest.scala
@@ -8,6 +8,7 @@ class ForkManagerTest extends JUnitSuite {
   @Test
   def ForkmangerTest: Unit = {
     val simpleForkConfigurator = new SimpleForkConfigurator
+    ForkManager.networkName = null
 
     var res = ForkManager.init(simpleForkConfigurator, "wrongname")
     assertEquals("Expected failure on ForkManger initialization", true, res.isFailure)

--- a/sdk/src/test/scala/com/horizen/fork/ForkManagerUtil.scala
+++ b/sdk/src/test/scala/com/horizen/fork/ForkManagerUtil.scala
@@ -1,0 +1,9 @@
+package com.horizen.fork
+import scala.util.Try
+
+class ForkManagerUtil {
+  def initializeForkManager(forkConfigurator:ForkConfigurator, networkName:String): Try[Unit] = Try {
+    ForkManager.networkName = null
+    ForkManager.init(forkConfigurator, networkName)
+  }
+}

--- a/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
@@ -130,7 +130,9 @@ class SidechainStateIntegrationTest
       None,
       initialBlockFeeInfo,
       None,
-      scHasCeased = false
+      scHasCeased = false,
+      new Array[Int](0),
+      0
     )
 
     // Init SidechainStateForgerBoxStorage with forger boxes
@@ -240,6 +242,9 @@ class SidechainStateIntegrationTest
 
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
+
+    Mockito.when(mockedBlock.sidechainTransactions)
+      .thenReturn(Seq())
 
     Mockito.when(mockedBlock.parentId)
       .thenReturn(bytesToId(initialVersion.data))

--- a/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
@@ -9,13 +9,14 @@ import com.horizen.companion.SidechainBoxesCompanion
 import com.horizen.consensus._
 import com.horizen.customtypes.DefaultApplicationState
 import com.horizen.fixtures.{SecretFixture, SidechainTypesTestsExtension, StoreFixture, TransactionFixture}
+import com.horizen.fork.{ForkManagerUtil, SimpleForkConfigurator}
 import com.horizen.params.MainNetParams
 import com.horizen.proposition.Proposition
 import com.horizen.secret.PrivateKey25519
 import com.horizen.storage.{SidechainStateForgerBoxStorage, SidechainStateStorage, SidechainStateUtxoMerkleTreeStorage}
 import com.horizen.transaction.RegularTransaction
 import com.horizen.utils.{BlockFeeInfo, ByteArrayWrapper, BytesUtils, FeePaymentsUtils, WithdrawalEpochInfo, Pair => JPair}
-import com.horizen.{SidechainState, SidechainTypes, SidechainStateUtxoMerkleTreeProvider, SidechainUtxoMerkleTreeProviderCSWDisabled, SidechainUtxoMerkleTreeProviderCSWEnabled}
+import com.horizen.{SidechainState, SidechainStateUtxoMerkleTreeProvider, SidechainTypes, SidechainUtxoMerkleTreeProviderCSWDisabled, SidechainUtxoMerkleTreeProviderCSWEnabled}
 import org.junit.Assert._
 import org.junit._
 import org.mockito.Mockito
@@ -51,6 +52,10 @@ class SidechainStateIntegrationTest
   val initialConsensusEpoch: ConsensusEpochNumber = intToConsensusEpochNumber(1)
 
   val initialBlockFeeInfo: BlockFeeInfo = BlockFeeInfo(100, getPrivateKey25519("1234".getBytes()).publicImage())
+
+  val simpleForkConfigurator = new SimpleForkConfigurator
+  val forkManagerUtil = new ForkManagerUtil()
+  forkManagerUtil.initializeForkManager(simpleForkConfigurator, "mainnet")
 
   def getRegularTransaction(zenOutputsCount: Int, forgerOutputsCount: Int): RegularTransaction = {
     val outputsCount = zenOutputsCount + forgerOutputsCount

--- a/sdk/src/test/scala/com/horizen/integration/storage/SidechainStateStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/storage/SidechainStateStorageTest.scala
@@ -58,7 +58,7 @@ class SidechainStateStorageTest
     // Test insert operation (empty storage).
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(version1, withdrawalEpochInfo, (bList1 ++ bList2).toSet, Set(), Seq(),
-        consensusEpoch, None, blockFeeInfo, None, false).isSuccess)
+        consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0).isSuccess)
     assertEquals("Version in storage must be - " + version1,
       version1, sidechainStateStorage.lastVersionId.get)
     assertEquals("Storage must contain 1 version.",
@@ -75,7 +75,7 @@ class SidechainStateStorageTest
     val boxIdsToRemoveSet: Set[ByteArrayWrapper] = Set(new ByteArrayWrapper(bList1.head.id()), new ByteArrayWrapper(bList2.head.id()))
     assertTrue("Update(delete) operation must be successful.",
       sidechainStateStorage.update(version2, withdrawalEpochInfo, Set(),
-        boxIdsToRemoveSet, Seq(), consensusEpoch, None, blockFeeInfo, None, false).isSuccess)
+        boxIdsToRemoveSet, Seq(), consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0).isSuccess)
 
     assertEquals("Version in storage must be - " + version2,
       version2, sidechainStateStorage.lastVersionId.get)
@@ -126,7 +126,7 @@ class SidechainStateStorageTest
     val mod1mcBlockHashInCertificate = Option(Array.fill(32)(rnd.nextInt().toByte))
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), withdrawalRequestsList,
-        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod1mcBlockHashInCertificate)), blockFeeInfo, None, false
+        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod1mcBlockHashInCertificate)), blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -153,7 +153,7 @@ class SidechainStateStorageTest
     val mod2mcBlockHashInCertificate = Option(Array.fill(32)(rnd.nextInt().toByte))
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), newWithdrawalRequestsList,
-        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod2mcBlockHashInCertificate)), blockFeeInfo, None, false
+        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod2mcBlockHashInCertificate)), blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -181,7 +181,7 @@ class SidechainStateStorageTest
     val secondEpochWithdrawalRequestsList: List[WithdrawalRequestBox] = getWithdrawalRequestsBoxList(2).asScala.toList
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod3Version, mod3WithdrawalEpochInfo, Set(), Set(), secondEpochWithdrawalRequestsList,
-        consensusEpoch, None, blockFeeInfo, None, false
+        consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
     // Check that first epoch withdrawals still exist -> no clean-up
@@ -195,7 +195,7 @@ class SidechainStateStorageTest
     val thirdEpochWithdrawalRequestsList: List[WithdrawalRequestBox] = getWithdrawalRequestsBoxList(3).asScala.toList
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod4Version, mod4WithdrawalEpochInfo, Set(), Set(), thirdEpochWithdrawalRequestsList,
-        consensusEpoch, None, blockFeeInfo, None, false
+        consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
     // Check that first epoch withdrawals were removed.
@@ -236,7 +236,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod1BlockFeeInfo, None, false
+        consensusEpoch, None, mod1BlockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -257,7 +257,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod2BlockFeeInfo, None, false
+        consensusEpoch, None, mod2BlockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -280,7 +280,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod3Version, mod3WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod3BlockFeeInfo, None, false
+        consensusEpoch, None, mod3BlockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -328,7 +328,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod1BlockFeeInfo, Some(utxoMerkleRoot1), scHasCeased = false
+        consensusEpoch, None, mod1BlockFeeInfo, Some(utxoMerkleRoot1), scHasCeased = false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -347,7 +347,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod2BlockFeeInfo, Some(utxoMerkleRoot2), scHasCeased = true
+        consensusEpoch, None, mod2BlockFeeInfo, Some(utxoMerkleRoot2), scHasCeased = true, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -378,7 +378,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod1BlockFeeInfo, None, scHasCeased = false
+        consensusEpoch, None, mod1BlockFeeInfo, None, scHasCeased = false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -393,7 +393,7 @@ class SidechainStateStorageTest
 
     assertTrue("Update(insert) must be successful.",
       sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod2BlockFeeInfo, None, scHasCeased = true
+        consensusEpoch, None, mod2BlockFeeInfo, None, scHasCeased = true, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -415,6 +415,6 @@ class SidechainStateStorageTest
     //Try to remove non-existent item
     assertFalse("Remove operation of non-existent item must not throw exception.",
       sidechainStateStorage.update(version1, withdrawalEpochInfo, Set(), bList1.map(b => new ByteArrayWrapper(b.id())),
-        Seq(), intToConsensusEpochNumber(0), None, blockFeeInfo, None, false).isFailure)
+        Seq(), intToConsensusEpochNumber(0), None, blockFeeInfo, None, false, new Array[Int](0), 0).isFailure)
   }
 }

--- a/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
@@ -117,6 +117,9 @@ class SidechainStateStorageTest
     toUpdate.add(new Pair(stateStorage.consensusEpochKey, new ByteArrayWrapper(Ints.toByteArray(consensusEpoch))))
     val toRemove = java.util.Arrays.asList(storedBoxList(2).getKey)
 
+    //forger list indexes
+    toUpdate.add(new Pair(stateStorage.forgerListIndexKey, new ByteArrayWrapper(Array[Byte](0.toByte))))
+
     Mockito.when(mockedPhysicalStorage.update(
       ArgumentMatchers.any[ByteArrayWrapper](),
       ArgumentMatchers.anyList[Pair[ByteArrayWrapper, ByteArrayWrapper]](),
@@ -136,7 +139,7 @@ class SidechainStateStorageTest
 
     // Test 1: test successful update
     tryRes = stateStorage.update(version, withdrawalEpochInfo, Set(boxList.head),
-      Set(new ByteArrayWrapper(boxList(2).id())), Seq(), consensusEpoch, None, blockFeeInfo, None, false)
+      Set(new ByteArrayWrapper(boxList(2).id())), Seq(), consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0)
     assertTrue("StateStorage successful update expected, instead exception occurred:\n %s".format(if(tryRes.isFailure) tryRes.failed.get.getMessage else ""),
       tryRes.isSuccess)
 
@@ -144,7 +147,7 @@ class SidechainStateStorageTest
     // Test 2: test failed update, when Storage throws an exception
     val box = getZenBox
     tryRes = stateStorage.update(version, withdrawalEpochInfo, Set(box),
-      Set(new ByteArrayWrapper(boxList(3).id())), Seq(), consensusEpoch, None, blockFeeInfo, None, false)
+      Set(new ByteArrayWrapper(boxList(3).id())), Seq(), consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0)
     assertTrue("StateStorage failure expected during update.", tryRes.isFailure)
     assertEquals("StateStorage different exception expected during update.", expectedException, tryRes.failed.get)
     assertTrue("Storage should NOT contain Box that was tried to update.", stateStorage.getBox(box.id()).isEmpty)


### PR DESCRIPTION
## Description
This PR introduces the BTs limit inside the certificate.
For more info please look at: https://www.notion.so/horizen-labs/Certificate-backward-transfers-limit-fd8b23f56cb44362a271d795d982c22f

For what regards the Fork 1 changes, in the first place i was trying to use the function `SidechainState.getCurrentConsensusEpochInfo()` but it requires to have some ForgingStakeInfos and there are some cases where this is not always true.
For this reason I used another approach, see `SidechainState.backwardTransferLimitEnabled()`

## Jira Ticket
[216](https://horizenlabs.atlassian.net/jira/software/c/projects/SDK/boards/14?modal=detail&selectedIssue=SDK-216&assignee=615f31c32f6aed0068c67291)

## Changes

- Added new max WithdrawalRequestBoxes per certificate (3999)
- Added new Transaction validation rule that checks that the transaction doesn't create more than 3999 WBs.
- Added new rule inside BlockMutualityCheck.
- Added new logic in the Forger that takes in account the total amount of WBs when it retrieves the mempool transactions in order to forge a block
- New Unit Tests
- New python test 

## Breaking Changes
- New consensus rules = **non backward compatible changes!**

## Checks
- [✔] Project Builds
- [✔] Project passes unit tests
- [✔] Project passes integration tests (Python)
- [✘] Updated documentation accordingly
- [✔] Breaking changes have been correctly tagged and notified

