### PR TITLE
[SDK-354] Optimized chainAfter method

### DIFF
--- a/sdk/src/main/scala/com/horizen/SidechainHistory.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainHistory.scala
@@ -190,7 +190,7 @@ class SidechainHistory private (val storage: SidechainHistoryStorage,
           // fork length is more than params.maxHistoryRewritingLength
           (Seq[ModifierId](), Seq[ModifierId]())
         else
-          (newBestChain, storage.activeChainAfter(newBestChain.head))
+          (newBestChain, storage.activeChainAfter(newBestChain.head, None))
 
       case None => (Seq[ModifierId](), Seq[ModifierId]())
     }
@@ -284,7 +284,7 @@ class SidechainHistory private (val storage: SidechainHistoryStorage,
   override def continuationIds(info: SidechainSyncInfo, size: Int): ModifierIds = {
     info.knownBlockIds.find(id => storage.isInActiveChain(id)) match {
       case Some(commonBlockId) =>
-        storage.activeChainAfter(commonBlockId).tail.take(size).map(id => (SidechainBlock.ModifierTypeId, id))
+        storage.activeChainAfter(commonBlockId, Some(size + 1)).tail.map(id => (SidechainBlock.ModifierTypeId, id))
       case None =>
         //log.warn("Found chain without common block ids from remote")
         Seq()

--- a/sdk/src/main/scala/com/horizen/SidechainHistory.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainHistory.scala
@@ -282,6 +282,8 @@ class SidechainHistory private (val storage: SidechainHistoryStorage,
 
 
   override def continuationIds(info: SidechainSyncInfo, size: Int): ModifierIds = {
+    if (size == Int.MaxValue)
+      throw new IllegalArgumentException("Can't ask for a number of blocks = Int.MaxInt!")
     info.knownBlockIds.find(id => storage.isInActiveChain(id)) match {
       case Some(commonBlockId) =>
         storage.activeChainAfter(commonBlockId, Some(size + 1)).tail.map(id => (SidechainBlock.ModifierTypeId, id))

--- a/sdk/src/main/scala/com/horizen/chain/ActiveChain.scala
+++ b/sdk/src/main/scala/com/horizen/chain/ActiveChain.scala
@@ -24,7 +24,7 @@ final class ActiveChain private(sidechainCache: ElementsChain[ModifierId, Sidech
 
   def contains(id: ModifierId): Boolean = sidechainCache.contains(id)
 
-  def chainAfter(id: ModifierId): Seq[ModifierId] = sidechainCache.chainAfter(id)
+  def chainAfter(id: ModifierId, limit: Option[Int]): Seq[ModifierId] = sidechainCache.chainAfter(id, limit)
 
   def blockInfoById(id: ModifierId): Option[SidechainBlockInfo] = sidechainCache.heightById(id).flatMap(sidechainCache.dataByHeight)
 

--- a/sdk/src/main/scala/com/horizen/chain/ElementsChain.scala
+++ b/sdk/src/main/scala/com/horizen/chain/ElementsChain.scala
@@ -86,7 +86,7 @@ class ElementsChain[ID, DATA <: LinkedElement[ID]](private var lastId: Option[ID
         currentHeight += 1
         res = res :+ dataByHeight(currentHeight).get.getParentId
       }
-      if (height - startHeight +1 <= blockLimit) {
+      if (res.size < blockLimit && currentHeight == height) {
         res = res :+ bestId.get
       }
       res

--- a/sdk/src/main/scala/com/horizen/chain/ElementsChain.scala
+++ b/sdk/src/main/scala/com/horizen/chain/ElementsChain.scala
@@ -71,16 +71,25 @@ class ElementsChain[ID, DATA <: LinkedElement[ID]](private var lastId: Option[ID
     lastId = Some(newId)
   }
 
-  def chainAfter(id: ID): Seq[ID] = {
+  def chainAfter(id: ID, limit: Option[Int]): Seq[ID] = {
     if (contains(id) && height > 0) {
       var res: Seq[ID] = Seq()
-
-      var currentHeight = heightById(id).get
-      while (currentHeight < height) {
+      val startHeight = heightById(id).get
+      var currentHeight = startHeight
+      val blockLimit = limit match {
+        case Some(number) =>
+          number
+        case None =>
+          height
+      }
+      while (currentHeight < height && res.size < blockLimit) {
         currentHeight += 1
         res = res :+ dataByHeight(currentHeight).get.getParentId
       }
-      res :+ bestId.get
+      if (height - startHeight +1 <= blockLimit) {
+        res = res :+ bestId.get
+      }
+      res
     }
     else {
       Seq()

--- a/sdk/src/main/scala/com/horizen/storage/SidechainHistoryStorage.scala
+++ b/sdk/src/main/scala/com/horizen/storage/SidechainHistoryStorage.scala
@@ -135,7 +135,7 @@ class SidechainHistoryStorage(storage: Storage, sidechainTransactionsCompanion: 
 
   def activeChainBlockId(height: Int): Option[ModifierId] = activeChain.idByHeight(height)
 
-  def activeChainAfter(blockId: ModifierId): Seq[ModifierId] = activeChain.chainAfter(blockId)
+  def activeChainAfter(blockId: ModifierId, limit: Option[Int]): Seq[ModifierId] = activeChain.chainAfter(blockId, limit)
 
   def getSidechainBlockContainingMainchainHeader(mainchainHeaderHash: Array[Byte]): Option[SidechainBlock] = {
     activeChain.idByMcHeader(byteArrayToMainchainHeaderHash(mainchainHeaderHash)).flatMap(blockById)

--- a/sdk/src/test/scala/com/horizen/chain/ActiveChainTest.scala
+++ b/sdk/src/test/scala/com/horizen/chain/ActiveChainTest.scala
@@ -61,7 +61,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     assertTrue("Empty ActiveChain expected not to find modifier for inconsistent height", chain.blockInfoByHeight(1).isEmpty)
     assertTrue("Empty ActiveChain expected not to find modifier id for inconsistent height", chain.idByHeight(0).isEmpty)
     assertTrue("Empty ActiveChain expected not to find modifier id for inconsistent height", chain.idByHeight(1).isEmpty)
-    assertTrue("Empty ActiveChain expected to return empty chain from nonexistent modifier", chain.chainAfter(getRandomModifier()).isEmpty)
+    assertTrue("Empty ActiveChain expected to return empty chain from nonexistent modifier", chain.chainAfter(getRandomModifier(), None).isEmpty)
 
     val randomMainchainHash: MainchainHeaderHash = generateMainchainHeaderHash(111L)
     assertTrue("Empty ActiveChain expected not to find height of nonexistent mainchain header", chain.mcHeadersHeightByMcHash(randomMainchainHash).isEmpty)
@@ -82,7 +82,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
                                     mainchainInitialHeight: Int,
                                     allMainchainReferences: Seq[MainchainHeaderHash] // TODO: in general we need to pass MainchainHeaders and RefData info separately
                                    ): Unit = {
-    assertTrue("Chain from shall not be empty for added element", chain.chainAfter(id).nonEmpty)
+    assertTrue("Chain from shall not be empty for added element", chain.chainAfter(id, None).nonEmpty)
     assertTrue("Element shall be present in chain", chain.contains(id))
     assertEquals("Data shall be reachable by height", data, chain.blockInfoByHeight(height).get)
     assertEquals("Data shall be reachable by id", data, chain.blockInfoById(id).get)
@@ -297,9 +297,9 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     assertTrue("ActiveChain expected to find modifier id for height 1", chain.idByHeight(1).isDefined)
     assertTrue("ActiveChain expected to find modifier id for chain current height", chain.idByHeight(chainHeight).isDefined)
 
-    assertTrue("ActiveChain expected to return empty chain from nonexistent modifier", chain.chainAfter(getRandomModifier()).isEmpty)
+    assertTrue("ActiveChain expected to return empty chain from nonexistent modifier", chain.chainAfter(getRandomModifier(), None).isEmpty)
 
-    var chainAfter: Seq[ModifierId] = chain.chainAfter(blockInfoData.head._1)
+    var chainAfter: Seq[ModifierId] = chain.chainAfter(blockInfoData.head._1, None)
     assertEquals("ActiveChain chainAfter expected to return chain with different height for first(genesis) modifier",
       blockInfoData.size, chainAfter.size)
     for(i <- chainAfter.indices)
@@ -307,14 +307,14 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
 
     val startingIndex = 3
-    chainAfter = chain.chainAfter(blockInfoData(startingIndex)._1)
+    chainAfter = chain.chainAfter(blockInfoData(startingIndex)._1, None)
     assertEquals("ActiveChain chainAfter expected to return chain with different height for 4th modifier",
       chainHeight - startingIndex, chainAfter.size)
     for(i <- chainAfter.indices)
       assertEquals("ActiveChain chainAfter item at index %d is different".format(i), blockInfoData(i + startingIndex)._1, chainAfter(i))
 
 
-    chainAfter = chain.chainAfter(blockInfoData.last._1)
+    chainAfter = chain.chainAfter(blockInfoData.last._1, None)
     assertEquals("ActiveChain chainAfter expected to return chain with size 1 for tip modifier", 1, chainAfter.size)
     assertEquals("ActiveChain chainAfter item at index 0 is different", blockInfoData.last._1, chainAfter.head)
   }
@@ -335,12 +335,12 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, firstId, firstData, 1, 0, mainchainDataAfterFirst)
     checkElementIsBest(chain, firstId, firstData, 1)
-    assertEquals("ChainFrom the beginning should contain just a tip", Seq(firstId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain just a tip", Seq(firstId), chain.chainAfter(firstId, None))
 
     // Try to add the same element second time
     addNewBestBlockShallBeFailed(chain, firstId, firstData, firstMainchainParent)
     checkElementIsBest(chain, firstId, firstData, 1)
-    assertEquals("ChainFrom the beginning should contain just a tip", Seq(firstId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain just a tip", Seq(firstId), chain.chainAfter(firstId, None))
 
     // Add second element
     val (secondId: ModifierId, secondData: SidechainBlockInfo, secondMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(firstId)
@@ -349,7 +349,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, secondId, secondData, 2, mainchainDataAfterFirst.size, mainchainDataAfterSecond)
     checkElementIsBest(chain, secondId, secondData, 2)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId), chain.chainAfter(firstId, None))
     checkElementIsNotBest(chain, firstId, firstData, 1)
 
     // Add third element
@@ -359,7 +359,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, thirdId, thirdData, 3, mainchainDataAfterSecond.size, mainchainDataAfterThird)
     checkElementIsBest(chain, thirdId, thirdData, 3)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId), chain.chainAfter(firstId, None))
     checkElementIsNotBest(chain, secondId, secondData, 2)
 
     // Add fourth element
@@ -368,7 +368,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     val mainchainDataAfterFourth = mainchainDataAfterThird ++ fourthData.mainchainHeaderHashes
 
     checkElementIsPresent(chain, fourthId, fourthData, 4, mainchainDataAfterThird.size, mainchainDataAfterFourth)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId, fourthId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId, fourthId), chain.chainAfter(firstId, None))
 
     //replace last element
     val (otherFourthId: ModifierId, otherFourthData: SidechainBlockInfo, otherFourthMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(thirdId)
@@ -377,7 +377,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, otherFourthId, otherFourthData, 4, mainchainDataAfterThird.size, mainchainDataAfterOtherFourth)
     checkElementIsNotPresent(chain, fourthId, fourthData, 4)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId, otherFourthId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId, otherFourthId), chain.chainAfter(firstId, None))
 
 
     // do fork on the second element and add element
@@ -388,7 +388,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     checkElementIsPresent(chain, otherThirdId, otherThirdData, 3, mainchainDataAfterSecond.size, mainchainDataAfterOtherThird)
     checkElementIsBest(chain, otherThirdId, otherThirdData, 3)
     checkElementIsNotPresent(chain, otherFourthId, otherFourthData, 4)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, otherThirdId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, otherThirdId), chain.chainAfter(firstId, None))
 
     val (afterThirdId: ModifierId, afterThirdData: SidechainBlockInfo, afterThirdMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(otherThirdId)
     addNewBestBlockIsSuccessful(chain, afterThirdId, afterThirdData, afterThirdMainchainParent)
@@ -396,14 +396,14 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, afterThirdId, afterThirdData, 4, mainchainDataAfterOtherThird.size, mainchainDataAfterAfterThird)
     checkElementIsBest(chain, afterThirdId, afterThirdData, 4)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, otherThirdId, afterThirdId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, otherThirdId, afterThirdId), chain.chainAfter(firstId, None))
 
     // try to add unconnected element
     val (unconnectedId: ModifierId, unconnectedData: SidechainBlockInfo, unconnectedMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(getRandomModifier())
     addNewBestBlockShallBeFailed(chain, unconnectedId, unconnectedData, unconnectedMainchainParent)
     checkElementIsPresent(chain, afterThirdId, afterThirdData, 4, mainchainDataAfterOtherThird.size, mainchainDataAfterAfterThird)
     checkElementIsBest(chain, afterThirdId, afterThirdData, 4)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, otherThirdId, afterThirdId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, otherThirdId, afterThirdId), chain.chainAfter(firstId, None))
   }
 
   @Test
@@ -443,13 +443,13 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, firstId, firstData, 1, 0, mainchainDataAfterFirst)
     checkElementIsBest(chain, firstId, firstData, 1)
-    assertEquals("ChainFrom the beginning should contain just a tip", Seq(firstId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain just a tip", Seq(firstId), chain.chainAfter(firstId, None))
 
     // Add second element
     val (secondId: ModifierId, secondData: SidechainBlockInfo, secondMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(firstId, Seq(generateMainchainBlockReference()))
     addNewBestBlockIsSuccessful(chain, secondId, secondData, secondMainchainParent)
     checkElementIsBest(chain, secondId, secondData, 2)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId), chain.chainAfter(firstId, None))
     val mainchainDataAfterSecond = mainchainDataAfterFirst ++ secondData.mainchainHeaderHashes
 
     // Add third element
@@ -458,7 +458,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     val mainchainDataAfterThird = mainchainDataAfterSecond ++ thirdData.mainchainHeaderHashes
     checkElementIsPresent(chain, thirdId, thirdData, 3, mainchainDataAfterSecond.size, mainchainDataAfterThird)
     checkElementIsBest(chain, thirdId, thirdData, 3)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId), chain.chainAfter(firstId))
+    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId), chain.chainAfter(firstId, None))
   }
 
   @Test

--- a/sdk/src/test/scala/com/horizen/chain/ElementsChainTest.scala
+++ b/sdk/src/test/scala/com/horizen/chain/ElementsChainTest.scala
@@ -85,7 +85,7 @@ class ElementsChainTest extends JUnitSuite {
     assertTrue("Empty ChainStorage expected not to find modifier for inconsistent height", chainStorage.dataByHeight(1).isEmpty)
     assertTrue("Empty ChainStorage expected not to find modifier id for inconsistent height", chainStorage.idByHeight(0).isEmpty)
     assertTrue("Empty ChainStorage expected not to find modifier id for inconsistent height", chainStorage.idByHeight(1).isEmpty)
-    assertTrue("Empty ChainStorage expected to return empty chain from nonexistent modifier", chainStorage.chainAfter(id).isEmpty)
+    assertTrue("Empty ChainStorage expected to return empty chain from nonexistent modifier", chainStorage.chainAfter(id, None).isEmpty)
     assertEquals("No parent shall be found for empty chain", None, chainStorage.parentOf(id))
   }
 
@@ -116,24 +116,31 @@ class ElementsChainTest extends JUnitSuite {
     checkAddNewBestBlockIsSuccessfully(chainStorage, id1, data1)
     checkStorageElementIsPresent(chainStorage, id1, data1, 1)
     checkBestElementIs(chainStorage, id1, data1, 1)
-    assertEquals("Chain from shall be equal", Seq(id1), chainStorage.chainAfter(id1))
+    assertEquals("Chain from shall be equal", Seq(id1), chainStorage.chainAfter(id1, None))
     assertEquals("Id shall be found for height 0", None, chainStorage.idByHeight(0))
 
     val (id2, data2) = dataGenerator.getNextData
     checkAddNewBestBlockIsSuccessfully(chainStorage, id2, data2)
     checkStorageElementIsPresent(chainStorage, id2, data2, 2)
     checkBestElementIs(chainStorage, id2, data2, 2)
-    assertEquals("Chain from shall be equal", Seq(id1, id2), chainStorage.chainAfter(id1))
+    assertEquals("Chain from shall be equal", Seq(id1, id2), chainStorage.chainAfter(id1, None))
 
     val (id3, data3) = dataGenerator.getNextData
     checkAddNewBestBlockIsSuccessfully(chainStorage, id3, data3)
-    assertEquals("Chain from shall be equal", Seq(id2, id3), chainStorage.chainAfter(id2))
+    assertEquals("Chain from shall be equal", Seq(id2, id3), chainStorage.chainAfter(id2, None))
 
     val (id4, data4) = dataGenerator.getNextData
     checkAddNewBestBlockIsSuccessfully(chainStorage, id4, data4)
     checkStorageElementIsPresent(chainStorage, id4, data4, 4)
     checkBestElementIs(chainStorage, id4, data4, 4)
-    assertEquals("Chain from shall be equal", Seq(id4), chainStorage.chainAfter(id4))
+    assertEquals("Chain from shall be equal", Seq(id4), chainStorage.chainAfter(id4, None))
+
+    //Test with only one block requested
+    assertEquals("Chain from shall be equal", Seq(id2), chainStorage.chainAfter(id2, Some(1)))
+    //Test by asking all the blocks
+    assertEquals("Chain from shall be equal", Seq(id3, id4), chainStorage.chainAfter(id3, Some(2)))
+    //Test by asking more than the maximum blocks
+    assertEquals("Chain from shall be equal", Seq(id3, id4), chainStorage.chainAfter(id3, Some(4)))
 
     val (newId4, newData4) = dataGenerator.setParentId(3).getNextData
     checkAddNewBestBlockIsSuccessfully(chainStorage, newId4, newData4)
@@ -141,7 +148,7 @@ class ElementsChainTest extends JUnitSuite {
     checkBestElementIsNot(chainStorage, id4, data4)
     checkStorageElementIsPresent(chainStorage, newId4, newData4, 4)
     checkBestElementIs(chainStorage, newId4, newData4, 4)
-    assertEquals("Chain from shall be equal", Seq(), chainStorage.chainAfter(id4))
+    assertEquals("Chain from shall be equal", Seq(), chainStorage.chainAfter(id4, None))
     assertEquals("Searching by predicate had been failed", Some(data3), chainStorage.getLastDataByPredicate(data => data.getParentId == data3.getParentId))
     assertEquals("Searching by predicate had been failed", Some(data2), chainStorage.getLastDataByPredicateTillHeight(2)(data => data.getParentId == data2.getParentId))
 

--- a/sdk/src/test/scala/com/horizen/integration/SidechainHistoryTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/SidechainHistoryTest.scala
@@ -499,7 +499,7 @@ class SidechainHistoryTest extends JUnitSuite
     var comparisonResult: History.HistoryComparisonResult = history2.compare(history1SyncInfo)
     assertEquals("History 1 chain expected to be older then history 2 chain", History.Older, comparisonResult)
     // Verify history2 continuationIds for history1 info
-    var continuationIds = history2.continuationIds(history1SyncInfo, Int.MaxValue)
+    var continuationIds = history2.continuationIds(history1SyncInfo, Int.MaxValue -1)
     assertTrue("History 2 continuation Ids for history 1 info expected to be empty.", continuationIds.isEmpty)
 
 
@@ -507,7 +507,7 @@ class SidechainHistoryTest extends JUnitSuite
     comparisonResult = history1.compare(history1SyncInfo)
     assertEquals("History 1 chain expected to equal to itself", History.Equal, comparisonResult)
     // Verify history1 continuationIds for its info
-    continuationIds = history1.continuationIds(history1SyncInfo, Int.MaxValue)
+    continuationIds = history1.continuationIds(history1SyncInfo, Int.MaxValue -1)
     assertTrue("History 1 continuation Ids for itself info expected to be empty.", continuationIds.isEmpty)
 
 
@@ -521,7 +521,7 @@ class SidechainHistoryTest extends JUnitSuite
     comparisonResult = history1.compare(history2SyncInfo)
     assertEquals("History 2 chain expected to be younger then history 1 chain", History.Younger, comparisonResult)
     // Verify history1 continuationIds for history2 info
-    continuationIds = history1.continuationIds(history2SyncInfo, Int.MaxValue)
+    continuationIds = history1.continuationIds(history2SyncInfo, Int.MaxValue -1)
     assertTrue("History 1 continuation Ids for history 2 info expected to be defined.", continuationIds.nonEmpty)
     assertEquals("History 1 continuation Ids for history 2 info expected to be with given size empty.", 1, continuationIds.size)
     assertEquals("History 1 continuation Ids for history 2 should contain different data.", history1blockSeq.last.id, continuationIds.head._2)
@@ -544,7 +544,7 @@ class SidechainHistoryTest extends JUnitSuite
     comparisonResult = history2.compare(history1SyncInfo)
     assertEquals("History 1 chain expected to be younger then history 2 chain", History.Fork, comparisonResult)
     // Verify history2 continuationIds for history1 info
-    continuationIds = history2.continuationIds(history1SyncInfo, Int.MaxValue)
+    continuationIds = history2.continuationIds(history1SyncInfo, Int.MaxValue -1)
     assertEquals("History 1 continuation Ids for history 2 info expected to be with given size empty.", 1, continuationIds.size)
     assertEquals("History 1 continuation Ids for history 2 should contain different data.", history2blockSeq.last.id, continuationIds.head._2)
 
@@ -560,7 +560,7 @@ class SidechainHistoryTest extends JUnitSuite
     comparisonResult = history2.compare(history1SyncInfo)
     assertEquals("History 1 chain expected to be equal then history 2 chain", History.Equal, comparisonResult)
     // Verify history2 continuationIds for history1 info
-    continuationIds = history2.continuationIds(history1SyncInfo, Int.MaxValue)
+    continuationIds = history2.continuationIds(history1SyncInfo, Int.MaxValue -1)
     assertEquals("History 1 continuation Ids for history 2 info expected to be with given size empty.", 1, continuationIds.size)
     assertEquals("History 1 continuation Ids for history 2 should contain different data.", history2blockSeq.last.id, continuationIds.head._2)
   }

--- a/sdk/src/test/scala/com/horizen/integration/storage/SidechainHistoryStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/storage/SidechainHistoryStorageTest.scala
@@ -59,7 +59,7 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertEquals("HistoryStorage different block info expected", genesisBlockInfo, historyStorage.blockInfoOptionById(genesisBlock.id).get)
     assertTrue("HistoryStorage genesis block expected to be a part of active chain", historyStorage.isInActiveChain(genesisBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", genesisBlock.id, historyStorage.activeChainBlockId(expectedHeight).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id), historyStorage.activeChainAfter(genesisBlock.id))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
 
 
     // Add one more block
@@ -76,7 +76,7 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertEquals("HistoryStorage different block expected", secondBlock.id, historyStorage.blockById(secondBlock.id).get.id)
     assertFalse("HistoryStorage next block expected NOT to be a part of active chain", historyStorage.isInActiveChain(secondBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", genesisBlock.id, historyStorage.activeChainBlockId(1).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id), historyStorage.activeChainAfter(genesisBlock.id))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
     assertEquals("HistoryStorage different semantic validity expected", ModifierSemanticValidity.Unknown, historyStorage.blockInfoOptionById(secondBlock.id).get.semanticValidity)
 
     // Update best block and validity -> active chain related data should change
@@ -91,7 +91,7 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertEquals("HistoryStorage different bestBlock expected", secondBlock.id, historyStorage.bestBlock.id)
     assertTrue("HistoryStorage block expected to be a part of active chain", historyStorage.isInActiveChain(secondBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", secondBlock.id, historyStorage.activeChainBlockId(expectedHeight).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, secondBlock.id), historyStorage.activeChainAfter(genesisBlock.id))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, secondBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
 
 
     // Add one more block
@@ -113,8 +113,8 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertEquals("HistoryStorage different bestBlock expected", thirdBlock.id, historyStorage.bestBlock.id)
     assertTrue("HistoryStorage block expected to be a part of active chain", historyStorage.isInActiveChain(thirdBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", thirdBlock.id, historyStorage.activeChainBlockId(expectedHeight).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, secondBlock.id, thirdBlock.id), historyStorage.activeChainAfter(genesisBlock.id))
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(secondBlock.id, thirdBlock.id), historyStorage.activeChainAfter(secondBlock.id))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, secondBlock.id, thirdBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(secondBlock.id, thirdBlock.id), historyStorage.activeChainAfter(secondBlock.id, None))
 
 
 
@@ -139,7 +139,7 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertTrue("HistoryStorage block expected to be a part of active chain", historyStorage.isInActiveChain(forkBlock.id))
     assertFalse("HistoryStorage block expected NOT to be a part of active chain", historyStorage.isInActiveChain(thirdBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", forkBlock.id, historyStorage.activeChainBlockId(expectedHeight).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, forkBlock.id), historyStorage.activeChainAfter(genesisBlock.id))
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(forkBlock.id), historyStorage.activeChainAfter(forkBlock.id))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, forkBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(forkBlock.id), historyStorage.activeChainAfter(forkBlock.id, None))
   }
 }

--- a/sdk/src/test/scala/com/horizen/storage/SidechainHistoryStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/storage/SidechainHistoryStorageTest.scala
@@ -345,13 +345,13 @@ class SidechainHistoryStorageTest extends JUnitSuite with MockitoSugar with Side
 
     // Test 11: get activeChainFrom
     // active chain from genesis block
-    assertEquals("Storage returned wrong active chain size", height, historyStorage.activeChainAfter(activeChainBlockList.head.id).size)
+    assertEquals("Storage returned wrong active chain size", height, historyStorage.activeChainAfter(activeChainBlockList.head.id, None).size)
     // active chain from 5th block
-    assertEquals("Storage returned wrong active chain size", height - 4, historyStorage.activeChainAfter(activeChainBlockList(4).id).size)
+    assertEquals("Storage returned wrong active chain size", height - 4, historyStorage.activeChainAfter(activeChainBlockList(4).id, None).size)
     // active chain last block id height
-    assertEquals("Storage returned wrong active chain size", 1, historyStorage.activeChainAfter(activeChainBlockList.last.id).size)
+    assertEquals("Storage returned wrong active chain size", 1, historyStorage.activeChainAfter(activeChainBlockList.last.id, None).size)
     // active chain from fork last block id
-    assertTrue("Storage active chain from forked block should be empty", historyStorage.activeChainAfter(forkChainBlockList.last.id).isEmpty)
+    assertTrue("Storage active chain from forked block should be empty", historyStorage.activeChainAfter(forkChainBlockList.last.id, None).isEmpty)
 
 
     // Test 12: get semanticValidity


### PR DESCRIPTION
## Description
Starting from an issue observed during the synchronization of the Explorer:

`scnode | [DEBUG] 2022-08-24 08:21:39:076 +0000 [Grizzly-worker(7)] com.horizen.websocket.server.WebSocketServerEndpoint - Error inside GET_NEW_BLOCK_HASHES websocket request: java. lang.Exception: java.util.concurrent.TimeoutException: Futures timed out after [5000 milliseconds]`

I've discovered that the function **chainAfter** was not optimized and it did scan the entire blockchain from a starting block height to the actual tip.
This means that when the explorer wants to sync the blockchain from scratch, this function iterate from the genesis block to the tip and this was not performed in time (5 seconds) and doesn't scale with the growth of the blockchain.
In order to solve this I've added an additional termination condition inside the function after a certain number of blocks.

## Jira Ticket
[354](https://horizenlabs.atlassian.net/jira/software/c/projects/SDK/boards/14?view=detail&selectedIssue=SDK-354&assignee=615f31c32f6aed0068c67291)

## Changes

- Optimized function **chainAfter**

## Checks
- [✔] Project Builds
- [✔] Project passes unit tests
- [✔] Project passes integration tests (Python)
- [✘] Updated documentation accordingly

