### PR TITLE
Gas refunds for fake contracts

### DIFF
--- a/libevm/lib/service_state_refund.go
+++ b/libevm/lib/service_state_refund.go
@@ -1,0 +1,61 @@
+package lib
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+	gethParams "github.com/ethereum/go-ethereum/params"
+)
+
+// setStateRefunds replicates the refund part of the original SSTORE gas consumption logic:
+//
+// 0. If *gasleft* is less than or equal to 2300, fail the current call.
+// 1. If current value equals new value (this is a no-op), SLOAD_GAS is deducted.
+// 2. If current value does not equal new value:
+//   2.1. If original value equals current value (this storage slot has not been changed by the current execution context):
+//     2.1.1. If original value is 0, SSTORE_SET_GAS (20K) gas is deducted.
+//     2.1.2. Otherwise, SSTORE_RESET_GAS gas is deducted. If new value is 0, add SSTORE_CLEARS_SCHEDULE to refund counter.
+//   2.2. If original value does not equal current value (this storage slot is dirty), SLOAD_GAS gas is deducted. Apply both of the following clauses:
+//     2.2.1. If original value is not 0:
+//       2.2.1.1. If current value is 0 (also means that new value is not 0), subtract SSTORE_CLEARS_SCHEDULE gas from refund counter.
+//       2.2.1.2. If new value is 0 (also means that current value is not 0), add SSTORE_CLEARS_SCHEDULE gas to refund counter.
+//     2.2.2. If original value equals new value (this storage slot is reset):
+//       2.2.2.1. If original value is 0, add SSTORE_SET_GAS - SLOAD_GAS to refund counter.
+//       2.2.2.2. Otherwise, add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter.
+func setStateRefunds(statedb *state.StateDB, address common.Address, key, value common.Hash) {
+	current := statedb.GetState(address, key)
+	// no change, no refund
+	if current == value {
+		return
+	}
+	original := statedb.GetCommittedState(address, key)
+	if original == current {
+		if original == (common.Hash{}) { // create slot (2.1.1)
+			return
+		}
+		if value == (common.Hash{}) { // delete slot (2.1.2b)
+			statedb.AddRefund(gethParams.SstoreClearsScheduleRefundEIP3529)
+			return
+		}
+		return // write existing slot (2.1.2)
+	}
+	if original != (common.Hash{}) {
+		if current == (common.Hash{}) { // recreate slot (2.2.1.1)
+			statedb.SubRefund(gethParams.SstoreClearsScheduleRefundEIP3529)
+		} else if value == (common.Hash{}) { // delete slot (2.2.1.2)
+			statedb.AddRefund(gethParams.SstoreClearsScheduleRefundEIP3529)
+		}
+	}
+	if original == value {
+		if original == (common.Hash{}) { // reset to original inexistent slot (2.2.2.1)
+			statedb.AddRefund(gethParams.SstoreSetGasEIP2200 - gethParams.WarmStorageReadCostEIP2929)
+		} else { // reset to original existing slot (2.2.2.2)
+			statedb.AddRefund((gethParams.SstoreResetGasEIP2200 - gethParams.ColdSloadCostEIP2929) - gethParams.WarmStorageReadCostEIP2929)
+		}
+	}
+	return // dirty update (2.2)
+}
+
+func (s *Service) setStateWithRefund(statedb *state.StateDB, address common.Address, key, value common.Hash) {
+	setStateRefunds(statedb, address, key, value)
+	statedb.SetState(address, key, value)
+}

--- a/libevm/lib/service_state_refund_test.go
+++ b/libevm/lib/service_state_refund_test.go
@@ -10,27 +10,26 @@ import (
 // test cases from EIP-3529:
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3529.md#with-reduced-refunds
 var refundTests = []struct {
-	original byte
-	values   []byte
+	sequence string
 	refund   uint64
 }{
-	{0, []byte{0, 0}, 0},        // 0 -> 0 -> 0
-	{0, []byte{0, 1}, 0},        // 0 -> 0 -> 1
-	{0, []byte{1, 0}, 19900},    // 0 -> 1 -> 0
-	{0, []byte{1, 2}, 0},        // 0 -> 1 -> 2
-	{0, []byte{1, 1}, 0},        // 0 -> 1 -> 1
-	{1, []byte{0, 0}, 4800},     // 1 -> 0 -> 0
-	{1, []byte{0, 1}, 2800},     // 1 -> 0 -> 1
-	{1, []byte{0, 2}, 0},        // 1 -> 0 -> 2
-	{1, []byte{2, 0}, 4800},     // 1 -> 2 -> 0
-	{1, []byte{2, 3}, 0},        // 1 -> 2 -> 3
-	{1, []byte{2, 1}, 2800},     // 1 -> 2 -> 1
-	{1, []byte{2, 2}, 0},        // 1 -> 2 -> 2
-	{1, []byte{1, 0}, 4800},     // 1 -> 1 -> 0
-	{1, []byte{1, 2}, 0},        // 1 -> 1 -> 2
-	{1, []byte{1, 1}, 0},        // 1 -> 1 -> 1
-	{0, []byte{1, 0, 1}, 19900}, // 0 -> 1 -> 0 -> 1
-	{1, []byte{0, 1, 0}, 7600},  // 1 -> 0 -> 1 -> 0
+	{"0x000000", 0},       // 0 -> 0 -> 0
+	{"0x000001", 0},       // 0 -> 0 -> 1
+	{"0x000100", 19900},   // 0 -> 1 -> 0
+	{"0x000102", 0},       // 0 -> 1 -> 2
+	{"0x000101", 0},       // 0 -> 1 -> 1
+	{"0x010000", 4800},    // 1 -> 0 -> 0
+	{"0x010001", 2800},    // 1 -> 0 -> 1
+	{"0x010002", 0},       // 1 -> 0 -> 2
+	{"0x010200", 4800},    // 1 -> 2 -> 0
+	{"0x010203", 0},       // 1 -> 2 -> 3
+	{"0x010201", 2800},    // 1 -> 2 -> 1
+	{"0x010202", 0},       // 1 -> 2 -> 2
+	{"0x010100", 4800},    // 1 -> 1 -> 0
+	{"0x010102", 0},       // 1 -> 1 -> 2
+	{"0x010101", 0},       // 1 -> 1 -> 1
+	{"0x00010001", 19900}, // 0 -> 1 -> 0 -> 1
+	{"0x01000100", 7600},  // 1 -> 0 -> 1 -> 0
 }
 
 func TestSetStateWithRefund(t *testing.T) {
@@ -40,28 +39,32 @@ func TestSetStateWithRefund(t *testing.T) {
 		key      = common.Hash{}
 	)
 	for i, tt := range refundTests {
-		var (
-			original   = common.BytesToHash([]byte{tt.original})
-			statedb, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-		)
+		// decode hex string to a list of values
+		var values []common.Hash
+		for _, value := range common.FromHex(tt.sequence) {
+			values = append(values, common.BytesToHash([]byte{value}))
+		}
+
+		// set and commit the first value
+		statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
 		statedb.CreateAccount(address)
-		statedb.SetState(address, key, original)
+		statedb.SetState(address, key, values[0])
 		// Push the state into the "original" slot
 		// note: we use "false" here because the test account would be removed otherwise as it is considered "empty",
 		// setting a "fake" code hash would also prevent that
 		statedb.Finalise(false)
 
 		// make sure the original value was properly committed
-		if originalTest := statedb.GetState(address, key); originalTest != original {
-			t.Errorf("test %d: failed to set original value:\nhave %v\nwant %v", i, originalTest, original)
+		if original := statedb.GetState(address, key); original != values[0] {
+			t.Errorf("test %d: failed to set original value:\nhave %v\nwant %v", i, original, values[0])
 		}
 
-		// write values in the order given
-		for _, v := range tt.values {
-			instance.setStateWithRefund(statedb, address, key, common.BytesToHash([]byte{v}))
+		// set all the remaining values in the order given
+		for _, value := range values[1:] {
+			instance.setStateWithRefund(statedb, address, key, value)
 		}
 
-		// verify refund is as expected
+		// verify the refund is as expected
 		if refund := statedb.GetRefund(); refund != tt.refund {
 			t.Errorf("test %d: gas refund mismatch: have %v, want %v", i, refund, tt.refund)
 		}

--- a/libevm/lib/service_state_refund_test.go
+++ b/libevm/lib/service_state_refund_test.go
@@ -1,0 +1,69 @@
+package lib
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"testing"
+)
+
+// test cases from EIP-3529:
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3529.md#with-reduced-refunds
+var refundTests = []struct {
+	original byte
+	values   []byte
+	refund   uint64
+}{
+	{0, []byte{0, 0}, 0},        // 0 -> 0 -> 0
+	{0, []byte{0, 1}, 0},        // 0 -> 0 -> 1
+	{0, []byte{1, 0}, 19900},    // 0 -> 1 -> 0
+	{0, []byte{1, 2}, 0},        // 0 -> 1 -> 2
+	{0, []byte{1, 1}, 0},        // 0 -> 1 -> 1
+	{1, []byte{0, 0}, 4800},     // 1 -> 0 -> 0
+	{1, []byte{0, 1}, 2800},     // 1 -> 0 -> 1
+	{1, []byte{0, 2}, 0},        // 1 -> 0 -> 2
+	{1, []byte{2, 0}, 4800},     // 1 -> 2 -> 0
+	{1, []byte{2, 3}, 0},        // 1 -> 2 -> 3
+	{1, []byte{2, 1}, 2800},     // 1 -> 2 -> 1
+	{1, []byte{2, 2}, 0},        // 1 -> 2 -> 2
+	{1, []byte{1, 0}, 4800},     // 1 -> 1 -> 0
+	{1, []byte{1, 2}, 0},        // 1 -> 1 -> 2
+	{1, []byte{1, 1}, 0},        // 1 -> 1 -> 1
+	{0, []byte{1, 0, 1}, 19900}, // 0 -> 1 -> 0 -> 1
+	{1, []byte{0, 1, 0}, 7600},  // 1 -> 0 -> 1 -> 0
+}
+
+func TestSetStateWithRefund(t *testing.T) {
+	var (
+		instance = New()
+		address  = common.BytesToAddress([]byte("contract"))
+		key      = common.Hash{}
+	)
+	for i, tt := range refundTests {
+		var (
+			original   = common.BytesToHash([]byte{tt.original})
+			statedb, _ = state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+		)
+		statedb.CreateAccount(address)
+		statedb.SetState(address, key, original)
+		// Push the state into the "original" slot
+		// note: we use "false" here because the test account would be removed otherwise as it is considered "empty",
+		// setting a "fake" code hash would also prevent that
+		statedb.Finalise(false)
+
+		// make sure the original value was properly committed
+		if originalTest := statedb.GetState(address, key); originalTest != original {
+			t.Errorf("test %d: failed to set original value:\nhave %v\nwant %v", i, originalTest, original)
+		}
+
+		// write values in the order given
+		for _, v := range tt.values {
+			instance.setStateWithRefund(statedb, address, key, common.BytesToHash([]byte{v}))
+		}
+
+		// verify refund is as expected
+		if refund := statedb.GetRefund(); refund != tt.refund {
+			t.Errorf("test %d: gas refund mismatch: have %v, want %v", i, refund, tt.refund)
+		}
+	}
+}


### PR DESCRIPTION
The EVM tracks gas refunds within the implementation of the SSTORE op-code, our fake smart contracts access StateDB directly and therefore bypass this logic.

This PR replicates the gas refund mechanic of SSTORE in our methods that write to account storage.