### PR TITLE
RPC error updates

### DIFF
--- a/sdk/src/main/java/com/horizen/account/api/rpc/types/ForwardTransfersView.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/types/ForwardTransfersView.java
@@ -4,12 +4,10 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.horizen.account.proposition.AddressProposition;
 import com.horizen.account.utils.MainchainTxCrosschainOutputAddressUtil;
 import com.horizen.account.utils.ZenWeiConverter;
-import com.horizen.block.MainchainTxForwardTransferCrosschainOutput;
 import com.horizen.serialization.Views;
 import com.horizen.transaction.mainchain.ForwardTransfer;
 import org.web3j.utils.Numeric;
 
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,13 +16,13 @@ public class ForwardTransfersView {
     private final List<ForwardTransferData> forwardTransfers = new ArrayList<>();
 
     public ForwardTransfersView(List<ForwardTransfer> transactions, boolean noPrefix) {
-        for (int i = 0; i < transactions.size(); i++) {
-            MainchainTxForwardTransferCrosschainOutput ftOutput = transactions.get(i).getFtOutput();
+        for (ForwardTransfer transaction : transactions) {
+            var ftOutput = transaction.getFtOutput();
             var to = "";
             var value = "";
-            AddressProposition address = new AddressProposition(
+            var address = new AddressProposition(
                     MainchainTxCrosschainOutputAddressUtil.getAccountAddress(ftOutput.propositionBytes()));
-            BigInteger weiValue = ZenWeiConverter.convertZenniesToWei(ftOutput.amount());
+            var weiValue = ZenWeiConverter.convertZenniesToWei(ftOutput.amount());
             if (noPrefix) {
                 to = Numeric.toHexStringNoPrefix(address.address());
                 value = String.valueOf(weiValue);

--- a/sdk/src/main/java/com/horizen/account/api/rpc/utils/RpcError.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/utils/RpcError.java
@@ -18,6 +18,10 @@ public class RpcError {
         this.data = data;
     }
 
+    public RpcError(RpcCode code, String message, String data) {
+        this(code.getCode(), message, data);
+    }
+
     public static RpcError fromCode(RpcCode code, String data) {
         return new RpcError(code.getCode(), code.getMessage(), data);
     }

--- a/sdk/src/main/scala/com/horizen/account/utils/AccountForwardTransfersHelper.scala
+++ b/sdk/src/main/scala/com/horizen/account/utils/AccountForwardTransfersHelper.scala
@@ -8,11 +8,9 @@ import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 object AccountForwardTransfersHelper {
   def getForwardTransfersForBlock(block: AccountBlock): Seq[ForwardTransfer] = {
     block.mainchainBlockReferencesData.flatMap(mcBlockRefData =>
-      mcBlockRefData.sidechainRelatedAggregatedTransaction match {
-        case Some(tx) => tx.mc2scTransactionsOutputs().filter(
-          _.isInstanceOf[ForwardTransfer]
-        ).map(_.asInstanceOf[ForwardTransfer])
-      }
+      mcBlockRefData.sidechainRelatedAggregatedTransaction
+        .map(_.mc2scTransactionsOutputs.filter(_.isInstanceOf[ForwardTransfer]).map(_.asInstanceOf[ForwardTransfer]))
+        .getOrElse(Seq())
     )
   }
 }


### PR DESCRIPTION
- Fixed a potential issue in `eth_getForwardTransfers` because the `match` clause was not exhaustive.
- Refactored `getBlockIdByTag` to always throw an `RpcException` with `InvalidParams` when parsing of the input fails or the given block does not exist. Previously this could throw other exceptions which would get returned to the caller as "internal error"
- Some refactoring to reduce usage of `asScala` etc.

**Note**: This does change the behavior of some RPC methods slightly. E.g. `getBalance(address, tag)` would previously return `null` in case an invalid block number is given, now it returns an "invalid params" error. To me this seems more accurate, but we need to check what the expected behavior is.

**Note 2**: This PR currently merges into `jb/truffle-fixes` becase it is based on that branch.