### PR TITLE
Refactoring

### DIFF
--- a/evm/src/main/java/com/horizen/evm/utils/Hash.java
+++ b/evm/src/main/java/com/horizen/evm/utils/Hash.java
@@ -1,5 +1,6 @@
 package com.horizen.evm.utils;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -45,19 +46,24 @@ public class Hash {
         return Arrays.hashCode(bytes);
     }
 
+    @JsonValue
+    @Override
+    public String toString() {
+        return "0x" + Converter.toHexString(bytes);
+    }
+
     public static class Serializer extends JsonSerializer<Hash> {
         @Override
-        public void serialize(
-                Hash address, JsonGenerator jsonGenerator, SerializerProvider serializerProvider
-        ) throws IOException {
-            jsonGenerator.writeString("0x" + Converter.toHexString(address.bytes));
+        public void serialize(Hash hash, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException {
+            jsonGenerator.writeString(hash.toString());
         }
     }
 
     public static class Deserializer extends JsonDeserializer<Hash> {
         @Override
         public Hash deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
-                throws IOException {
+            throws IOException {
             var text = jsonParser.getText();
             if (!text.startsWith("0x")) {
                 throw new IOException("hash must be prefixed with 0x");

--- a/qa/run_sc_tests.sh
+++ b/qa/run_sc_tests.sh
@@ -55,6 +55,7 @@ testScripts=(
     'sc_evm_mempool.py'
     'sc_evm_mempool_invalid_txs.py'
     'sc_evm_orphan_txs.py'
+    'sc_evm_rpc_invalid_txs.py'
     'sc_evm_test_debug_methods.py'
     'sc_evm_estimateGas.py'
     'sc_evm_test_block_bloom_filter.py'

--- a/qa/sc_evm_rpc_invalid_txs.py
+++ b/qa/sc_evm_rpc_invalid_txs.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import logging
+from decimal import Decimal
+
+from SidechainTestFramework.account.address_util import format_evm
+from SidechainTestFramework.account.eoa_util import eoa_transaction
+from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
+    SCNetworkConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH
+from SidechainTestFramework.sc_test_framework import SidechainTestFramework
+from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, start_sc_nodes, generate_next_block, \
+    EVM_APP_BINARY, AccountModelBlockVersion, assert_true, convertZenToWei
+from test_framework.util import start_nodes, \
+    websocket_port_by_mc_node_index, forward_transfer_to_sidechain
+
+"""
+Check that sending an invalid transaction to the RPC method eth_sendRawTransaction returns an error
+"""
+
+
+class SCEvmRPCInvalidTx(SidechainTestFramework):
+    sc_nodes_bootstrap_info = None
+    number_of_mc_nodes = 1
+    number_of_sidechain_nodes = 1
+
+    def setup_nodes(self):
+        return start_nodes(self.number_of_mc_nodes, self.options.tmpdir)
+
+    def sc_setup_network(self, split=False):
+        self.sc_nodes = self.sc_setup_nodes()
+
+    def sc_setup_chain(self):
+        mc_node = self.nodes[0]
+        sc_node_1_configuration = SCNodeConfiguration(
+            MCConnectionInfo(address="ws://{0}:{1}".format(mc_node.hostname, websocket_port_by_mc_node_index(0)))
+        )
+        network = SCNetworkConfiguration(
+            SCCreationInfo(mc_node, 100, LARGE_WITHDRAWAL_EPOCH_LENGTH),
+            sc_node_1_configuration
+        )
+        self.sc_nodes_bootstrap_info = bootstrap_sidechain_nodes(
+            self.options, network,
+            block_timestamp_rewind=720 * 120 * 5,
+            blockversion=AccountModelBlockVersion
+        )
+
+    def sc_setup_nodes(self):
+        return start_sc_nodes(
+            self.number_of_sidechain_nodes, dirname=self.options.tmpdir,
+            binary=[EVM_APP_BINARY] * 2,
+            # extra_args=[['-agentlib'], []],
+        )
+
+    def run_test(self):
+        mc_node = self.nodes[0]
+        sc_node_1 = self.sc_nodes[0]
+
+        # transfer some fund from MC to SC1 at a new evm address, then mine mc block
+        evm_address_sc1 = sc_node_1.wallet_createPrivateKeySecp256k1()["result"]["proposition"]["address"]
+        evm_address_sc2 = sc_node_1.wallet_createPrivateKeySecp256k1()["result"]["proposition"]["address"]
+
+        ft_amount_in_zen = Decimal('3000.0')
+        forward_transfer_to_sidechain(
+            self.sc_nodes_bootstrap_info.sidechain_id,
+            mc_node,
+            evm_address_sc1,
+            ft_amount_in_zen,
+            mc_return_address=mc_node.getnewaddress(),
+            generate_block=True
+        )
+        self.sync_all()
+
+        generate_next_block(sc_node_1, "first node")
+        self.sc_sync_all()
+
+        # test that sending an invalid transaction to eth_sendRawTransaction fails with an error
+        # the tx is semantically invalid because the supplied gas limit is below the required intrinsic gas
+        exception_occured = False
+        try:
+            res = eoa_transaction(
+                sc_node_1, gas=20000,
+                from_addr=format_evm(evm_address_sc1), to_addr=format_evm(evm_address_sc2), value=convertZenToWei(1)
+            )
+            logging.error("invalid transaction was accepted via RPC api: {}".format(str(res)))
+        except RuntimeError as err:
+            logging.debug("invalid transaction was rejected with: {}".format(str(err)))
+            if str(err).find("gas limit is below intrinsic gas") != -1:
+                exception_occured = True
+        assert_true(exception_occured, "invalid transaction should be rejected by RPC api")
+
+
+if __name__ == "__main__":
+    SCEvmRPCInvalidTx().main()

--- a/sdk/src/main/java/com/horizen/account/api/rpc/types/Quantity.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/types/Quantity.java
@@ -18,6 +18,10 @@ public class Quantity {
         this(Numeric.encodeQuantity(number));
     }
 
+    public Quantity(Long number) {
+        this(BigInteger.valueOf(number));
+    }
+
     @JsonValue
     public String getValue() {
         return value;

--- a/sdk/src/main/java/com/horizen/account/utils/EthereumTransactionDecoder.java
+++ b/sdk/src/main/java/com/horizen/account/utils/EthereumTransactionDecoder.java
@@ -33,7 +33,7 @@ public class EthereumTransactionDecoder {
         byte[] encodedTx = Arrays.copyOfRange(transaction, 1, transaction.length);
         RlpList rlpList = RlpDecoder.decode(encodedTx);
         RlpList values = (RlpList)rlpList.getValues().get(0);
-        long chainId = ((RlpString)values.getValues().get(0)).asPositiveBigInteger().longValue();
+        long chainId = ((RlpString)values.getValues().get(0)).asPositiveBigInteger().longValueExact();
         BigInteger nonce = ((RlpString)values.getValues().get(1)).asPositiveBigInteger();
         BigInteger maxPriorityFeePerGas = ((RlpString)values.getValues().get(2)).asPositiveBigInteger();
         BigInteger maxFeePerGas = ((RlpString)values.getValues().get(3)).asPositiveBigInteger();
@@ -46,7 +46,7 @@ public class EthereumTransactionDecoder {
         if (values.getValues().size() == 9) {
             return rawTransaction;
         } else {
-            byte[] v = Sign.getVFromRecId(Numeric.toBigInt(((RlpString)values.getValues().get(9)).getBytes()).intValue());
+            byte[] v = Sign.getVFromRecId(Numeric.toBigInt(((RlpString)values.getValues().get(9)).getBytes()).intValueExact());
             byte[] r = Numeric.toBytesPadded(Numeric.toBigInt(((RlpString)values.getValues().get(10)).getBytes()), 32);
             byte[] s = Numeric.toBytesPadded(Numeric.toBigInt(((RlpString)values.getValues().get(11)).getBytes()), 32);
             Sign.SignatureData signatureData = new Sign.SignatureData(v, r, s);

--- a/sdk/src/main/java/com/horizen/account/utils/EthereumTransactionUtils.java
+++ b/sdk/src/main/java/com/horizen/account/utils/EthereumTransactionUtils.java
@@ -18,7 +18,7 @@ public final class EthereumTransactionUtils {
     // w3j way for converting bytes, it works also with generic byte contents (not only Long.BYTES byte arrays)
     public static long convertToLong(byte[] bytes) {
         BigInteger bi = Numeric.toBigInt(bytes);
-        return bi.longValue();
+        return bi.longValueExact();
     }
 
     private EthereumTransactionUtils() {

--- a/sdk/src/main/java/com/horizen/utils/Utils.java
+++ b/sdk/src/main/java/com/horizen/utils/Utils.java
@@ -69,9 +69,9 @@ public final class Utils
         long result;
         int size = value.toByteArray().length;
         if (size <= 3)
-            result = value.longValue() << 8 * (3 - size);
+            result = value.longValueExact() << 8 * (3 - size);
         else
-            result = value.shiftRight(8 * (size - 3)).longValue();
+            result = value.shiftRight(8 * (size - 3)).longValueExact();
         // The 0x00800000 bit denotes the sign.
         // Thus, if it is already set, divide the mantissa by 256 and increase the exponent.
         if ((result & 0x00800000L) != 0) {

--- a/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
@@ -1,12 +1,9 @@
 package com.horizen.account.api.rpc.service
 
 import akka.actor.ActorRef
-import akka.http.scaladsl.server.Directives.onComplete
 import akka.pattern.ask
 import akka.util.Timeout
 import com.horizen.SidechainSettings
-import com.horizen.account.api.http.AccountTransactionErrorResponse.GenericTransactionError
-import com.horizen.account.api.http.AccountTransactionRestScheme.TransactionIdDTO
 import com.horizen.account.api.rpc.handler.RpcException
 import com.horizen.account.api.rpc.types._
 import com.horizen.account.api.rpc.utils._
@@ -20,14 +17,12 @@ import com.horizen.account.utils.AccountForwardTransfersHelper.getForwardTransfe
 import com.horizen.account.utils.EthereumTransactionDecoder
 import com.horizen.account.wallet.AccountWallet
 import com.horizen.api.http.SidechainTransactionActor.ReceivableMessages.BroadcastTransaction
-import com.horizen.api.http.{ApiResponseUtil, SuccessResponse}
 import com.horizen.chain.SidechainBlockInfo
 import com.horizen.evm.interop.TraceParams
 import com.horizen.evm.utils.Address
 import com.horizen.params.NetworkParams
-import com.horizen.transaction.Transaction
 import com.horizen.transaction.exception.TransactionSemanticValidityException
-import com.horizen.utils.{BytesUtils, ClosableResourceHandler, TimeToEpochUtils}
+import com.horizen.utils.{ClosableResourceHandler, TimeToEpochUtils}
 import org.web3j.crypto.Sign.SignatureData
 import org.web3j.crypto.{SignedRawTransaction, TransactionEncoder}
 import org.web3j.utils.Numeric
@@ -37,10 +32,9 @@ import sparkz.core.NodeViewHolder.CurrentView
 
 import java.math.BigInteger
 import java.util
-import java.util.{Optional => JOptional}
 import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.{FiniteDuration, SECONDS}
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -91,11 +85,6 @@ class EthService(
     }
   }
 
-  // function which describes default transaction representation for answer after adding the transaction to a memory pool
-  val defaultTransactionResponseRepresentation: Transaction => SuccessResponse = { transaction =>
-    TransactionIdDTO(transaction.id)
-  }
-
   @RpcMethod("eth_getBlockByNumber")
   def getBlockByNumber(tag: String, hydratedTx: Boolean): EthereumBlock = {
     applyOnAccountView { nodeView =>
@@ -120,14 +109,11 @@ class EthService(
       blockId: ModifierId,
       hydratedTx: Boolean
   ): EthereumBlock = {
-    nodeView.history.getStorageBlockById(blockId) match {
-      case None => null
-      case Some(block) =>
-        val transactions = block.transactions.filter {
-          _.isInstanceOf[EthereumTransaction]
-        } map {
-          _.asInstanceOf[EthereumTransaction]
-        }
+    nodeView.history
+      .getStorageBlockById(blockId)
+      .map(block => {
+        val transactions =
+          block.transactions.filter(_.isInstanceOf[EthereumTransaction]).map(_.asInstanceOf[EthereumTransaction])
         new EthereumBlock(
           Numeric.prependHexPrefix(Integer.toHexString(nodeView.history.getBlockHeightById(blockId).get())),
           Numeric.prependHexPrefix(blockId),
@@ -145,15 +131,14 @@ class EthService(
           },
           block
         )
-    }
+      })
+      .orNull
   }
 
-  private def doCall[A](nodeView: NV, params: TransactionArgs, tag: String)(
-      fun: (Array[Byte], AccountStateView) ⇒ A
-  ): A = {
+  private def doCall(nodeView: NV, params: TransactionArgs, tag: String): Array[Byte] = {
     getStateViewAtTag(nodeView, tag) { (tagStateView, blockContext) =>
       val msg = params.toMessage(blockContext.baseFee)
-      fun(tagStateView.applyMessage(msg, new GasPool(msg.getGasLimit), blockContext), tagStateView)
+      tagStateView.applyMessage(msg, new GasPool(msg.getGasLimit), blockContext)
     }
   }
 
@@ -161,9 +146,7 @@ class EthService(
   @RpcOptionalParameters(1)
   def call(params: TransactionArgs, tag: String): String = {
     applyOnAccountView { nodeView =>
-      doCall(nodeView, params, tag) { (result, _) =>
-        if (result != null) Numeric.toHexString(result) else null
-      }
+      Option.apply(doCall(nodeView, params, tag)).map(Numeric.toHexString).orNull
     }
   }
 
@@ -185,17 +168,10 @@ class EthService(
 
   @RpcMethod("eth_signTransaction") def signTransaction(params: TransactionArgs): String = {
     applyOnAccountView { nodeView =>
-      var signedTx = params.toTransaction
-      getFittingSecret(nodeView.vault, nodeView.state, Option.apply(params.from), params.value) match {
-        case Some(secret) =>
-          signedTx = signTransactionWithSecret(secret, signedTx)
-        case None =>
-          return null
-      }
-      "0x" + BytesUtils.toHexString(
-        TransactionEncoder
-          .encode(signedTx.getTransaction, signedTx.getTransaction.asInstanceOf[SignedRawTransaction].getSignatureData)
-      )
+      getFittingSecret(nodeView.vault, nodeView.state, Option.apply(params.from), params.value)
+        .map(secret => signTransactionWithSecret(secret, params.toTransaction))
+        .map(tx => Numeric.toHexString(TransactionEncoder.encode(tx.getTransaction, tx.getSignatureData)))
+        .orNull
     }
   }
 
@@ -217,14 +193,12 @@ class EthService(
   }
 
   private def signTransactionWithSecret(secret: PrivateKeySecp256k1, tx: EthereumTransaction): EthereumTransaction = {
-    val messageToSign = tx.messageToSign()
-    val msgSignature = secret.sign(messageToSign)
-    var signatureData = new SignatureData(msgSignature.getV, msgSignature.getR, msgSignature.getS)
+    val signature = secret.sign(tx.messageToSign())
+    var signatureData = new SignatureData(signature.getV, signature.getR, signature.getS)
     if (!tx.isEIP1559 && tx.isSigned && tx.getChainId != null) {
       signatureData = TransactionEncoder.createEip155SignatureData(signatureData, tx.getChainId)
     }
-    val signedTx = new EthereumTransaction(new SignedRawTransaction(tx.getTransaction.getTransaction, signatureData))
-    signedTx
+    new EthereumTransaction(new SignedRawTransaction(tx.getTransaction.getTransaction, signatureData))
   }
 
   @RpcMethod("eth_estimateGas")
@@ -277,7 +251,8 @@ class EthService(
       val check = (gas: BigInteger) =>
         try {
           params.gas = gas
-          doCall(nodeView, params, tag) { (_, _) => true }
+          doCall(nodeView, params, tag)
+          true
         } catch {
           case _: ExecutionFailedException => false
           case _: IntrinsicGasException => false
@@ -401,24 +376,9 @@ class EthService(
 
   @RpcMethod("eth_sendRawTransaction") def sendRawTransaction(signedTxData: String): Quantity = {
     val tx = new EthereumTransaction(EthereumTransactionDecoder.decode(signedTxData))
-    validateAndSendTransaction(tx)
+    implicit val timeout: Timeout = Timeout.apply(5, SECONDS)
+    Await.result(sidechainTransactionActorRef ? BroadcastTransaction(tx), timeout.duration)
     new Quantity(Numeric.prependHexPrefix(tx.id))
-  }
-
-  private def validateAndSendTransaction(
-      transaction: Transaction,
-      transactionResponseRepresentation: Transaction => SuccessResponse = defaultTransactionResponseRepresentation
-  ) = {
-    implicit val timeout: Timeout = 5 seconds
-    val barrier = Await
-      .result(sidechainTransactionActorRef ? BroadcastTransaction(transaction), timeout.duration)
-      .asInstanceOf[Future[Unit]]
-    onComplete(barrier) {
-      // TODO: add correct responses
-      case Success(_) => ApiResponseUtil.toResponse(transactionResponseRepresentation(transaction))
-      case Failure(exp) =>
-        ApiResponseUtil.toResponse(GenericTransactionError("GenericTransactionError", JOptional.of(exp)))
-    }
   }
 
   @RpcMethod("eth_getCode")
@@ -426,11 +386,8 @@ class EthService(
   def getCode(address: Address, tag: String): String = {
     applyOnAccountView { nodeView =>
       getStateViewAtTag(nodeView, tag) { (tagStateView, _) =>
-        val code = tagStateView.getCode(address.toBytes)
-        if (code == null)
-          "0x"
-        else
-          Numeric.toHexString(code)
+        val code = Option.apply(tagStateView.getCode(address.toBytes)).getOrElse(Array.emptyByteArray)
+        Numeric.toHexString(code)
       }
     }
   }
@@ -510,10 +467,10 @@ class EthService(
   def getForwardTransfers(blockId: String): ForwardTransfersView = {
     if (blockId == null) return null
     applyOnAccountView { nodeView =>
-      nodeView.history.getStorageBlockById(getBlockIdByTag(nodeView, blockId)) match {
-        case Some(block) => new ForwardTransfersView(getForwardTransfersForBlock(block).asJava, false)
-        case None => null
-      }
+      nodeView.history
+        .getStorageBlockById(getBlockIdByTag(nodeView, blockId))
+        .map(block => new ForwardTransfersView(getForwardTransfersForBlock(block).asJava, false))
+        .orNull
     }
   }
 }

--- a/sdk/src/main/scala/com/horizen/account/block/AccountBlockHeader.scala
+++ b/sdk/src/main/scala/com/horizen/account/block/AccountBlockHeader.scala
@@ -94,7 +94,7 @@ case class AccountBlockHeader(
           throw new InvalidSidechainBlockHeaderException(s"AccountBlockHeader $id signature is invalid.")
 
         // check, that gas limit is valid
-        if (baseFee.compareTo(BigInteger.ZERO) == 1) {
+        if (baseFee.signum() == 1) {
           if(gasLimit != FeeUtils.GAS_LIMIT)
             throw new InvalidSidechainBlockHeaderException(s"AccountBlockHeader $gasLimit is invalid.")
           if(gasUsed < 0)

--- a/sdk/src/main/scala/com/horizen/account/forger/AccountForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/com/horizen/account/forger/AccountForgeMessageBuilder.scala
@@ -243,7 +243,7 @@ class AccountForgeMessageBuilder(
     val receiptsRoot: Array[Byte] = calculateReceiptRoot(receiptList)
 
     // 7. Get cumulativeGasUsed from last receipt in list if available
-    val gasUsed: Long = receiptList.lastOption.map(_.cumulativeGasUsed.longValue()).getOrElse(0)
+    val gasUsed: Long = receiptList.lastOption.map(_.cumulativeGasUsed.longValueExact()).getOrElse(0)
 
     // 8. set the fee payments hash
     val feePaymentsHash: Array[Byte] = AccountFeePaymentsUtils.calculateFeePaymentsHash(feePayments)

--- a/sdk/src/main/scala/com/horizen/account/state/AccountStateView.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/AccountStateView.scala
@@ -195,7 +195,7 @@ class AccountStateView(
 
   @throws(classOf[ExecutionFailedException])
   override def addBalance(address: Array[Byte], amount: BigInteger): Unit = {
-    amount.compareTo(BigInteger.ZERO) match {
+    amount.signum() match {
       case x if x == 0 => // amount is zero
       case x if x < 0 =>
         throw new ExecutionFailedException("cannot add negative amount to balance")
@@ -209,7 +209,7 @@ class AccountStateView(
   override def subBalance(address: Array[Byte], amount: BigInteger): Unit = {
     // stateDb lib does not do any sanity check, and negative balances might arise (and java/go json IF does not correctly handle it)
     // TODO: for the time being do the checks here, later they will be done in the caller stack
-    amount.compareTo(BigInteger.ZERO) match {
+    amount.signum() match {
       case x if x == 0 => // amount is zero
       case x if x < 0 =>
         throw new ExecutionFailedException("cannot subtract negative amount from balance")

--- a/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
@@ -221,7 +221,7 @@ case class ForgerStakeMsgProcessor(params: NetworkParams) extends FakeSmartContr
     }
 
     // check that msg.value is greater than zero
-    if (msg.getValue.compareTo(BigInteger.ZERO) <= 0) {
+    if (msg.getValue.signum() <= 0) {
       throw new ExecutionRevertedException("Value must not be zero")
     }
 

--- a/sdk/src/main/scala/com/horizen/account/state/GasPool.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/GasPool.scala
@@ -14,7 +14,7 @@ class GasPool(initialGas: BigInteger) extends ScorexLogging {
 
   @throws(classOf[OutOfGasException])
   def subGas(gas: BigInteger): Unit = {
-    if (gas.compareTo(BigInteger.ZERO) < 0)
+    if (gas.signum() == -1)
       throw new IllegalArgumentException("cannot consume a negative amount of gas")
     if (currentGas.compareTo(gas) < 0) {
       throw new OutOfGasException()
@@ -25,7 +25,7 @@ class GasPool(initialGas: BigInteger) extends ScorexLogging {
   }
 
   def addGas(gas: BigInteger): Unit = {
-    if (gas.compareTo(BigInteger.ZERO) < 0)
+    if (gas.signum() == -1)
       throw new IllegalArgumentException("cannot return a negative amount of gas")
     log.trace(s"adding $gas to currentGas=$currentGas")
     val sum = currentGas.add(gas)

--- a/sdk/src/main/scala/com/horizen/account/state/StateTransition.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/StateTransition.scala
@@ -60,12 +60,13 @@ class StateTransition(
     val sender = msg.getFrom.address()
 
     // Check the nonce
-    val stateNonce = view.getNonce(sender)
     if (!msg.getIsFakeMsg) {
-      val txNonce = msg.getNonce
-      val result = txNonce.compareTo(stateNonce)
-      if (result < 0) throw NonceTooLowException(sender, txNonce, stateNonce)
-      if (result > 0) throw NonceTooHighException(sender, txNonce, stateNonce)
+      val stateNonce = view.getNonce(sender)
+      msg.getNonce.compareTo(stateNonce) match {
+        case x if x < 0 => throw NonceTooLowException(sender, msg.getNonce, stateNonce)
+        case x if x > 0 => throw NonceTooHighException(sender, msg.getNonce, stateNonce)
+        case _ => // nonce matches
+      }
       // GETH and therefore StateDB use uint64 to store the nonce and perform an overflow check here using (nonce+1<nonce)
       // BigInteger will not overflow like that, so we just verify that the result after increment still fits into 64 bits
       if (!BigIntegerUtil.isUint64(stateNonce.add(BigInteger.ONE))) throw NonceMaxException(sender, stateNonce)

--- a/sdk/src/main/scala/com/horizen/account/state/StateTransition.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/StateTransition.scala
@@ -5,7 +5,6 @@ import scorex.util.ScorexLogging
 
 import java.math.BigInteger
 
-
 class StateTransition(
     view: AccountStateView,
     messageProcessors: Seq[MessageProcessor],
@@ -22,6 +21,7 @@ class StateTransition(
     val gasPool = buyGas(msg)
     // consume intrinsic gas
     val intrinsicGas = GasUtil.intrinsicGas(msg.getData, msg.getTo == null)
+    if (gasPool.getGas.compareTo(intrinsicGas) < 0) throw IntrinsicGasException(gasPool.getGas, intrinsicGas)
     gasPool.subGas(intrinsicGas)
     // find and execute the first matching processor
     messageProcessors.find(_.canProcess(msg, view)) match {

--- a/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
@@ -165,7 +165,7 @@ object GetListOfWithdrawalRequestsCmdInputDecoder extends ABIDecoder[GetListOfWi
   override def getListOfABIParamTypes: util.List[TypeReference[Type[_]]] = org.web3j.abi.Utils.convert(util.Arrays.asList(new TypeReference[Uint32]() {}))
 
   override def createType(listOfParams: util.List[Type[_]]): GetListOfWithdrawalRequestsInputCmd = {
-    GetListOfWithdrawalRequestsInputCmd(listOfParams.get(0).asInstanceOf[Uint32].getValue.intValue())
+    GetListOfWithdrawalRequestsInputCmd(listOfParams.get(0).asInstanceOf[Uint32].getValue.intValueExact())
   }
 
 }

--- a/sdk/src/main/scala/com/horizen/account/utils/AccountFeePaymentsUtils.scala
+++ b/sdk/src/main/scala/com/horizen/account/utils/AccountFeePaymentsUtils.scala
@@ -31,7 +31,7 @@ object AccountFeePaymentsUtils {
     // Split poolFee in equal parts to be paid to forgers.
     val forgerPoolFee: BigInteger = poolFee.divide(BigInteger.valueOf(forgersBlockRewards.size))
     // The rest N satoshis must be paid to the first N forgers (1 satoshi each)
-    val rest = poolFee.mod(BigInteger.valueOf(forgersBlockRewards.size)).longValue()
+    val rest = poolFee.mod(BigInteger.valueOf(forgersBlockRewards.size)).longValueExact()
 
     // Calculate final fee for forger considering forger fee, pool fee and the undistributed satoshis
     val allForgersRewards : Seq[AccountPayment] = forgersBlockRewards.zipWithIndex.map {
@@ -49,7 +49,8 @@ object AccountFeePaymentsUtils {
         // sum all rewards for this forger address
         val forgerTotalFee = allForgersRewards
           .filter(info => forgerKey.equals(info.address))
-          .foldLeft(BigInteger.ZERO)((sum, info) => sum.add(info.value))
+          .map(_.value)
+          .reduce(_.add(_))
 
         // return the resulting entry
         AccountPayment(forgerKey, forgerTotalFee)

--- a/sdk/src/main/scala/com/horizen/account/utils/AccountFeePaymentsUtils.scala
+++ b/sdk/src/main/scala/com/horizen/account/utils/AccountFeePaymentsUtils.scala
@@ -49,8 +49,7 @@ object AccountFeePaymentsUtils {
         // sum all rewards for this forger address
         val forgerTotalFee = allForgersRewards
           .filter(info => forgerKey.equals(info.address))
-          .map(_.value)
-          .reduce(_.add(_))
+          .foldLeft(BigInteger.ZERO)((sum, info) => sum.add(info.value))
 
         // return the resulting entry
         AccountPayment(forgerKey, forgerTotalFee)

--- a/sdk/src/main/scala/com/horizen/account/utils/AccountForwardTransfersHelper.scala
+++ b/sdk/src/main/scala/com/horizen/account/utils/AccountForwardTransfersHelper.scala
@@ -10,7 +10,7 @@ object AccountForwardTransfersHelper {
     block.mainchainBlockReferencesData.flatMap(mcBlockRefData =>
       mcBlockRefData.sidechainRelatedAggregatedTransaction
         .map(_.mc2scTransactionsOutputs.filter(_.isInstanceOf[ForwardTransfer]).map(_.asInstanceOf[ForwardTransfer]))
-        .getOrElse(Seq())
+        .getOrElse(Seq.empty)
     )
   }
 }

--- a/sdk/src/main/scala/com/horizen/account/utils/ZenWeiConverter.scala
+++ b/sdk/src/main/scala/com/horizen/account/utils/ZenWeiConverter.scala
@@ -1,12 +1,12 @@
 package com.horizen.account.utils
 
 import com.horizen.utils.ZenCoinsUtils
+
 import java.math.BigInteger
 
 object ZenWeiConverter {
   val ZENNY_TO_WEI_MULTIPLIER: BigInteger = BigInteger.TEN.pow(10)
   val MAX_MONEY_IN_WEI: BigInteger = convertZenniesToWei(ZenCoinsUtils.MAX_MONEY)
-
 
   def convertZenniesToWei(valueInZennies: Long): BigInteger = {
     ZENNY_TO_WEI_MULTIPLIER.multiply(BigInteger.valueOf(valueInZennies))
@@ -14,17 +14,13 @@ object ZenWeiConverter {
 
   def convertWeiToZennies(valueInWei: BigInteger): Long = {
     require(isValidZenAmount(valueInWei), s"Amount $valueInWei wei is not a valid Zen sum")
-    valueInWei.divide(ZENNY_TO_WEI_MULTIPLIER).longValue()
+    valueInWei.divide(ZENNY_TO_WEI_MULTIPLIER).longValueExact()
   }
-
 
   def isValidZenAmount(valueInWei: BigInteger): Boolean = {
     require(valueInWei != null, s"Wei amount is null")
-    if (valueInWei.compareTo(BigInteger.ZERO) >= 0) {
-      (valueInWei.compareTo(MAX_MONEY_IN_WEI) <= 0 &&
-        valueInWei.remainder(ZENNY_TO_WEI_MULTIPLIER).longValue() == 0)
-    }
-    else
-      false
+    valueInWei.signum() >= 0 &&
+    valueInWei.compareTo(MAX_MONEY_IN_WEI) <= 0 &&
+    valueInWei.mod(ZENNY_TO_WEI_MULTIPLIER).signum() == 0
   }
 }

--- a/sdk/src/main/scala/com/horizen/account/validation/BaseFeeBlockValidator.scala
+++ b/sdk/src/main/scala/com/horizen/account/validation/BaseFeeBlockValidator.scala
@@ -15,7 +15,7 @@ case class BaseFeeBlockValidator() extends HistoryBlockValidator[SidechainTypes#
   override def validate(block: AccountBlock, history: AccountHistory): Try[Unit] = Try {
     val baseFee = block.header.baseFee
     val expectedBaseFee: BigInteger = FeeUtils.calculateBaseFee(history, block.header.parentId)
-    if (baseFee.compareTo(expectedBaseFee) != 0)
+    if (!baseFee.equals(expectedBaseFee))
       throw new InvalidBaseFeeException(s"Calculated base fee $baseFee of block with id ${block.id} is invalid")
   }
 }

--- a/sdk/src/test/java/com/horizen/account/transaction/EthereumTransactionTest.java
+++ b/sdk/src/test/java/com/horizen/account/transaction/EthereumTransactionTest.java
@@ -1,6 +1,5 @@
 package com.horizen.account.transaction;
 
-import com.horizen.account.fixtures.EthereumTransactionFixture;
 import com.horizen.account.proof.SignatureSecp256k1;
 import com.horizen.account.proposition.AddressProposition;
 import com.horizen.account.utils.EthereumTransactionDecoder;
@@ -12,8 +11,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.web3j.crypto.*;
 import org.web3j.utils.Numeric;
-import scala.Option;
-import scala.Some;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -271,13 +268,13 @@ public class EthereumTransactionTest {
     @Test
     public void ethereumEIP1559RawTransactionTest() {
         // Test 0: direct constructor
-        var someTx = new EthereumTransaction(someValue.longValue(),
+        var someTx = new EthereumTransaction(someValue.longValueExact(),
                 "0x", someValue, someValue, someValue, someValue,
                 someValue, "", null
         );
         assertNull(someTx.getSignature());
 
-        rawTransaction = RawTransaction.createTransaction(someValue.longValue(), someValue,
+        rawTransaction = RawTransaction.createTransaction(someValue.longValueExact(), someValue,
                 someValue, "0x", someValue, "", someValue, someValue);
 
         // Test 1: everything is correct
@@ -318,11 +315,11 @@ public class EthereumTransactionTest {
 
         assertEquals(ethereumTransaction.getMaxFeePerGas(), someValue);
         assertEquals(ethereumTransaction.getMaxPriorityFeePerGas(), someValue);
-        assertEquals(ethereumTransaction.getChainId().longValue(), someValue.longValue());
+        assertEquals(ethereumTransaction.getChainId().longValue(), someValue.longValueExact());
 
         // Test 9: ethereum transaction instance returns to proposition address correctly
         RawTransaction toTx =
-                RawTransaction.createTransaction(someValue.longValue(), someValue,
+                RawTransaction.createTransaction(someValue.longValueExact(), someValue,
                         someValue, "0x00112233445566778899AABBCCDDEEFF01020304", someValue,
                         "", someValue, someValue);
         EthereumTransaction toEthereumTransaction = new EthereumTransaction(toTx);
@@ -419,7 +416,7 @@ public class EthereumTransactionTest {
     public void ethereumSignedEIP1559TransactionTest() {
         // Test 0: direct constructor
         try {
-            var someTx = new EthereumTransaction(someValue.longValue(),
+            var someTx = new EthereumTransaction(someValue.longValueExact(),
                     "0x", someValue, someValue, someValue, someValue,
                     someValue, "", signedRawTransaction.getSignatureData()
             );

--- a/sdk/src/test/scala/com/horizen/account/forger/AccountForgeMessageBuilderTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/forger/AccountForgeMessageBuilderTest.scala
@@ -133,7 +133,7 @@ class AccountForgeMessageBuilderTest
       Array.empty[Byte],
       1000,
       BigInteger.ZERO,
-      gasLimit.longValue(),//Just enough for 1 tx
+      gasLimit.longValueExact(),//Just enough for 1 tx
       11,
       2,
       3

--- a/sdk/src/test/scala/com/horizen/account/state/AccountStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/AccountStateTest.scala
@@ -87,7 +87,7 @@ class AccountStateTest
     feePayments = state.getFeePayments(0)
     assertEquals(s"Fee payments size expected to be different.", 3, feePayments.size)
 
-    var forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))
+    var forgerTotalFee = feePayments.map(_.value).reduce(_.add(_))
 
     assertEquals(s"Total fee value is wrong", totalFee, forgerTotalFee)
 
@@ -119,7 +119,7 @@ class AccountStateTest
 
     assertEquals(s"Fee payments size expected to be different.", 3, feePayments.size)
 
-    forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))
+    forgerTotalFee = feePayments.map(_.value).reduce(_.add(_))
 
     assertEquals(s"Total fee value is wrong", totalFee, forgerTotalFee)
 
@@ -159,7 +159,7 @@ class AccountStateTest
 
     assertEquals(s"Fee payments size expected to be different.", 2, feePayments.size)
 
-    forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))
+    forgerTotalFee = feePayments.map(_.value).reduce(_.add(_))
 
     assertEquals(s"Total fee value is wrong", totalFee, forgerTotalFee)
 

--- a/sdk/src/test/scala/com/horizen/account/state/AccountStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/AccountStateTest.scala
@@ -87,7 +87,7 @@ class AccountStateTest
     feePayments = state.getFeePayments(0)
     assertEquals(s"Fee payments size expected to be different.", 3, feePayments.size)
 
-    var forgerTotalFee = feePayments.map(_.value).reduce(_.add(_))
+    var forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))
 
     assertEquals(s"Total fee value is wrong", totalFee, forgerTotalFee)
 
@@ -119,7 +119,7 @@ class AccountStateTest
 
     assertEquals(s"Fee payments size expected to be different.", 3, feePayments.size)
 
-    forgerTotalFee = feePayments.map(_.value).reduce(_.add(_))
+    forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))
 
     assertEquals(s"Total fee value is wrong", totalFee, forgerTotalFee)
 
@@ -159,7 +159,7 @@ class AccountStateTest
 
     assertEquals(s"Fee payments size expected to be different.", 2, feePayments.size)
 
-    forgerTotalFee = feePayments.map(_.value).reduce(_.add(_))
+    forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))
 
     assertEquals(s"Total fee value is wrong", totalFee, forgerTotalFee)
 

--- a/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
@@ -109,7 +109,7 @@ class ForgerStakeMsgProcessorTest
     if (!view.accountExists(origin)) {
       view.addAccount(origin, randomHash)
 
-      if (amount.compareTo(BigInteger.ZERO) >= 0) {
+      if (amount.signum() == 1) {
         view.addBalance(origin, amount)
       }
     }

--- a/sdk/src/test/scala/com/horizen/account/utils/FeeUtilsTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/utils/FeeUtilsTest.scala
@@ -1,24 +1,49 @@
 package com.horizen.account.utils
 
-import com.horizen.account.utils.FeeUtils.{GAS_LIMIT, INITIAL_BASE_FEE, calculateNextBaseFee}
-import com.horizen.account.block.AccountBlock
-import org.junit.Assert.assertTrue
+import com.horizen.account.utils.FeeUtils.{INITIAL_BASE_FEE, calculateNextBaseFee}
+import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 import org.scalatestplus.junit.JUnitSuite
 
 import java.math.BigInteger
 
 class FeeUtilsTest extends JUnitSuite {
-  // separate test for calculate next base fee as it is not used in base fee validator test
+
+  private def assertBaseFeeChange(
+      message: String,
+      gasUsedPercent: Long,
+      currentBaseFee: Long,
+      expectedBaseFee: Long
+  ): Unit = {
+    val block =
+      AccountMockDataHelper(false).getMockedBlock(BigInteger.valueOf(currentBaseFee), gasUsedPercent, 100, null, null)
+    assertEquals(message, calculateNextBaseFee(block), BigInteger.valueOf(expectedBaseFee))
+  }
+
+  /**
+   * Separate test for calculate next base fee as it is not used in base fee validator test
+   */
   @Test
   def calculateNextBaseFeeTest(): Unit = {
-    val mockedBlock: AccountBlock = AccountMockDataHelper(false).getMockedBlock(INITIAL_BASE_FEE, GAS_LIMIT, GAS_LIMIT,
-      null, null)
+    assertTrue("no block passed returns initial base fee", calculateNextBaseFee(null) == INITIAL_BASE_FEE)
 
-    // Test 1: No block passed returns initial base fee
-    assertTrue(calculateNextBaseFee(null) == INITIAL_BASE_FEE)
+    assertBaseFeeChange("full block should increase base fee by 12.5%", 100, 1000000000, 1125000000)
+    assertBaseFeeChange("full block should increase base fee by 12.5%", 100, 1672530, 1881596)
+    assertBaseFeeChange("empty block should decrease base fee by 12.5%", 0, 1000000000, 875000000)
+    assertBaseFeeChange("empty block should decrease base fee by 12.5%", 0, 523122, 457732)
+    assertBaseFeeChange("50% filled block should not change base fee", 50, 1000000000, 1000000000)
+    assertBaseFeeChange("50% filled block should not change base fee", 50, 671823, 671823)
 
-    // Test 2: 100% full block passed returns 12.5% increased value
-    assertTrue(calculateNextBaseFee(mockedBlock) == BigInteger.valueOf(1125000000))
+    assertBaseFeeChange("70% filled block should increase base fee by 5%", 70, 1000000000, 1050000000)
+    assertBaseFeeChange("30% filled block should decrease base fee by 5%", 30, 1000000000, 950000000)
+
+    assertBaseFeeChange("base fee should not fall to zero", 0, 1, 1)
+    // because of integer division the base fee cannot decrease anymore beclow 8
+    assertBaseFeeChange("base fee should decrease by one", 0, 8, 7)
+    assertBaseFeeChange("base fee should not decrease below 8", 0, 7, 7)
+    // sanity check: base fee should never reach zero, but even if it does it should increase by at least one here
+    assertBaseFeeChange("base fee should increase at least by one", 51, 0, 1)
+    assertBaseFeeChange("base fee should increase at least by one", 51, 1, 2)
+    assertBaseFeeChange("base fee should increase at least by one", 51, 2, 3)
   }
 }

--- a/sdk/src/test/scala/com/horizen/account/utils/FeeUtilsTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/utils/FeeUtilsTest.scala
@@ -21,7 +21,7 @@ class FeeUtilsTest extends JUnitSuite {
   }
 
   /**
-   * Separate test for calculate next base fee as it is not used in base fee validator test
+   * Separate test for calculating the next base fee as it is not used in base fee validator test.
    */
   @Test
   def calculateNextBaseFeeTest(): Unit = {
@@ -38,7 +38,7 @@ class FeeUtilsTest extends JUnitSuite {
     assertBaseFeeChange("30% filled block should decrease base fee by 5%", 30, 1000000000, 950000000)
 
     assertBaseFeeChange("base fee should not fall to zero", 0, 1, 1)
-    // because of integer division the base fee cannot decrease anymore beclow 8
+    // because of integer division the base fee cannot decrease anymore below 8
     assertBaseFeeChange("base fee should decrease by one", 0, 8, 7)
     assertBaseFeeChange("base fee should not decrease below 8", 0, 7, 7)
     // sanity check: base fee should never reach zero, but even if it does it should increase by at least one here


### PR DESCRIPTION
- refactor `BigInteger` usages:
  - `compareTo(BigInteger.Zero)` => `signum()` same result, better performance
  - `longValue()` => `longValueExact()` make sure we throw an exception instead of working with unexpected values
  - `intValue()` => `intValueExact()` same
- refactor base fee calculation
  - add more test cases to make sure the edge cases are covered
- cleanup RPC methods