### PR TITLE
Fix/fake smart contract function modifiers

### DIFF
--- a/qa/truffle/contracts/ForgerStakes.sol
+++ b/qa/truffle/contracts/ForgerStakes.sol
@@ -16,7 +16,7 @@ interface ForgerStakes {
         bytes1 vrf2;
     }
 
-    function getAllForgersStakes() external returns (StakeInfo[] memory);
+    function getAllForgersStakes() external view returns (StakeInfo[] memory);
 
     function delegate(bytes32 publicKey, bytes32 vrf1, bytes1 vrf2, address owner) external payable returns (StakeID);
 

--- a/qa/truffle/contracts/WithdrawalRequests.sol
+++ b/qa/truffle/contracts/WithdrawalRequests.sol
@@ -12,7 +12,7 @@ interface WithdrawalRequests {
         uint256 value;
     }
 
-    function getWithdrawalRequests(uint32 withdrawalEpoch) external returns (WithdrawalRequest[] memory);
+    function getWithdrawalRequests(uint32 withdrawalEpoch) external view returns (WithdrawalRequest[] memory);
 
     function submitWithdrawalRequest(MCAddress mcAddress) external payable returns (WithdrawalRequest memory);
 }


### PR DESCRIPTION
Add view modifiers to smart contract methods that only read state.
This needed to be added to avoid waiting for unnecessary tx receipt during testing (hardhat, truffle...).