### PR TITLE
Automatic gas consumption for fake contracts

### DIFF
--- a/sdk/src/main/scala/com/horizen/account/state/AccountStateViewGasTracked.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/AccountStateViewGasTracked.scala
@@ -1,0 +1,137 @@
+package com.horizen.account.state
+
+import com.horizen.block.WithdrawalEpochCertificate
+import com.horizen.evm.ResourceHandle
+import com.horizen.evm.interop.EvmLog
+import com.horizen.utils.BlockFeeInfo
+
+import java.math.BigInteger
+
+/**
+ * Wrapper for AccountStateView to help with tracking gas consumption.
+ * @param view
+ *   instance of BaseAccountStateView
+ * @param gas
+ *   GasPool instance to deduct gas from
+ */
+class AccountStateViewGasTracked(view: BaseAccountStateView, gas: GasPool) extends BaseAccountStateView {
+  override def getStateDbHandle: ResourceHandle = view.getStateDbHandle
+
+  override def addAccount(address: Array[Byte], codeHash: Array[Byte]): Unit = view.addAccount(address, codeHash)
+
+  override def accountExists(address: Array[Byte]): Boolean = {
+    gas.subGas(GasUtil.ExtcodeHashGasEIP1884)
+    view.accountExists(address)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def isEoaAccount(address: Array[Byte]): Boolean = {
+    gas.subGas(GasUtil.ExtcodeHashGasEIP1884)
+    view.isEoaAccount(address)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def isSmartContractAccount(address: Array[Byte]): Boolean = {
+    gas.subGas(GasUtil.ExtcodeHashGasEIP1884)
+    view.isSmartContractAccount(address)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def getCodeHash(address: Array[Byte]): Array[Byte] = {
+    gas.subGas(GasUtil.ExtcodeHashGasEIP1884)
+    view.getCodeHash(address)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def getCode(address: Array[Byte]): Array[Byte] = {
+    gas.subGas(GasUtil.ExtcodeHashGasEIP1884)
+    view.getCode(address)
+  }
+
+  override def getNonce(address: Array[Byte]): BigInteger = view.getNonce(address)
+
+  override def increaseNonce(address: Array[Byte]): Unit = view.increaseNonce(address)
+
+  @throws(classOf[OutOfGasException])
+  override def getBalance(address: Array[Byte]): BigInteger = {
+    gas.subGas(GasUtil.BalanceGasEIP1884)
+    view.getBalance(address)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def addBalance(address: Array[Byte], amount: BigInteger): Unit = {
+    gas.subGas(GasUtil.BalanceGasEIP1884)
+    view.addBalance(address, amount)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def subBalance(address: Array[Byte], amount: BigInteger): Unit = {
+    gas.subGas(GasUtil.BalanceGasEIP1884)
+    view.subBalance(address, amount)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def getAccountStorage(address: Array[Byte], key: Array[Byte]): Array[Byte] = {
+    gas.subGas(GasUtil.GasTBD)
+    view.getAccountStorage(address, key)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def getAccountStorageBytes(address: Array[Byte], key: Array[Byte]): Array[Byte] = {
+    gas.subGas(GasUtil.GasTBD)
+    view.getAccountStorageBytes(address, key)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def updateAccountStorage(address: Array[Byte], key: Array[Byte], value: Array[Byte]): Unit = {
+    gas.subGas(GasUtil.GasTBD)
+    view.updateAccountStorage(address, key, value)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def updateAccountStorageBytes(address: Array[Byte], key: Array[Byte], value: Array[Byte]): Unit = {
+    gas.subGas(GasUtil.GasTBD)
+    view.updateAccountStorageBytes(address, key, value)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def removeAccountStorage(address: Array[Byte], key: Array[Byte]): Unit = {
+    gas.subGas(GasUtil.GasTBD)
+    view.removeAccountStorage(address, key)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def removeAccountStorageBytes(address: Array[Byte], key: Array[Byte]): Unit = {
+    gas.subGas(GasUtil.GasTBD)
+    view.removeAccountStorageBytes(address, key)
+  }
+
+  @throws(classOf[OutOfGasException])
+  override def addLog(evmLog: EvmLog): Unit = {
+    gas.subGas(GasUtil.logGas(evmLog))
+    view.addLog(evmLog)
+  }
+
+  override def getAccountStateRoot: Array[Byte] = view.getAccountStateRoot
+
+  override def getListOfForgerStakes: Seq[AccountForgingStakeInfo] = view.getListOfForgerStakes
+
+  override def getForgerStakeData(stakeId: String): Option[ForgerStakeData] = view.getForgerStakeData(stakeId)
+
+  override def getLogs(txHash: Array[Byte]): Array[EvmLog] = view.getLogs(txHash)
+
+  override def getIntermediateRoot: Array[Byte] = view.getIntermediateRoot
+
+  override def withdrawalRequests(withdrawalEpoch: Int): Seq[WithdrawalRequest] =
+    view.withdrawalRequests(withdrawalEpoch)
+
+  override def getFeePayments(withdrawalEpoch: Int): Seq[BlockFeeInfo] = view.getFeePayments(withdrawalEpoch)
+
+  override def certificate(referencedWithdrawalEpoch: Int): Option[WithdrawalEpochCertificate] =
+    view.certificate(referencedWithdrawalEpoch)
+
+  override def certificateTopQuality(referencedWithdrawalEpoch: Int): Long =
+    view.certificateTopQuality(referencedWithdrawalEpoch)
+
+  override def hasCeased: Boolean = view.hasCeased
+}

--- a/sdk/src/main/scala/com/horizen/account/state/BaseAccountStateView.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/BaseAccountStateView.scala
@@ -20,22 +20,12 @@ trait BaseAccountStateView extends AccountStateReader {
   @throws(classOf[ExecutionFailedException])
   def subBalance(address: Array[Byte], amount: BigInteger): Unit
 
-  @throws(classOf[OutOfGasException])
   def getAccountStorage(address: Array[Byte], key: Array[Byte]): Array[Byte]
-  @throws(classOf[OutOfGasException])
   def getAccountStorageBytes(address: Array[Byte], key: Array[Byte]): Array[Byte]
-  @throws(classOf[OutOfGasException])
   def updateAccountStorage(address: Array[Byte], key: Array[Byte], value: Array[Byte]): Unit
-  @throws(classOf[OutOfGasException])
   def updateAccountStorageBytes(address: Array[Byte], key: Array[Byte], value: Array[Byte]): Unit
-  @throws(classOf[OutOfGasException])
   def removeAccountStorage(address: Array[Byte], key: Array[Byte]): Unit
-  @throws(classOf[OutOfGasException])
   def removeAccountStorageBytes(address: Array[Byte], key: Array[Byte]): Unit
 
-  @throws(classOf[OutOfGasException])
   def addLog(evmLog: EvmLog): Unit
-
-  def enableGasTracking(gasPool: GasPool): Unit
-  def disableGasTracking(): Unit
 }

--- a/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
@@ -345,11 +345,11 @@ case class ForgerStakeMsgProcessor(params: NetworkParams) extends FakeSmartContr
 
   @throws(classOf[ExecutionFailedException])
   override def process(msg: Message, view: BaseAccountStateView, gas: GasPool, blockContext: BlockContext): Array[Byte] = {
-    view.enableGasTracking(gas)
+    val gasView = new AccountStateViewGasTracked(view, gas)
     getFunctionSignature(msg.getData) match {
-      case GetListOfForgersCmd => doGetListOfForgersCmd(msg, view)
-      case AddNewStakeCmd => doAddNewStakeCmd(msg, view)
-      case RemoveStakeCmd => doRemoveStakeCmd(msg, view)
+      case GetListOfForgersCmd => doGetListOfForgersCmd(msg, gasView)
+      case AddNewStakeCmd => doAddNewStakeCmd(msg, gasView)
+      case RemoveStakeCmd => doRemoveStakeCmd(msg, gasView)
       case opCodeHex => throw new ExecutionRevertedException(s"op code $opCodeHex not supported")
     }
   }

--- a/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
@@ -38,15 +38,15 @@ object WithdrawalMsgProcessor extends FakeSmartContractMsgProcessor with Withdra
   @throws(classOf[ExecutionFailedException])
   override def process(msg: Message, view: BaseAccountStateView, gas: GasPool, blockContext: BlockContext): Array[Byte] = {
     //TODO: check errors in Ethereum, maybe for some kind of errors there a predefined types or codes
-    view.enableGasTracking(gas)
+    val gasView = new AccountStateViewGasTracked(view, gas)
     getFunctionSignature(msg.getData) match {
       case GetListOfWithdrawalReqsCmdSig =>
         gas.subGas(GasSpentForGetListOfWithdrawalReqsCmd)
-        execGetListOfWithdrawalReqRecords(msg, view)
+        execGetListOfWithdrawalReqRecords(msg, gasView)
 
       case AddNewWithdrawalReqCmdSig =>
         gas.subGas(GasSpentForAddNewWithdrawalReqCmd)
-        execAddWithdrawalRequest(msg, view, blockContext.withdrawalEpochNumber)
+        execAddWithdrawalRequest(msg, gasView, blockContext.withdrawalEpochNumber)
 
       case functionSig =>
         throw new ExecutionRevertedException(s"Requested function does not exist. Function signature: $functionSig")

--- a/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
@@ -94,9 +94,13 @@ class ForgerStakeMsgProcessorTest
 
   def getForgerStakeList(stateView: AccountStateView): Array[Byte] = {
     val msg = getMessage(contractAddress, 0, BytesUtils.fromHexString(GetListOfForgersCmd), randomNonce)
-    val returnData = assertGas(2250) {
-      forgerStakeMessageProcessor.process(msg, stateView, _, defaultBlockContext)
+    val (returnData, usedGas) = withGas { gas =>
+      val result = forgerStakeMessageProcessor.process(msg, stateView, gas, defaultBlockContext)
+      (result, gas.getUsedGas)
     }
+    // gas consumption depends on the number of items in the list
+    assertTrue(usedGas.compareTo(0) > 0)
+    assertTrue(usedGas.compareTo(3000) < 0)
     assertNotNull(returnData)
     returnData
   }
@@ -203,7 +207,7 @@ class ForgerStakeMsgProcessorTest
       val msg = getMessage(contractAddress, validWeiAmount, BytesUtils.fromHexString(AddNewStakeCmd) ++ data, randomNonce)
 
       // positive case, verify we can add the stake to view
-      val returnData = assertGas(3500) {
+      val returnData = assertGas(4850) {
         forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext)
       }
       assertNotNull(returnData)
@@ -240,7 +244,7 @@ class ForgerStakeMsgProcessorTest
         ForgerStakeData(ForgerPublicKeys(blockSignerProposition, vrfPublicKey),
           ownerAddressProposition, validWeiAmount))
 
-      val returnData2 = assertGas(4000) {
+      val returnData2 = assertGas(5350) {
         forgerStakeMessageProcessor.process(msg2, view, _, defaultBlockContext)
       }
       assertNotNull(returnData2)
@@ -272,7 +276,7 @@ class ForgerStakeMsgProcessorTest
       view.setupTxContext(txHash4, 10)
 
       // try processing the removal of stake, should succeed
-      val returnData3 = assertGas(3125) {
+      val returnData3 = assertGas(4025) {
         forgerStakeMessageProcessor.process(msg3, view, _, defaultBlockContext)
       }
       assertNotNull(returnData3)
@@ -336,7 +340,7 @@ class ForgerStakeMsgProcessorTest
         data, randomNonce, validWeiAmount)
 
       // should fail because forger is not in the allowed list
-      assertGas(250) { gas =>
+      assertGas(700) { gas =>
         assertThrows[ExecutionFailedException] {
           forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
         }
@@ -445,7 +449,7 @@ class ForgerStakeMsgProcessorTest
         data, randomNonce, validWeiAmount)
 
       // should fail because staked amount is not a zat amount
-      assertGas(3250) { gas =>
+      assertGas(4150) { gas =>
         assertThrows[ExecutionFailedException] {
           forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
         }

--- a/sdk/src/test/scala/com/horizen/account/state/MessageProcessorFixture.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/MessageProcessorFixture.scala
@@ -83,9 +83,8 @@ trait MessageProcessorFixture extends ClosableResourceHandler {
 
   /**
    * Creates a large temporary gas pool and verifies the amount of total gas consumed.
-   * TODO: enable gas checks again
    */
-  def assertGas[A](expectedGas: BigInteger = BigInteger.ZERO, enfore: Boolean = false)(fun: GasPool => A): A = {
+  def assertGas[A](expectedGas: BigInteger, enfore: Boolean = true)(fun: GasPool => A): A = {
     withGas { gas =>
       try {
         fun(gas)

--- a/sdk/src/test/scala/com/horizen/account/state/MessageProcessorFixture.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/MessageProcessorFixture.scala
@@ -77,8 +77,8 @@ trait MessageProcessorFixture extends ClosableResourceHandler {
   /**
    * Creates a large temporary gas pool and passes it into the given function.
    */
-  def withGas[A](fun: GasPool => A): A = {
-    fun(new GasPool(BigInteger.valueOf(1000000)))
+  def withGas[A](fun: GasPool => A, gasLimit: BigInteger = 1000000): A = {
+    fun(new GasPool(gasLimit))
   }
 
   /**

--- a/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorTest.scala
@@ -164,7 +164,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
         mockWithdrawalRequestsList.get(new ByteArrayWrapper(key))
       })
 
-    returnData = withGas(WithdrawalMsgProcessor.process(msg, mockStateView, _, defaultBlockContext))
+    returnData = withGas(WithdrawalMsgProcessor.process(msg, mockStateView, _, defaultBlockContext), 10000000)
     assertArrayEquals(WithdrawalRequestsListEncoder.encode(expectedListOfWR), returnData)
   }
 }


### PR DESCRIPTION
- remove `OutOfGas` exceptions from `BaseAccountStateView`
- remove automatic gas consumption from `AccountStateView`
- create a "gas tracked" wrapper around `BaseAccountStateView` that Message Processors can use to automatically consume gas
- reenable and fix gas verification in tests

Note: This PR requires a rebase before merge, currently it would merge into the temporary branch of #529