### PR TITLE
[SDK-221] Fixed Node termination in case of an unexpected shutdown

### DIFF
--- a/sdk/src/main/resources/log4j2.xml
+++ b/sdk/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" monitorInterval="30">
+<Configuration status="WARN" monitorInterval="30" shutdownHook="disable">
 
     <Properties>
         <Property name="LOG_PATTERN">[%-5level] %d{yyyy-MM-dd HH:mm:ss:SSS Z} [%28F:%-4L] [%t] %c - %msg%n</Property>

--- a/sdk/src/main/resources/log4j2.xml
+++ b/sdk/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" monitorInterval="30" shutdownHook="disable">
+<Configuration status="WARN" monitorInterval="30">
 
     <Properties>
         <Property name="LOG_PATTERN">[%-5level] %d{yyyy-MM-dd HH:mm:ss:SSS Z} [%28F:%-4L] [%t] %c - %msg%n</Property>

--- a/sdk/src/main/scala/com/horizen/SidechainApp.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainApp.scala
@@ -2,14 +2,11 @@ package com.horizen
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.Http
+
 import java.lang.{Byte => JByte}
 import java.nio.file.{Files, Paths}
-import java.util.{HashMap => JHashMap, List => JList}
-
-import akka.actor.{ActorRef, ActorSystem}
-import akka.http.scaladsl.Http
+import java.util.{HashMap => JHashMap, List => JList, Map => JMap}
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler}
-import akka.stream.ActorMaterializer
 import akka.stream.ActorMaterializer
 import com.google.inject.Inject
 import com.google.inject.name.Named
@@ -22,9 +19,8 @@ import com.horizen.companion._
 import com.horizen.consensus.ConsensusDataStorage
 import com.horizen.cryptolibprovider.CryptoLibProvider
 import com.horizen.customconfig.CustomAkkaConfiguration
-import com.horizen.cryptolibprovider.{CommonCircuit, CryptoLibProvider}
+import com.horizen.cryptolibprovider.CommonCircuit
 import com.horizen.csw.CswManagerRef
-import com.horizen.customconfig.CustomAkkaConfiguration
 import com.horizen.forge.{ForgerRef, MainchainSynchronizer}
 import com.horizen.helper._
 import com.horizen.network.SidechainNodeViewSynchronizer
@@ -38,7 +34,6 @@ import com.horizen.transaction._
 import com.horizen.transaction.mainchain.SidechainCreation
 import com.horizen.utils.{BlockUtils, BytesUtils, Pair}
 import com.horizen.wallet.ApplicationWallet
-import com.horizen.websocket.client._
 import com.horizen.websocket.server.WebSocketServerRef
 import scorex.core.api.http.ApiRoute
 import scorex.core.app.Application
@@ -50,24 +45,18 @@ import scorex.core.settings.ScorexSettings
 import scorex.core.transaction.Transaction
 import scorex.core.{ModifierTypeId, NodeViewModifier}
 import scorex.util.ScorexLogging
-import java.lang.{Byte => JByte}
-import java.nio.file.{Files, Paths}
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.{HashMap => JHashMap, List => JList}
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.io.{Codec, Source}
-import com.horizen.network.SidechainNodeViewSynchronizer
 import com.horizen.websocket.client.{DefaultWebSocketReconnectionHandler, MainchainNodeChannelImpl, WebSocketChannel, WebSocketCommunicationClient, WebSocketConnector, WebSocketConnectorImpl, WebSocketReconnectionHandler}
-import com.horizen.websocket.server.WebSocketServerRef
-import com.horizen.serialization.JsonHorizenPublicKeyHashSerializer
-import com.horizen.transaction.mainchain.SidechainCreation
-import scorex.core.network.NetworkController.ReceivableMessages.ShutdownNetwork
-import java.util.concurrent.atomic.AtomicBoolean
-
 import com.horizen.fork.{ForkConfigurator, ForkManager}
+import org.apache.logging.log4j.LogManager
 
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success, Try}
 
 
@@ -413,7 +402,7 @@ class SidechainApp @Inject()
 
   override val swaggerConfig: String = Source.fromResource("api/sidechainApi.yaml")(Codec.UTF8).getLines.mkString("\n")
 
-  val shutdownHookThread = new Thread() {
+  val shutdownHookThread = new Thread("ShutdownHook-Thread") {
     override def run(): Unit = {
       log.error("Unexpected shutdown")
       sidechainStopAll()
@@ -434,15 +423,28 @@ class SidechainApp @Inject()
 
     Http().bindAndHandle(combinedRoute, bindAddress.getAddress.getHostAddress, bindAddress.getPort)
 
-    //on unexpected shutdown
+    //Retrieve the list of all registered Shutdown hooks
+    val clazz = Class.forName("java.lang.ApplicationShutdownHooks")
+    val field = clazz.getDeclaredField("hooks")
+    field.setAccessible(true)
+    val hooks = field.get(null)
+
+    //Remove the Logger shutdown hook
+    val threadMap = hooks.asInstanceOf[JMap[Thread, Thread]].values()
+    threadMap.asScala.toArray.find(thread => thread.getName.equals("Logging-Cleaner")) match {
+      case Some(thread) =>
+        Runtime.getRuntime.removeShutdownHook(thread)
+      case None =>
+    }
+
+    //Add a new Shutdown hook that closes all the storages and stops all the interfaces and actors.
     Runtime.getRuntime.addShutdownHook(shutdownHookThread)
   }
 
   val stopAllInProgress : AtomicBoolean = new AtomicBoolean(false)
 
   // this method does not override stopAll(), but it rewrites part of its contents
-  def sidechainStopAll(): Unit = synchronized {
-
+  def sidechainStopAll(fromEndpoint: Boolean = false): Unit = synchronized {
     val currentThreadId     = Thread.currentThread().getId()
     val shutdownHookThreadId = shutdownHookThread.getId()
 
@@ -460,16 +462,20 @@ class SidechainApp @Inject()
     networkControllerRef ! ShutdownNetwork
 
     log.info("Stopping actors")
-    actorSystem.terminate().onComplete { _ =>
-      synchronized {
-        log.info("Calling custom application stopAll...")
-        applicationStopper.stopAll()
+    actorSystem.terminate()
+    Await.result(actorSystem.whenTerminated, Duration(5, TimeUnit.SECONDS))
 
-        log.info("Closing all data storages...")
-        storageList.foreach(_.close())
+    synchronized {
+      log.info("Calling custom application stopAll...")
+      applicationStopper.stopAll()
 
-        log.info("Exiting from the app...")
-        System.out.println("SidechainApp is calling exit()...")
+      log.info("Closing all data storages...")
+      storageList.foreach(_.close())
+
+      log.info("Shutdown the logger...")
+      LogManager.shutdown()
+
+      if(fromEndpoint) {
         System.exit(0)
       }
     }

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainNodeApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainNodeApiRoute.scala
@@ -129,7 +129,7 @@ case class SidechainNodeApiRoute(peerManager: ActorRef,
             log.info("Stop command triggered...")
             sleep(500)
             log.info("Calling core application stop...")
-            app.sidechainStopAll()
+            app.sidechainStopAll(true)
             log.info("... core application stop returned")
           }
         } ).start()


### PR DESCRIPTION
## Description
This PR fixes the issue that causes the Node to not terminate correctly in case of an unexpected shutdown.

## Jira Ticket
[221](https://horizenlabs.atlassian.net/jira/software/c/projects/SDK/boards/14?modal=detail&selectedIssue=SDK-221&assignee=615f31c32f6aed0068c67291)

## Changes

- Removed the preloaded Log shutdown hook and added its termination inside our shutdown thread.
- Fixed the akka actors termination.

## Checks
- [✔] Project Builds
- [✔] Project passes unit tests
- [✔] Project passes integration tests (Python)
- [✘] Updated documentation accordingly
