### PR TITLE
libevm build on maven test

### DIFF
--- a/libevm/pom.xml
+++ b/libevm/pom.xml
@@ -69,6 +69,14 @@
         <configuration>
           <buildMode>c-shared</buildMode>
         </configuration>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- add libevm `build` goal to mavens `generate-resources` phase
- this will make sure the libevm binary is built not just on `package` but also on `compile`, `test`, etc.