### PR TITLE
Bloom filter implementation

### DIFF
--- a/sdk/src/main/java/com/horizen/account/api/rpc/types/EthereumReceiptView.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/types/EthereumReceiptView.java
@@ -40,7 +40,7 @@ public class EthereumReceiptView {
         gasUsed = Numeric.toHexStringWithPrefix(receipt.gasUsed());
         contractAddress = receipt.contractAddress().length != Account.ADDRESS_SIZE ? null : Numeric.toHexString(receipt.contractAddress());
         logs = receipt.deriveFullLogs().seq().toList();
-        logsBloom = Numeric.toHexString(receipt.consensusDataReceipt().logsBloom());
+        logsBloom = Numeric.toHexString(receipt.consensusDataReceipt().logsBloom().getBloomFilter());
         status = Numeric.prependHexPrefix(Integer.toHexString(receipt.consensusDataReceipt().status()));
         effectiveGasPrice = (tx.getGasPrice() != null) ? Numeric.toHexStringWithPrefix(tx.getGasPrice()) : null;
     }

--- a/sdk/src/main/scala/com/horizen/account/receipt/EthereumConsensusDataReceipt.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/EthereumConsensusDataReceipt.scala
@@ -271,6 +271,7 @@ object EthereumConsensusDataReceipt {
     var bloomFilter = Array.fill[Byte](256)(0)
 
     evmLog.foreach(log => {
+      bloomFilter = addDataToBloomFilter(bloomFilter, log.address.toBytes)
       log.topics.foreach(topic => {
         bloomFilter = addDataToBloomFilter(bloomFilter, topic.toBytes)
       })

--- a/sdk/src/main/scala/com/horizen/account/receipt/EthereumConsensusDataReceipt.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/EthereumConsensusDataReceipt.scala
@@ -101,8 +101,7 @@ case class EthereumConsensusDataReceipt(
     logsString = logsString.concat("}")
 
     var logsBloomStr = "null"
-    if (logsBloom != null)
-      logsBloomStr = BytesUtils.toHexString(logsBloom.getBloomFilter())
+    logsBloomStr = BytesUtils.toHexString(logsBloom.getBloomFilter())
 
     String.format(
       s"EthereumReceipt (receipt consensus data) { txType=$getTxType, status=$getStatus, cumGasUsed=$cumulativeGasUsed, logs=$logsString, logsBloom=$logsBloomStr}"

--- a/sdk/src/main/scala/com/horizen/account/receipt/EthereumConsensusDataReceipt.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/EthereumConsensusDataReceipt.scala
@@ -225,15 +225,6 @@ object EthereumConsensusDataReceipt {
     result
   }
 
-  def bytesToShort(byte1: Byte, byte2: Byte): Short = {
-    ByteBuffer
-      .allocate(2)
-      .order(ByteOrder.BIG_ENDIAN)
-      .put(byte1)
-      .put(byte2)
-      .getShort(0)
-  }
-
   def getBloomFilterValues(data: Array[Byte]) = {
     // Copy first 3 pairs of bytes to hashBuffer
     val hashBuffer = Keccak256.hash(data)
@@ -245,11 +236,20 @@ object EthereumConsensusDataReceipt {
 
     // Calculate byte indexes
     val i1 =
-      256 - ((bytesToShort(hashBuffer(0), hashBuffer(1)) & 0x7ff) >> 3) - 1
+      256 - ((BytesUtils.getShort(
+        Array[Byte](hashBuffer(0), hashBuffer(1)),
+        0
+      ) & 0x7ff) >> 3) - 1
     val i2 =
-      256 - ((bytesToShort(hashBuffer(2), hashBuffer(3)) & 0x7ff) >> 3) - 1
+      256 - ((BytesUtils.getShort(
+        Array[Byte](hashBuffer(2), hashBuffer(3)),
+        0
+      ) & 0x7ff) >> 3) - 1
     val i3 =
-      256 - ((bytesToShort(hashBuffer(4), hashBuffer(5)) & 0x7ff) >> 3) - 1
+      256 - ((BytesUtils.getShort(
+        Array[Byte](hashBuffer(4), hashBuffer(5)),
+        0
+      ) & 0x7ff) >> 3) - 1
 
     (i1, v1, i2, v2, i3, v3)
   }

--- a/sdk/src/main/scala/com/horizen/account/receipt/EthereumConsensusDataReceipt.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/EthereumConsensusDataReceipt.scala
@@ -6,9 +6,10 @@ import com.horizen.account.receipt.ReceiptTxType.ReceiptTxType
 import com.horizen.evm.interop.EvmLog
 import com.horizen.utils.BytesUtils
 import org.web3j.rlp._
+import scorex.crypto.hash.Keccak256
 
 import java.math.BigInteger
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, ByteOrder}
 import java.util
 import scala.collection.mutable.ListBuffer
 
@@ -36,7 +37,7 @@ case class EthereumConsensusDataReceipt(
   }
 
   require(transactionType >= 0 && transactionType <= ReceiptTxType.DynamicFeeTxType.id)
-  require(status == ReceiptStatus.SUCCESSFUL.id || status == ReceiptStatus.FAILED.id )
+  require(status == ReceiptStatus.SUCCESSFUL.id || status == ReceiptStatus.FAILED.id)
 
   def getTxType: ReceiptTxType = {
     transactionType match {
@@ -63,14 +64,14 @@ case class EthereumConsensusDataReceipt(
       case other: EthereumConsensusDataReceipt =>
         transactionType == other.transactionType &&
           status == other.status &&
-        cumulativeGasUsed.equals(other.cumulativeGasUsed) &&
+          cumulativeGasUsed.equals(other.cumulativeGasUsed) &&
           logs.toSet == other.logs.toSet
 
       case _ => false
     }
   }
 
-  override def hashCode: Int =  {
+  override def hashCode: Int = {
     var result = Integer.hashCode(transactionType)
     result = 31 * result + Integer.hashCode(status)
     result = 31 * result + cumulativeGasUsed.hashCode()
@@ -103,13 +104,12 @@ object ReceiptTxType extends Enumeration {
   val LegacyTxType, AccessListTxType, DynamicFeeTxType = Value
 }
 
-object EthereumConsensusDataReceipt{
+object EthereumConsensusDataReceipt {
 
   object ReceiptStatus extends Enumeration {
     type ReceiptStatus = Value
     val FAILED, SUCCESSFUL = Value
   }
-
 
 
   def decodeLegacy(rlpData: Array[Byte]): EthereumConsensusDataReceipt = {
@@ -188,54 +188,41 @@ object EthereumConsensusDataReceipt{
     result
   }
 
-  def createLogsBloom(receipt : Seq[EvmLog]): Array[Byte] = {
-    // we can create bloom filter out of a log or out of a receipt log list 
-    /* see: https://github.com/ethereum/go-ethereum/blob/55f914a1d764dac4bd37a48173092b1f5c3b186d/core/types/bloom9.go
-
-                // CreateBloom creates a bloom filter out of the give Receipts (+Logs)
-                func CreateBloom(receipts Receipts) Bloom {
-                    buf := make([]byte, 6)
-                    var bin Bloom
-                    for _, receipt := range receipts {
-                        for _, log := range receipt.Logs {
-                            bin.add(log.Address.Bytes(), buf)
-                            for _, b := range log.Topics {
-                                bin.add(b[:], buf)
-                            }
-                        }
-                    }
-                    return bin
-                }
-
-                // add is internal version of Add, which takes a scratch buffer for reuse (needs to be at least 6 bytes)
-                func (b *Bloom) add(d []byte, buf []byte) {
-                    i1, v1, i2, v2, i3, v3 := bloomValues(d, buf)
-                    b[i1] |= v1
-                    b[i2] |= v2
-                    b[i3] |= v3
-                }
-
-                // bloomValues returns the bytes (index-value pairs) to set for the given data
-                func bloomValues(data []byte, hashbuf []byte) (uint, byte, uint, byte, uint, byte) {
-                    sha := hasherPool.Get().(crypto.KeccakState)
-                    sha.Reset()
-                    sha.Write(data)
-                    sha.Read(hashbuf)
-                    hasherPool.Put(sha)
-                    // The actual bits to flip
-                    v1 := byte(1 << (hashbuf[1] & 0x7))
-                    v2 := byte(1 << (hashbuf[3] & 0x7))
-                    v3 := byte(1 << (hashbuf[5] & 0x7))
-                    // The indices for the bytes to OR in
-                    i1 := BloomByteLength - uint((binary.BigEndian.Uint16(hashbuf)&0x7ff)>>3) - 1
-                    i2 := BloomByteLength - uint((binary.BigEndian.Uint16(hashbuf[2:])&0x7ff)>>3) - 1
-                    i3 := BloomByteLength - uint((binary.BigEndian.Uint16(hashbuf[4:])&0x7ff)>>3) - 1
-
-                    return i1, v1, i2, v2, i3, v3
-                }
-
-             */
-    // TODO shall we use libevm implementation?
-    new Array[Byte](256)
+  def bytesToShort(byte1: Byte, byte2: Byte): Short = {
+    ByteBuffer
+      .allocate(2)
+      .order(ByteOrder.BIG_ENDIAN)
+      .put(byte1)
+      .put(byte2)
+      .getShort(0)
   }
+
+  def getBloomFilterValues(data: Array[Byte]) = {
+    // Copy first 3 pairs of bytes to hashBuffer
+    val hashBuffer = Keccak256.hash(data)
+    println(String.format("%02x", Byte.box(hashBuffer(1))))
+
+    // Calculate byte values
+    val v1 = 1 << (hashBuffer(1) & 0x7)
+    val v2 = 1 << (hashBuffer(3) & 0x7)
+    val v3 = 1 << (hashBuffer(5) & 0x7)
+
+    // Calculate byte indexes
+    val i1 = 256 - ((bytesToShort(hashBuffer(0), hashBuffer(1)) & 0x7ff) >> 3) - 1
+    val i2 = 256 - ((bytesToShort(hashBuffer(2), hashBuffer(3)) & 0x7ff) >> 3) - 1
+    val i3 = 256 - ((bytesToShort(hashBuffer(4), hashBuffer(5)) & 0x7ff) >> 3) - 1
+
+    (i1, v1, i2, v2, i3, v3)
+  }
+
+  def addDataToBloomFilter(bloomFilter: Array[Byte], data: Array[Byte]): Array[Byte] = {
+    val (i1, v1, i2, v2, i3, v3) = getBloomFilterValues(data)
+
+    bloomFilter(i1) = (bloomFilter(i1) | v1).toByte
+    bloomFilter(i2) = (bloomFilter(i2) | v2).toByte
+    bloomFilter(i3) = (bloomFilter(i3) | v3).toByte
+
+    bloomFilter
+  }
+
 }

--- a/sdk/src/main/scala/com/horizen/account/receipt/EthereumReceipt.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/EthereumReceipt.scala
@@ -95,10 +95,6 @@ object EthereumReceiptSerializer extends ScorexSerializer[EthereumReceipt]{
     for (log <- receipt.consensusDataReceipt.logs)
       EvmLogUtils.serialize(log, writer)
 
-    val bloomBytes: Array[Byte] = receipt.consensusDataReceipt.logsBloom.getBloomFilter()
-    writer.putInt(bloomBytes.length)
-    writer.putBytes(bloomBytes)
-
     // non consensus data
     writer.putBytes(receipt.transactionHash)
     writer.putInt(receipt.transactionIndex)

--- a/sdk/src/main/scala/com/horizen/account/receipt/EthereumReceipt.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/EthereumReceipt.scala
@@ -122,10 +122,7 @@ object EthereumReceiptSerializer extends ScorexSerializer[EthereumReceipt]{
     for (_ <- 0 until numberOfLogs)
       logs += EvmLogUtils.parse(reader)
 
-    val bloomsLength: Int = reader.getInt
-    val blooms: Array[Byte] = reader.getBytes(bloomsLength)
-
-    val receipt: EthereumConsensusDataReceipt = EthereumConsensusDataReceipt(transactionType, status, cumGasUsed, logs, new LogsBloom(blooms))
+    val receipt: EthereumConsensusDataReceipt = new EthereumConsensusDataReceipt(transactionType, status, cumGasUsed, logs)
 
     val txHash: Array[Byte] = reader.getBytes(32)
     val txIndex: Int = reader.getInt

--- a/sdk/src/main/scala/com/horizen/account/receipt/EthereumReceipt.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/EthereumReceipt.scala
@@ -95,7 +95,7 @@ object EthereumReceiptSerializer extends ScorexSerializer[EthereumReceipt]{
     for (log <- receipt.consensusDataReceipt.logs)
       EvmLogUtils.serialize(log, writer)
 
-    val bloomBytes: Array[Byte] = receipt.consensusDataReceipt.logsBloom
+    val bloomBytes: Array[Byte] = receipt.consensusDataReceipt.logsBloom.getBloomFilter()
     writer.putInt(bloomBytes.length)
     writer.putBytes(bloomBytes)
 
@@ -129,7 +129,7 @@ object EthereumReceiptSerializer extends ScorexSerializer[EthereumReceipt]{
     val bloomsLength: Int = reader.getInt
     val blooms: Array[Byte] = reader.getBytes(bloomsLength)
 
-    val receipt: EthereumConsensusDataReceipt = EthereumConsensusDataReceipt(transactionType, status, cumGasUsed, logs, blooms)
+    val receipt: EthereumConsensusDataReceipt = EthereumConsensusDataReceipt(transactionType, status, cumGasUsed, logs, new LogsBloom(blooms))
 
     val txHash: Array[Byte] = reader.getBytes(32)
     val txIndex: Int = reader.getInt

--- a/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
@@ -1,0 +1,96 @@
+package com.horizen.account.receipt
+
+import scorex.crypto.hash.Keccak256
+
+import com.horizen.account.receipt.LogsBloom.BLOOM_FILTER_LENGTH
+import com.horizen.evm.interop.EvmLog
+import com.horizen.utils.BytesUtils
+
+class LogsBloom() {
+  private var bloomFilter = Array.fill[Byte](BLOOM_FILTER_LENGTH)(0)
+
+  def this(bloomFilter: Array[Byte]) = {
+    this()
+
+    require(bloomFilter.length == BLOOM_FILTER_LENGTH)
+    this.bloomFilter = bloomFilter
+  }
+
+  def addLogToBloomFilter(log: EvmLog): Unit = {
+    addBytesToBloomFilter(log.address.toBytes)
+    log.topics.foreach(topic => addBytesToBloomFilter(topic.toBytes))
+  }
+
+  def addBytesToBloomFilter(
+      data: Array[Byte]
+  ): Unit = {
+    val (bloomFilterIndexes, bloomFilterValues) = getBloomFilterValues(data)
+
+    bloomFilterIndexes.zipWithIndex
+      .foreach({ case (bloomFilterIndex, i) =>
+        bloomFilter(bloomFilterIndex) |= bloomFilterValues(i)
+      })
+  }
+
+  def contains(data: Array[Byte]): Boolean = {
+    val (dataIndexes, dataValues) = getBloomFilterValues(data)
+
+    dataIndexes.zipWithIndex.foreach({ case (dataIndex, i) =>
+      if (bloomFilter(dataIndex) != dataValues(i)) {
+        return false
+      }
+    })
+
+    true
+  }
+
+  private def getBloomFilterValues(
+      data: Array[Byte]
+  ): (Array[Int], Array[Int]) = {
+    val hashBuffer = Keccak256.hash(data)
+
+    val bloomFilterValues: Array[Int] =
+      Array(1, 3, 5).map(e => 1 << (hashBuffer(e) & 0x7))
+
+    val bloomFilterIndexes: Array[Int] = Array((0, 1), (2, 3), (4, 5)).map(e =>
+      BLOOM_FILTER_LENGTH - ((BytesUtils.getShort(
+        Array[Byte](hashBuffer(e._1), hashBuffer(e._2)),
+        0
+      ) & 0x7ff) >> 3) - 1
+    )
+
+    (bloomFilterIndexes, bloomFilterValues)
+  }
+
+  def getBloomFilter(): Array[Byte] = {
+    bloomFilter
+  }
+}
+
+object LogsBloom {
+  val BLOOM_FILTER_LENGTH = 256
+
+  def fromEvmLog(evmLogs: Seq[EvmLog]): LogsBloom = {
+    val logsBloom = new LogsBloom()
+
+    evmLogs.foreach(log => {
+      logsBloom.addLogToBloomFilter(log)
+    })
+
+    logsBloom
+  }
+
+  def fromEthereumReceipt(
+      ethereumReceipts: Seq[EthereumReceipt]
+  ): LogsBloom = {
+    val logsBloom = new LogsBloom()
+
+    ethereumReceipts.foreach(receipt => {
+      receipt.consensusDataReceipt.logs.foreach(log => {
+        logsBloom.addLogToBloomFilter(log)
+      })
+    })
+
+    logsBloom
+  }
+}

--- a/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
@@ -57,16 +57,25 @@ class LogsBloom() {
       data: Array[Byte]
   ): (Array[Int], Array[Int]) = {
     val hashBuffer = Keccak256.hash(data)
+    val bloomFilterIndexes : Array[Int] = new Array[Int](3)
+
+    bloomFilterIndexes(0) = BLOOM_FILTER_LENGTH - ((BytesUtils.getShort(
+      Array[Byte](hashBuffer(0), hashBuffer(1)),
+      0
+    ) & 0x7ff) >> 3) - 1
+
+    bloomFilterIndexes(1) = BLOOM_FILTER_LENGTH - ((BytesUtils.getShort(
+      Array[Byte](hashBuffer(2), hashBuffer(3)),
+      0
+    ) & 0x7ff) >> 3) - 1
+
+    bloomFilterIndexes(2) = BLOOM_FILTER_LENGTH - ((BytesUtils.getShort(
+      Array[Byte](hashBuffer(4), hashBuffer(5)),
+      0
+    ) & 0x7ff) >> 3) - 1
 
     val bloomFilterValues: Array[Int] =
       Array(1, 3, 5).map(e => 1 << (hashBuffer(e) & 0x7))
-
-    val bloomFilterIndexes: Array[Int] = Array((0, 1), (2, 3), (4, 5)).map(e =>
-      BLOOM_FILTER_LENGTH - ((BytesUtils.getShort(
-        Array[Byte](hashBuffer(e._1), hashBuffer(e._2)),
-        0
-      ) & 0x7ff) >> 3) - 1
-    )
 
     (bloomFilterIndexes, bloomFilterValues)
   }

--- a/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
@@ -28,7 +28,8 @@ class LogsBloom() {
 
     bloomFilterIndexes.zipWithIndex
       .foreach({ case (bloomFilterIndex, i) =>
-        bloomFilter(bloomFilterIndex) |= bloomFilterValues(i)
+        bloomFilter(bloomFilterIndex) =
+          (bloomFilter(bloomFilterIndex) | bloomFilterValues(i)).toByte
       })
   }
 

--- a/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
@@ -72,7 +72,7 @@ class LogsBloom() {
   }
 
   def getBloomFilter(): Array[Byte] = {
-    bloomFilter
+    bloomFilter.clone()
   }
 }
 

--- a/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
@@ -12,7 +12,7 @@ class LogsBloom() {
     this()
 
     require(bloomFilter.length == BLOOM_FILTER_LENGTH)
-    this.bloomFilter = bloomFilter
+    this.bloomFilter = bloomFilter.clone()
   }
 
   def addLogToBloomFilter(log: EvmLog): Unit = {
@@ -32,12 +32,12 @@ class LogsBloom() {
       })
   }
 
-  def setBytes(data: Array[Byte]): Unit = {
-    require(bloomFilter.length == BLOOM_FILTER_LENGTH)
+  def addBloomFilter(bloomFilter: LogsBloom): Unit = {
+    val bloomBytes = bloomFilter.getBloomFilter()
 
-    bloomFilter.zipWithIndex
+    this.bloomFilter.zipWithIndex
       .foreach({ case (bloomByte, i) =>
-        bloomFilter(i) = (bloomByte | data(i)).toByte
+        this.bloomFilter(i) = (bloomByte | bloomBytes(i)).toByte
       })
   }
 

--- a/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
+++ b/sdk/src/main/scala/com/horizen/account/receipt/LogsBloom.scala
@@ -1,7 +1,6 @@
 package com.horizen.account.receipt
 
 import scorex.crypto.hash.Keccak256
-
 import com.horizen.account.receipt.LogsBloom.BLOOM_FILTER_LENGTH
 import com.horizen.evm.interop.EvmLog
 import com.horizen.utils.BytesUtils
@@ -33,11 +32,20 @@ class LogsBloom() {
       })
   }
 
+  def setBytes(data: Array[Byte]): Unit = {
+    require(bloomFilter.length == BLOOM_FILTER_LENGTH)
+
+    bloomFilter.zipWithIndex
+      .foreach({ case (bloomByte, i) =>
+        bloomFilter(i) = (bloomByte | data(i)).toByte
+      })
+  }
+
   def contains(data: Array[Byte]): Boolean = {
     val (dataIndexes, dataValues) = getBloomFilterValues(data)
 
     dataIndexes.zipWithIndex.foreach({ case (dataIndex, i) =>
-      if (bloomFilter(dataIndex) != dataValues(i)) {
+      if (bloomFilter(dataIndex).&(dataValues(i)) != dataValues(i)) {
         return false
       }
     })

--- a/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
@@ -1,0 +1,33 @@
+package com.horizen.account.receipt
+
+import com.horizen.account.receipt.EthereumConsensusDataReceipt.addDataToBloomFilter
+import com.horizen.utils.BytesUtils
+import org.junit.Assert._
+import org.junit._
+import org.scalatestplus.junit.JUnitSuite
+import org.scalatestplus.mockito._
+
+class EthereumConsensusDataReceiptTest
+  extends JUnitSuite
+    with MockitoSugar
+    with ReceiptFixture
+{
+
+  @Test def bloomFilterTest(): Unit = {
+    val BLOOM_FILTER_LENGTH = 256
+    var bloomFilter = Array.fill[Byte](BLOOM_FILTER_LENGTH)(0)
+    val data = BytesUtils.fromHexString("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+
+    bloomFilter = addDataToBloomFilter(bloomFilter, data)
+
+    val bloomFilterExpected = Array.fill[Byte](BLOOM_FILTER_LENGTH)(0)
+    bloomFilterExpected(75) = 0x8
+    bloomFilterExpected(195) = 0x2
+    bloomFilterExpected(123) = 0x10
+
+    assertEquals(bloomFilter, bloomFilterExpected)
+  }
+
+}
+
+

--- a/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
@@ -40,7 +40,7 @@ class EthereumConsensusDataReceiptTest
     negative.foreach(s => assert(!bloomLog.contains(s.getBytes())))
 
     val bloomLog2 = new LogsBloom()
-    bloomLog2.setBytes(bloomLog.getBloomFilter())
+    bloomLog2.addBloomFilter(bloomLog)
 
     positive.foreach(s => assert(bloomLog2.contains(s.getBytes())))
     negative.foreach(s => assert(!bloomLog2.contains(s.getBytes())))
@@ -63,7 +63,7 @@ class EthereumConsensusDataReceiptTest
     assertArrayEquals(exp, bloomFilterHash)
 
     val bloomLog2 = new LogsBloom()
-    bloomLog2.setBytes(bloomLog.getBloomFilter())
+    bloomLog2.addBloomFilter(bloomLog)
 
     val bloomFilterHash2 = Keccak256.hash(bloomLog2.getBloomFilter())
     assertArrayEquals(bloomFilterHash, bloomFilterHash2)

--- a/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
@@ -1,6 +1,5 @@
 package com.horizen.account.receipt
 
-import com.horizen.account.receipt.EthereumConsensusDataReceipt.addDataToBloomFilter
 import com.horizen.utils.BytesUtils
 import org.junit.Assert._
 import org.junit._
@@ -13,20 +12,19 @@ class EthereumConsensusDataReceiptTest
     with ReceiptFixture {
 
   @Test def bloomFilterTest(): Unit = {
-    val BLOOM_FILTER_LENGTH = 256
-    var bloomFilter = Array.fill[Byte](BLOOM_FILTER_LENGTH)(0)
     val data = BytesUtils.fromHexString(
       "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
     )
 
-    bloomFilter = addDataToBloomFilter(bloomFilter, data)
+    val bloomLogs = new LogsBloom()
+    bloomLogs.addBytesToBloomFilter(data)
 
-    val bloomFilterExpected = Array.fill[Byte](BLOOM_FILTER_LENGTH)(0)
+    val bloomFilterExpected = Array.fill[Byte](LogsBloom.BLOOM_FILTER_LENGTH)(0)
     bloomFilterExpected(75) = 0x8
     bloomFilterExpected(195) = 0x2
     bloomFilterExpected(123) = 0x10
 
-    assertArrayEquals(bloomFilter, bloomFilterExpected)
+    assertArrayEquals(bloomLogs.getBloomFilter(), bloomFilterExpected)
   }
 
 }

--- a/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
@@ -8,15 +8,16 @@ import org.scalatestplus.junit.JUnitSuite
 import org.scalatestplus.mockito._
 
 class EthereumConsensusDataReceiptTest
-  extends JUnitSuite
+    extends JUnitSuite
     with MockitoSugar
-    with ReceiptFixture
-{
+    with ReceiptFixture {
 
   @Test def bloomFilterTest(): Unit = {
     val BLOOM_FILTER_LENGTH = 256
     var bloomFilter = Array.fill[Byte](BLOOM_FILTER_LENGTH)(0)
-    val data = BytesUtils.fromHexString("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+    val data = BytesUtils.fromHexString(
+      "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+    )
 
     bloomFilter = addDataToBloomFilter(bloomFilter, data)
 
@@ -25,9 +26,7 @@ class EthereumConsensusDataReceiptTest
     bloomFilterExpected(195) = 0x2
     bloomFilterExpected(123) = 0x10
 
-    assertEquals(bloomFilter, bloomFilterExpected)
+    assertArrayEquals(bloomFilter, bloomFilterExpected)
   }
 
 }
-
-

--- a/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
@@ -1,5 +1,6 @@
 package com.horizen.account.receipt
 
+import com.horizen.account.receipt.LogsBloom.BLOOM_FILTER_LENGTH
 import com.horizen.utils.BytesUtils
 import org.junit.Assert._
 import org.junit._
@@ -66,6 +67,13 @@ class EthereumConsensusDataReceiptTest
 
     val bloomFilterHash2 = Keccak256.hash(bloomLog2.getBloomFilter())
     assertArrayEquals(bloomFilterHash, bloomFilterHash2)
+  }
+
+  @Test def bloomFilterEmptyTest(): Unit = {
+    val bloomLog = new LogsBloom()
+    val bloomFilter = bloomLog.getBloomFilter()
+
+    assertArrayEquals(bloomFilter, Array.fill[Byte](BLOOM_FILTER_LENGTH)(0))
   }
 
 }

--- a/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/EthereumConsensusDataReceiptTest.scala
@@ -5,6 +5,7 @@ import org.junit.Assert._
 import org.junit._
 import org.scalatestplus.junit.JUnitSuite
 import org.scalatestplus.mockito._
+import scorex.crypto.hash.Keccak256
 
 class EthereumConsensusDataReceiptTest
     extends JUnitSuite
@@ -25,6 +26,46 @@ class EthereumConsensusDataReceiptTest
     bloomFilterExpected(123) = 0x10
 
     assertArrayEquals(bloomLogs.getBloomFilter(), bloomFilterExpected)
+  }
+
+  @Test def bloomFilterGethTest(): Unit = {
+    val positive = Array("testtest", "test", "hallo", "other")
+    val negative = Array("tes", "lo")
+
+    val bloomLog = new LogsBloom()
+
+    positive.foreach(s => bloomLog.addBytesToBloomFilter(s.getBytes()))
+    positive.foreach(s => assert(bloomLog.contains(s.getBytes())))
+    negative.foreach(s => assert(!bloomLog.contains(s.getBytes())))
+
+    val bloomLog2 = new LogsBloom()
+    bloomLog2.setBytes(bloomLog.getBloomFilter())
+
+    positive.foreach(s => assert(bloomLog2.contains(s.getBytes())))
+    negative.foreach(s => assert(!bloomLog2.contains(s.getBytes())))
+
+    val bloomLog3 = new LogsBloom()
+
+    positive.foreach(s => assert(!bloomLog3.contains(s.getBytes())))
+    negative.foreach(s => assert(!bloomLog3.contains(s.getBytes())))
+  }
+
+  @Test def bloomFilterGethExtensiveTest(): Unit = {
+    val exp = BytesUtils.fromHexString("c8d3ca65cdb4874300a9e39475508f23ed6da09fdbc487f89a2dcf50b09eb263")
+    val bloomLog = new LogsBloom()
+
+    for(i <- 0 until 100) {
+      bloomLog.addBytesToBloomFilter(s"xxxxxxxxxx data $i yyyyyyyyyyyyyy".getBytes())
+    }
+
+    val bloomFilterHash = Keccak256.hash(bloomLog.getBloomFilter())
+    assertArrayEquals(exp, bloomFilterHash)
+
+    val bloomLog2 = new LogsBloom()
+    bloomLog2.setBytes(bloomLog.getBloomFilter())
+
+    val bloomFilterHash2 = Keccak256.hash(bloomLog2.getBloomFilter())
+    assertArrayEquals(bloomFilterHash, bloomFilterHash2)
   }
 
 }

--- a/sdk/src/test/scala/com/horizen/account/receipt/EthereumReceiptTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/EthereumReceiptTest.scala
@@ -185,9 +185,8 @@ class EthereumReceiptTest
       val txType = i % 3
       val cumGas = BigInteger.valueOf(i).multiply(BigInteger.TEN.pow(3))
       //println("cumGas =" + cumGas.toString())
-      val logsBloom = new Array[Byte](256)
       val logs = new ListBuffer[EvmLog]
-      receipts(i) = new EthereumConsensusDataReceipt(txType, status, cumGas, logs,new LogsBloom(logsBloom))
+      receipts(i) = new EthereumConsensusDataReceipt(txType, status, cumGas, logs)
       //println("i=" + i + receipts[i].toString())
     }
     receipts.toSeq

--- a/sdk/src/test/scala/com/horizen/account/receipt/EthereumReceiptTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/EthereumReceiptTest.scala
@@ -187,7 +187,7 @@ class EthereumReceiptTest
       //println("cumGas =" + cumGas.toString())
       val logsBloom = new Array[Byte](256)
       val logs = new ListBuffer[EvmLog]
-      receipts(i) = new EthereumConsensusDataReceipt(txType, status, cumGas, logs, logsBloom)
+      receipts(i) = new EthereumConsensusDataReceipt(txType, status, cumGas, logs,new LogsBloom(logsBloom))
       //println("i=" + i + receipts[i].toString())
     }
     receipts.toSeq

--- a/sdk/src/test/scala/com/horizen/account/receipt/LogsBloomTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/LogsBloomTest.scala
@@ -8,7 +8,7 @@ import org.scalatestplus.junit.JUnitSuite
 import org.scalatestplus.mockito._
 import scorex.crypto.hash.Keccak256
 
-class EthereumConsensusDataReceiptTest
+class LogsBloomTest
     extends JUnitSuite
     with MockitoSugar
     with ReceiptFixture {

--- a/sdk/src/test/scala/com/horizen/account/receipt/ReceiptFixture.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/ReceiptFixture.scala
@@ -42,7 +42,7 @@ trait ReceiptFixture {
     } else {
       new Array[Byte](0)
     }
-    val consensusDataReceipt = new EthereumConsensusDataReceipt(txType, 1, BigInteger.valueOf(1000), logs, new Array[Byte](256))
+    val consensusDataReceipt = new EthereumConsensusDataReceipt(txType, 1, BigInteger.valueOf(1000), logs, new LogsBloom())
     val receipt = EthereumReceipt(consensusDataReceipt,
       txHash, 33, Keccak256.hash("blockhash".getBytes).asInstanceOf[Array[Byte]], 22,
       BigInteger.valueOf(1234567),
@@ -57,7 +57,7 @@ trait ReceiptFixture {
     val logs = new ListBuffer[EvmLog]
     for (_ <- 1 to num_logs)
       logs += createTestEvmLog
-    new EthereumConsensusDataReceipt(txType, 1, BigInteger.valueOf(1000), logs, new Array[Byte](256))
+    new EthereumConsensusDataReceipt(txType, 1, BigInteger.valueOf(1000), logs, new LogsBloom())
   }
 
 }

--- a/sdk/src/test/scala/com/horizen/account/receipt/ReceiptFixture.scala
+++ b/sdk/src/test/scala/com/horizen/account/receipt/ReceiptFixture.scala
@@ -42,7 +42,7 @@ trait ReceiptFixture {
     } else {
       new Array[Byte](0)
     }
-    val consensusDataReceipt = new EthereumConsensusDataReceipt(txType, 1, BigInteger.valueOf(1000), logs, new LogsBloom())
+    val consensusDataReceipt = new EthereumConsensusDataReceipt(txType, 1, BigInteger.valueOf(1000), logs)
     val receipt = EthereumReceipt(consensusDataReceipt,
       txHash, 33, Keccak256.hash("blockhash".getBytes).asInstanceOf[Array[Byte]], 22,
       BigInteger.valueOf(1234567),
@@ -57,7 +57,7 @@ trait ReceiptFixture {
     val logs = new ListBuffer[EvmLog]
     for (_ <- 1 to num_logs)
       logs += createTestEvmLog
-    new EthereumConsensusDataReceipt(txType, 1, BigInteger.valueOf(1000), logs, new LogsBloom())
+    new EthereumConsensusDataReceipt(txType, 1, BigInteger.valueOf(1000), logs)
   }
 
 }


### PR DESCRIPTION
Functions: 

- getBloomFilterValues - takes in an array of bytes, eg. a topic and returns byte indexes and values that the bytes should be set to in the bloom filter.
- addDataToBloomFilter - takes in a bloom filter instance and data, eg. a topic and returns a modified bloom filter array of bytes
- createBloomFilter - initializes an empty 256 size byte array and populates it based on the addresses from topics and topic data