### PR TITLE
Sdk 306 add run xml configuration for simple app

### DIFF
--- a/.run/.runConfiguration/SimpleApp.run.xml
+++ b/.run/.runConfiguration/SimpleApp.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="SimpleApp" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="com.horizen.examples.SimpleApp" />
+    <module name="sidechains-sdk-simpleapp" />
+    <option name="PROGRAM_PARAMETERS" value="examples/simpleapp/src/main/resources/sc_settings.conf" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="com.horizen.examples.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
This configuration allows developer to run SimpleApp in the IntelliJ IDEA without need to configure manually