### PR TITLE
Additional RPC functions

### DIFF
--- a/evm/src/main/java/com/horizen/evm/LibEvm.java
+++ b/evm/src/main/java/com/horizen/evm/LibEvm.java
@@ -177,6 +177,10 @@ final class LibEvm {
         invoke("StateRemoveStorageBytes", new StorageParams(handle, address, key));
     }
 
+    public static ProofAccountResult stateGetProof(int handle, byte[] address, byte[][] keys) {
+        return invoke("StateGetProof", new ProofParams(handle, address, keys), ProofAccountResult.class);
+    }
+
     public static int stateSnapshot(int handle) {
         return invoke("StateSnapshot", new HandleParams(handle), int.class);
     }

--- a/evm/src/main/java/com/horizen/evm/StateDB.java
+++ b/evm/src/main/java/com/horizen/evm/StateDB.java
@@ -1,6 +1,7 @@
 package com.horizen.evm;
 
 import com.horizen.evm.interop.EvmLog;
+import com.horizen.evm.interop.ProofAccountResult;
 import com.horizen.evm.utils.Converter;
 
 import java.math.BigInteger;
@@ -258,6 +259,16 @@ public class StateDB extends ResourceHandle {
             default:
                 throw new RuntimeException("invalid storage strategy");
         }
+    }
+
+    /**
+     * Get the Merkle-proof for a given account and optionally some storage keys.
+     * @param address account address
+     * @param keys storage keys
+     * @return proofs
+     */
+    public ProofAccountResult getProof(byte[] address, byte[][] keys) {
+        return LibEvm.stateGetProof(handle, address, keys);
     }
 
     /**

--- a/evm/src/main/java/com/horizen/evm/interop/EvmLog.java
+++ b/evm/src/main/java/com/horizen/evm/interop/EvmLog.java
@@ -7,7 +7,6 @@ import com.horizen.evm.utils.Converter;
 import com.horizen.evm.utils.Hash;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 public class EvmLog {
     public Address address;
@@ -25,7 +24,7 @@ public class EvmLog {
         if (data != null) {
             this.data = data;
         }
-     }
+    }
 
     public EvmLog() {
     }
@@ -34,59 +33,46 @@ public class EvmLog {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        EvmLog log = (EvmLog) o;
-
-        if ((address == null && log.address != null) ||
-                (log.address == null && address != null))
-            return false;
-        boolean areEqual = (address == null) || Arrays.equals(address.toBytes(), log.address.toBytes());
-        areEqual = areEqual &&
-                Arrays.equals(topics, log.topics) &&
-                Arrays.equals(data, log.data);
-        return areEqual;
+        var log = (EvmLog) o;
+        if ((address == null) != (log.address == null)) return false;
+        return ((address == null) || Arrays.equals(address.toBytes(), log.address.toBytes())) &&
+            Arrays.equals(topics, log.topics) &&
+            Arrays.equals(data, log.data);
     }
 
     @Override
     public int hashCode() {
-        int result = 1;
-        byte[] addressBytes = (address == null) ? null : address.toBytes();
+        var result = 1;
+        var addressBytes = (address == null) ? null : address.toBytes();
         result = result + Arrays.hashCode(addressBytes);
-        if (topics != null && topics.length != 0){
-            for (int i = 0; i < topics.length; i++) {
-                byte[] topic = (topics[i] == null) ? null : topics[i].toBytes();
+        if (topics != null && topics.length != 0) {
+            for (var hash : topics) {
+                var topic = (hash == null) ? null : hash.toBytes();
                 result = 31 * result + Arrays.hashCode(topic);
             }
-        }
-        else {
+        } else {
             result = 31 * result + Arrays.hashCode(topics);
         }
         result = 31 * result + Arrays.hashCode(data);
         return result;
     }
 
+    private String getTopicsString() {
+        if (topics == null) return "null";
+        var strs = Arrays
+            .stream(topics)
+            .map(topic -> topic == null ? "null" : Converter.toHexString(topic.toBytes()))
+            .toArray(String[]::new);
+        return String.format("[%s]", String.join(",", strs));
+    }
 
     @Override
     public String toString() {
-        String addressString = (address == null) ? "null" : Converter.toHexString(address.toBytes());
-
-
-        String topicsStr = "topics{";
-
-        if (topics != null) {
-            for (int i = 0; i < topics.length; i++) {
-                String topic = (topics[i] == null) ? "null" : Converter.toHexString(topics[i].toBytes());
-                topicsStr = topicsStr.concat(" " + topic);
-            }
-        }
-        else
-            topicsStr = topicsStr.concat("null");
-        topicsStr = topicsStr.concat("}");
-
-        String dataString = (data == null) ? "null" : Converter.toHexString(data);
         return String.format(
-                "EvmLog (log consensus data) {address=%s, topics=%s, data=%s}",
-                addressString,
-                topicsStr,
-                dataString);
+            "EvmLog (log consensus data) {address=%s, topics=%s, data=%s}",
+            address == null ? "null" : Converter.toHexString(address.toBytes()),
+            getTopicsString(),
+            data == null ? "null" : Converter.toHexString(data)
+        );
     }
 }

--- a/evm/src/main/java/com/horizen/evm/interop/ProofAccountResult.java
+++ b/evm/src/main/java/com/horizen/evm/interop/ProofAccountResult.java
@@ -1,0 +1,22 @@
+package com.horizen.evm.interop;
+
+import com.horizen.evm.utils.Address;
+import com.horizen.evm.utils.Hash;
+
+import java.math.BigInteger;
+
+public class ProofAccountResult {
+    public Address address;
+    public String[] accountProof;
+    public BigInteger balance;
+    public Hash codeHash;
+    public BigInteger nonce;
+    public Hash storageHash;
+    public ProofStorageResult[] storageProof;
+
+    public static class ProofStorageResult {
+        public String key;
+        public BigInteger value;
+        public String[] proof;
+    }
+}

--- a/evm/src/main/java/com/horizen/evm/interop/ProofParams.java
+++ b/evm/src/main/java/com/horizen/evm/interop/ProofParams.java
@@ -1,0 +1,21 @@
+package com.horizen.evm.interop;
+
+import com.horizen.evm.utils.Address;
+import com.horizen.evm.utils.Hash;
+
+import java.util.Arrays;
+
+public class ProofParams extends AccountParams {
+    public Hash[] keys;
+
+    public ProofParams() {
+    }
+
+    public ProofParams(int handle, byte[] address, byte[][] keys) {
+        super(handle, address);
+        this.address = Address.FromBytes(address);
+        this.keys = Arrays.stream(keys).map(Hash::FromBytes).toArray(Hash[]::new);
+    }
+}
+
+

--- a/evm/src/test/java/com/horizen/evm/interop/EvmLogTest.java
+++ b/evm/src/test/java/com/horizen/evm/interop/EvmLogTest.java
@@ -15,25 +15,22 @@ public class EvmLogTest extends LibEvmTestBase {
 
     @Test
     public void nullEvmLogToStringTest() {
-
         EvmLog defaultLog = new EvmLog();
-
-        assertEquals("EvmLog (log consensus data) {address=null, topics=topics{}, data=}", defaultLog.toString());
+        assertEquals("EvmLog (log consensus data) {address=null, topics=[], data=}", defaultLog.toString());
 
         EvmLog nullLog = new EvmLog();
-
         nullLog.data = null;
         nullLog.topics = null;
-        assertEquals("EvmLog (log consensus data) {address=null, topics=topics{null}, data=null}", nullLog.toString());
+        assertEquals("EvmLog (log consensus data) {address=null, topics=null, data=null}", nullLog.toString());
 
         EvmLog invalidTopicsLog = new EvmLog();
         invalidTopicsLog.topics = new Hash[2];
-        assertEquals("EvmLog (log consensus data) {address=null, topics=topics{ null null}, data=}", invalidTopicsLog.toString());
+        assertEquals(
+            "EvmLog (log consensus data) {address=null, topics=[null,null], data=}", invalidTopicsLog.toString());
     }
 
     @Test
     public void nullEvmLogHashCodeTest() {
-
         EvmLog defaultLog = new EvmLog();
         EvmLog defaultLog2 = new EvmLog();
         assertEquals(defaultLog, defaultLog2);
@@ -67,14 +64,17 @@ public class EvmLogTest extends LibEvmTestBase {
 
         EvmLog randomLog = new EvmLog();
         var addressBytes = new byte[Address.LENGTH];
-               new Random().nextBytes(addressBytes);
-        var address = Address.FromBytes(addressBytes);
-        randomLog.address = address;
+        new Random().nextBytes(addressBytes);
+        randomLog.address = Address.FromBytes(addressBytes);
         var topics = new Hash[4];
-        topics[0] = Hash.FromBytes(Converter.fromHexString("0000000000000000000000000000000000000000000000000000000000000000"));
-        topics[1] = Hash.FromBytes(Converter.fromHexString("1111111111111111111111111111111111111111111111111111111111111111"));
-        topics[2] = Hash.FromBytes(Converter.fromHexString("2222222222222222222222222222222222222222222222222222222222222222"));
-        topics[3] = Hash.FromBytes(Converter.fromHexString("3333333333333333333333333333333333333333333333333333333333333333"));
+        topics[0] = Hash.FromBytes(
+            Converter.fromHexString("0000000000000000000000000000000000000000000000000000000000000000"));
+        topics[1] = Hash.FromBytes(
+            Converter.fromHexString("1111111111111111111111111111111111111111111111111111111111111111"));
+        topics[2] = Hash.FromBytes(
+            Converter.fromHexString("2222222222222222222222222222222222222222222222222222222222222222"));
+        topics[3] = Hash.FromBytes(
+            Converter.fromHexString("3333333333333333333333333333333333333333333333333333333333333333"));
 
         randomLog.topics = topics;
         var data = Converter.fromHexString("aabbccddeeff22");
@@ -83,8 +83,5 @@ public class EvmLogTest extends LibEvmTestBase {
         EvmLog randomLog2 = new EvmLog(Address.FromBytes(addressBytes), topics, data);
         assertEquals(randomLog, randomLog2);
         assertEquals(randomLog.hashCode(), randomLog2.hashCode());
-
-
     }
-
 }

--- a/libevm/lib/geth_internal/proof.go
+++ b/libevm/lib/geth_internal/proof.go
@@ -1,0 +1,80 @@
+package geth_internal
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// AccountResult holds the results of GetProof
+type AccountResult struct {
+	Address      common.Address  `json:"address"`
+	AccountProof []string        `json:"accountProof"`
+	Balance      *hexutil.Big    `json:"balance"`
+	CodeHash     common.Hash     `json:"codeHash"`
+	Nonce        hexutil.Uint64  `json:"nonce"`
+	StorageHash  common.Hash     `json:"storageHash"`
+	StorageProof []StorageResult `json:"storageProof"`
+}
+
+type StorageResult struct {
+	Key   string       `json:"key"`
+	Value *hexutil.Big `json:"value"`
+	Proof []string     `json:"proof"`
+}
+
+// GetProof returns the Merkle-proof for a given account and optionally some storage keys.
+func GetProof(state *state.StateDB, address common.Address, storageKeys []string) (*AccountResult, error) {
+	storageTrie := state.StorageTrie(address)
+	storageHash := types.EmptyRootHash
+	codeHash := state.GetCodeHash(address)
+	storageProof := make([]StorageResult, len(storageKeys))
+
+	// if we have a storageTrie, (which means the account exists), we can update the storagehash
+	if storageTrie != nil {
+		storageHash = storageTrie.Hash()
+	} else {
+		// no storageTrie means the account does not exist, so the codeHash is the hash of an empty bytearray.
+		codeHash = crypto.Keccak256Hash(nil)
+	}
+
+	// create the proof for the storageKeys
+	for i, key := range storageKeys {
+		if storageTrie != nil {
+			proof, storageError := state.GetStorageProof(address, common.HexToHash(key))
+			if storageError != nil {
+				return nil, storageError
+			}
+			storageProof[i] = StorageResult{key, (*hexutil.Big)(state.GetState(address, common.HexToHash(key)).Big()), toHexSlice(proof)}
+		} else {
+			storageProof[i] = StorageResult{key, &hexutil.Big{}, []string{}}
+		}
+	}
+
+	// create the accountProof
+	accountProof, proofErr := state.GetProof(address)
+	if proofErr != nil {
+		return nil, proofErr
+	}
+
+	return &AccountResult{
+		Address:      address,
+		AccountProof: toHexSlice(accountProof),
+		Balance:      (*hexutil.Big)(state.GetBalance(address)),
+		CodeHash:     codeHash,
+		Nonce:        hexutil.Uint64(state.GetNonce(address)),
+		StorageHash:  storageHash,
+		StorageProof: storageProof,
+	}, state.Error()
+}
+
+// toHexSlice creates a slice of hex-strings based on []byte.
+func toHexSlice(b [][]byte) []string {
+	r := make([]string, len(b))
+	for i := range b {
+		r[i] = hexutil.Encode(b[i])
+	}
+	return r
+}

--- a/qa/SidechainTestFramework/account/requirements.txt
+++ b/qa/SidechainTestFramework/account/requirements.txt
@@ -2,3 +2,4 @@ eth_abi
 pycryptodome
 rlp
 eth_utils
+eth_bloom

--- a/qa/SidechainTestFramework/scutil.py
+++ b/qa/SidechainTestFramework/scutil.py
@@ -16,6 +16,7 @@ from contextlib import closing
 from SidechainTestFramework.sidechainauthproxy import SidechainAuthServiceProxy
 from test_framework.mc_test.mc_test import generate_random_field_element_hex, get_field_element_with_padding
 from test_framework.util import get_spendable, swap_bytes, assert_equal, initialize_new_sidechain_in_mainchain
+from eth_utils import add_0x_prefix
 
 WAIT_CONST = 1
 
@@ -1260,6 +1261,8 @@ def computeForgedTxGasUsed(sc_node, tx_hash, tracing_on=False):
     return int(receiptJson['gasUsed'], 16)
 
 def computeForgedTxFee(sc_node, tx_hash, tracing_on=False):
+    # make sure the transaction hash prefixed with 0x
+    tx_hash = add_0x_prefix(tx_hash)
     resp = sc_node.rpc_eth_getTransactionByHash(tx_hash)
     if not 'result' in resp:
         raise Exception('Rpc eth_getTransactionByHash cmd failed: {}'.format(json.dumps(resp, indent=2)))

--- a/qa/sc_evm_backward_transfer.py
+++ b/qa/sc_evm_backward_transfer.py
@@ -1,23 +1,31 @@
 #!/usr/bin/env python3
+import json
 import logging
 import time
+
 import base58
 from eth_abi import decode
-from eth_utils import to_checksum_address, remove_0x_prefix, event_signature_to_log_topic, encode_hex
+from eth_utils import add_0x_prefix, encode_hex, event_signature_to_log_topic, remove_0x_prefix
 
 from SidechainTestFramework.account.httpCalls.transaction.allWithdrawRequests import all_withdrawal_requests
 from SidechainTestFramework.account.httpCalls.transaction.withdrawCoins import withdrawcoins
 from SidechainTestFramework.account.httpCalls.wallet.balance import http_wallet_balance
-from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
-    SCNetworkConfiguration
-from SidechainTestFramework.sc_forging_util import *
+from SidechainTestFramework.sc_boostrap_info import (
+    MCConnectionInfo, SCCreationInfo, SCNetworkConfiguration,
+    SCNodeConfiguration,
+)
+from SidechainTestFramework.sc_forging_util import check_mcreference_presence, check_mcreferencedata_presence
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, \
-    start_sc_nodes, generate_next_blocks, generate_next_block, \
-    AccountModelBlockVersion, EVM_APP_BINARY, is_mainchain_block_included_in_sc_block, assert_true, \
-    check_mainchain_block_reference_info, convertZenToZennies, convertZenniesToWei, computeForgedTxFee
-from test_framework.util import assert_equal, assert_false, start_nodes, \
-    websocket_port_by_mc_node_index, forward_transfer_to_sidechain, fail, hex_str_to_bytes
+from SidechainTestFramework.scutil import (
+    AccountModelBlockVersion, EVM_APP_BINARY, assert_true,
+    bootstrap_sidechain_nodes, check_mainchain_block_reference_info, computeForgedTxFee, convertZenToZennies,
+    convertZenniesToWei, generate_next_block, generate_next_blocks, is_mainchain_block_included_in_sc_block,
+    start_sc_nodes,
+)
+from test_framework.util import (
+    assert_equal, assert_false, fail, forward_transfer_to_sidechain, hex_str_to_bytes,
+    start_nodes, websocket_port_by_mc_node_index,
+)
 
 """
 Checks Certificate automatic creation and submission to MC for an EVM Sidechain:
@@ -220,7 +228,7 @@ class SCEvmBackwardTransfer(SidechainTestFramework):
         if "error" in res:
             fail(f"Creating Withdrawal request failed: " + json.dumps(res))
 
-        tx_id = res["result"]["transactionId"]
+        tx_id = add_0x_prefix(res["result"]["transactionId"])
 
         # Check the balance hasn't changed yet
         new_balance = http_wallet_balance(sc_node, evm_address)
@@ -270,7 +278,7 @@ class SCEvmBackwardTransfer(SidechainTestFramework):
         # Generate SC block
         generate_next_blocks(sc_node, "first node", 1)
 
-        tx_id = res["result"]["transactionId"]
+        tx_id = add_0x_prefix(res["result"]["transactionId"])
         #Check the receipt
         receipt = sc_node.rpc_eth_getTransactionReceipt(tx_id)
 

--- a/qa/sc_evm_backward_transfer_2.py
+++ b/qa/sc_evm_backward_transfer_2.py
@@ -1,20 +1,29 @@
 #!/usr/bin/env python3
+import json
+import logging
 import time
-from decimal import Decimal
+
+from eth_utils import add_0x_prefix
 
 from SidechainTestFramework.account.httpCalls.transaction.allWithdrawRequests import all_withdrawal_requests
 from SidechainTestFramework.account.httpCalls.transaction.withdrawCoins import withdrawcoins
 from SidechainTestFramework.account.httpCalls.wallet.balance import http_wallet_balance
-from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
-    SCNetworkConfiguration
-from SidechainTestFramework.sc_forging_util import *
+from SidechainTestFramework.sc_boostrap_info import (
+    MCConnectionInfo, SCCreationInfo, SCNetworkConfiguration,
+    SCNodeConfiguration,
+)
+from SidechainTestFramework.sc_forging_util import check_mcreference_presence, check_mcreferencedata_presence
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, \
-    start_sc_nodes, generate_next_blocks, generate_next_block, \
-    AccountModelBlockVersion, EVM_APP_BINARY, is_mainchain_block_included_in_sc_block, assert_true, \
-    check_mainchain_block_reference_info, convertZenToZennies, convertZenniesToWei, computeForgedTxFee
-from test_framework.util import assert_equal, assert_false, start_nodes, \
-    websocket_port_by_mc_node_index, forward_transfer_to_sidechain, fail
+from SidechainTestFramework.scutil import (
+    AccountModelBlockVersion, EVM_APP_BINARY, assert_true,
+    bootstrap_sidechain_nodes, check_mainchain_block_reference_info, computeForgedTxFee, convertZenToZennies,
+    convertZenniesToWei, generate_next_block, generate_next_blocks, is_mainchain_block_included_in_sc_block,
+    start_sc_nodes,
+)
+from test_framework.util import (
+    assert_equal, assert_false, fail, forward_transfer_to_sidechain, start_nodes,
+    websocket_port_by_mc_node_index,
+)
 
 """
 This is similar to sc_evm_backward_transfer.py, but uses a longer withdrawal epoch length.
@@ -206,7 +215,7 @@ class SCEvmBackwardTransfer2(SidechainTestFramework):
         if "error" in res:
             fail(f"Creating Withdrawal request failed: " + json.dumps(res))
 
-        tx_id = res["result"]["transactionId"]
+        tx_id = add_0x_prefix(res["result"]["transactionId"])
 
         # Check the balance hasn't changed yet
         new_balance = http_wallet_balance(sc_node, evm_address)

--- a/qa/sc_evm_bwt_corner_cases.py
+++ b/qa/sc_evm_bwt_corner_cases.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python3
+import json
 import time
+
+from eth_utils import add_0x_prefix, remove_0x_prefix
 
 from SidechainTestFramework.account.httpCalls.transaction.allWithdrawRequests import all_withdrawal_requests
 from SidechainTestFramework.account.httpCalls.transaction.withdrawCoins import withdrawcoins
 from SidechainTestFramework.account.httpCalls.wallet.balance import http_wallet_balance
-from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
-    SCNetworkConfiguration
-from SidechainTestFramework.sc_forging_util import *
+from SidechainTestFramework.sc_boostrap_info import (
+    MCConnectionInfo, SCCreationInfo, SCNetworkConfiguration,
+    SCNodeConfiguration,
+)
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, \
-    start_sc_nodes, generate_next_blocks, generate_next_block, \
-    AccountModelBlockVersion, EVM_APP_BINARY, convertZenToZennies, convertZenniesToWei, \
-    computeForgedTxFee
-from test_framework.util import assert_equal, start_nodes, \
-    websocket_port_by_mc_node_index, forward_transfer_to_sidechain, fail
+from SidechainTestFramework.scutil import (
+    AccountModelBlockVersion, EVM_APP_BINARY, bootstrap_sidechain_nodes,
+    computeForgedTxFee, convertZenToZennies, convertZenniesToWei, generate_next_block, generate_next_blocks,
+    start_sc_nodes,
+)
+from test_framework.util import (
+    assert_equal, fail, forward_transfer_to_sidechain, start_nodes,
+    websocket_port_by_mc_node_index,
+)
 
 """
 Checks withdrawal requests creation in special cases:
@@ -130,7 +137,7 @@ class SCEvmBWTCornerCases(SidechainTestFramework):
         res = withdrawcoins(sc_node, mc_address1, bt_amount_in_zennies)
         if "error" in res:
             fail(f"Creating Withdrawal request failed: " + json.dumps(res))
-        tx_id = res["result"]["transactionId"]
+        tx_id = add_0x_prefix(res["result"]["transactionId"])
 
         generate_next_block(sc_node, "first node")
 
@@ -155,7 +162,7 @@ class SCEvmBWTCornerCases(SidechainTestFramework):
         # Verifies there is the transaction in the block
 
         tx_in_block = sc_node.block_best()["result"]["block"]["sidechainTransactions"][0]["id"]
-        assert_equal(tx_id, tx_in_block, "Tx is not in the block")
+        assert_equal(remove_0x_prefix(tx_id), tx_in_block, "Tx is not in the block")
 
         # *************** Test 3: Withdrawal amount not valid zen amount (e.g. 1 wei) TODO *****************
         # *************** Test 4: Test all_withdrawal_requests with a value >0. Being non-payable, it should fail TODO *****************

--- a/qa/sc_evm_closed_forger.py
+++ b/qa/sc_evm_closed_forger.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python3
 import json
 import logging
-
 from decimal import Decimal
 
-from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
-    SCNetworkConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH, SCForgerConfiguration
+from eth_utils import add_0x_prefix
+
+from SidechainTestFramework.sc_boostrap_info import (
+    LARGE_WITHDRAWAL_EPOCH_LENGTH, MCConnectionInfo, SCCreationInfo,
+    SCForgerConfiguration, SCNetworkConfiguration, SCNodeConfiguration,
+)
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from test_framework.util import assert_equal, assert_true, start_nodes, \
-    websocket_port_by_mc_node_index, forward_transfer_to_sidechain, assert_false
-from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, \
-    start_sc_nodes, AccountModelBlockVersion, EVM_APP_BINARY, generate_next_block, \
-    convertZenToZennies, connect_sc_nodes, convertZenToWei, generate_secrets, \
-    generate_vrf_secrets, get_account_balance
+from SidechainTestFramework.scutil import (
+    AccountModelBlockVersion, EVM_APP_BINARY, bootstrap_sidechain_nodes,
+    connect_sc_nodes, convertZenToWei, convertZenToZennies, generate_next_block, generate_secrets, generate_vrf_secrets,
+    get_account_balance, start_sc_nodes,
+)
+from test_framework.util import (
+    assert_equal, assert_false, assert_true, forward_transfer_to_sidechain, start_nodes,
+    websocket_port_by_mc_node_index,
+)
 
 """
 Check the EVM bootstrap feature.
@@ -27,7 +33,6 @@ Test:
 
 
 """
-
 
 
 class SCEvmClosedForgerList(SidechainTestFramework):
@@ -96,7 +101,7 @@ class SCEvmClosedForgerList(SidechainTestFramework):
         tx_hash = makeForgerStakeJsonRes['result']["transactionId"]
         logging.info("Getting receipt for txhash={}".format(tx_hash))
 
-        receipt = sc_node.rpc_eth_getTransactionReceipt(tx_hash)
+        receipt = sc_node.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_hash))
         status = int(receipt['result']['status'], 16)
         # status == 1 is succesful
         return (status == 1)

--- a/qa/sc_evm_eoa2eoa.py
+++ b/qa/sc_evm_eoa2eoa.py
@@ -3,17 +3,22 @@ import json
 import logging
 from decimal import Decimal
 
-from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
-    SCNetworkConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH
+from eth_utils import add_0x_prefix
+
+from SidechainTestFramework.sc_boostrap_info import (
+    LARGE_WITHDRAWAL_EPOCH_LENGTH, MCConnectionInfo, SCCreationInfo,
+    SCNetworkConfiguration, SCNodeConfiguration,
+)
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from test_framework.util import assert_equal, assert_true, start_nodes, \
-    websocket_port_by_mc_node_index, forward_transfer_to_sidechain, fail, assert_false
-from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, \
-    start_sc_nodes, \
-    check_mainchain_block_reference_info, \
-    AccountModelBlockVersion, EVM_APP_BINARY, generate_next_blocks, generate_next_block, generate_account_proposition, \
-    convertZenniesToWei, convertZenToZennies, connect_sc_nodes, get_account_balance, convertZenToWei, \
-    ForgerStakeSmartContractAddress, WithdrawalReqSmartContractAddress, convertWeiToZen, computeForgedTxFee
+from SidechainTestFramework.scutil import (
+    AccountModelBlockVersion, EVM_APP_BINARY, ForgerStakeSmartContractAddress,
+    WithdrawalReqSmartContractAddress, bootstrap_sidechain_nodes, connect_sc_nodes, convertWeiToZen, convertZenToWei,
+    convertZenToZennies, generate_next_block, get_account_balance, start_sc_nodes,
+)
+from test_framework.util import (
+    assert_equal, assert_true, fail, forward_transfer_to_sidechain, start_nodes,
+    websocket_port_by_mc_node_index,
+)
 
 """
 Configuration: 
@@ -104,7 +109,7 @@ class SCEvmEOA2EOA(SidechainTestFramework):
         final_balance_to = get_account_balance(to_sc_node, to_addr)
 
         # check receipt, meanwhile do some check on amounts
-        receipt = from_sc_node.rpc_eth_getTransactionReceipt(tx_hash)
+        receipt = from_sc_node.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_hash))
         if print_json_results:
             logging.info(receipt)
         status = int(receipt['result']['status'], 16)
@@ -192,7 +197,7 @@ class SCEvmEOA2EOA(SidechainTestFramework):
         assert_true(ret, msg)
 
         # moreover, check we have consistent chainId and ser/deser signature v value in tx json, as per EIP155
-        txJsonResult = sc_node_1.rpc_eth_getTransactionByHash(txHash)['result']
+        txJsonResult = sc_node_1.rpc_eth_getTransactionByHash(add_0x_prefix(txHash))['result']
         chainId = int(txJsonResult['chainId'], 16)
         sigV = int(txJsonResult['v'], 16)
         assert_equal(chainId, getChainIdFromSignatureV(sigV))

--- a/qa/sc_evm_forger.py
+++ b/qa/sc_evm_forger.py
@@ -1,25 +1,29 @@
 #!/usr/bin/env python3
 import json
+import logging
 import time
 from decimal import Decimal
 
 from eth_abi import decode
-from eth_utils import remove_0x_prefix, event_signature_to_log_topic, encode_hex, to_hex
+from eth_utils import add_0x_prefix, encode_hex, event_signature_to_log_topic, remove_0x_prefix, to_hex
 
 from SidechainTestFramework.account.ac_use_smart_contract import SmartContract
-from SidechainTestFramework.account.address_util import format_evm, format_eoa
-from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
-    SCNetworkConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH
+from SidechainTestFramework.account.address_util import format_eoa, format_evm
+from SidechainTestFramework.sc_boostrap_info import (
+    LARGE_WITHDRAWAL_EPOCH_LENGTH, MCConnectionInfo, SCCreationInfo,
+    SCNetworkConfiguration, SCNodeConfiguration,
+)
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from SidechainTestFramework.scutil import WithdrawalReqSmartContractAddress
-from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, \
-    start_sc_nodes, AccountModelBlockVersion, EVM_APP_BINARY, generate_next_block, convertZenniesToWei, \
-    convertZenToZennies, connect_sc_nodes, convertZenToWei, ForgerStakeSmartContractAddress, get_account_balance, \
-    computeForgedTxFee, convertWeiToZen
+from SidechainTestFramework.scutil import (
+    AccountModelBlockVersion, EVM_APP_BINARY, ForgerStakeSmartContractAddress,
+    WithdrawalReqSmartContractAddress, bootstrap_sidechain_nodes, computeForgedTxFee, connect_sc_nodes, convertWeiToZen,
+    convertZenToWei, convertZenToZennies, convertZenniesToWei, generate_next_block, get_account_balance, start_sc_nodes,
+)
 from sc_evm_test_contract_contract_deployment_and_interaction import random_byte_string
-from test_framework.util import assert_equal, assert_true, start_nodes, \
-    websocket_port_by_mc_node_index, forward_transfer_to_sidechain, fail
-from test_framework.util import hex_str_to_bytes
+from test_framework.util import (
+    assert_equal, assert_true, fail, forward_transfer_to_sidechain, hex_str_to_bytes,
+    start_nodes, websocket_port_by_mc_node_index,
+)
 
 """
 Configuration: 
@@ -251,7 +255,8 @@ class SCEvmForger(SidechainTestFramework):
         self.sc_sync_all()
 
         # Checking the receipt
-        receipt = sc_node_1.rpc_eth_getTransactionReceipt(makeForgerStakeJsonRes['result']['transactionId'])
+        tx_id = makeForgerStakeJsonRes['result']['transactionId']
+        receipt = sc_node_1.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_id))
         status = int(receipt['result']['status'], 16)
         assert_equal(0, status, "Make forger stake with fake smart contract as owner should create a failed tx")
         # Check the logs
@@ -296,7 +301,8 @@ class SCEvmForger(SidechainTestFramework):
         self.sc_sync_all()
 
         # Checking the receipt
-        receipt = sc_node_1.rpc_eth_getTransactionReceipt(makeForgerStakeJsonRes['result']['transactionId'])
+        tx_id = makeForgerStakeJsonRes['result']['transactionId']
+        receipt = sc_node_1.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_id))
         status = int(receipt['result']['status'], 16)
         assert_equal(0, status, "Make forger stake with fake smart contract as owner should create a failed tx")
 
@@ -327,7 +333,7 @@ class SCEvmForger(SidechainTestFramework):
         print_current_epoch_and_slot(sc_node_1)
 
         # Checking the receipt
-        receipt = sc_node_1.rpc_eth_getTransactionReceipt(tx_hash)
+        receipt = sc_node_1.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_hash))
         status = int(receipt['result']['status'], 16)
         assert_equal(1, status)
 
@@ -372,7 +378,7 @@ class SCEvmForger(SidechainTestFramework):
         print_current_epoch_and_slot(sc_node_1)
 
         # Checking the receipt
-        receipt = sc_node_1.rpc_eth_getTransactionReceipt(tx_hash)
+        receipt = sc_node_1.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_hash))
         status = int(receipt['result']['status'], 16)
         assert_equal(1, status)
 
@@ -523,7 +529,7 @@ class SCEvmForger(SidechainTestFramework):
         print_current_epoch_and_slot(sc_node_1)
 
         # Checking the receipt
-        receipt = sc_node_1.rpc_eth_getTransactionReceipt(tx_hash)
+        receipt = sc_node_1.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_hash))
         status = int(receipt['result']['status'], 16)
         assert_equal(1, status)
 
@@ -564,7 +570,7 @@ class SCEvmForger(SidechainTestFramework):
 
         # all balance is now at the expected owner address
         # Checking the receipt
-        receipt = sc_node_1.rpc_eth_getTransactionReceipt(tx_hash)
+        receipt = sc_node_1.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_hash))
         status = int(receipt['result']['status'], 16)
         assert_equal(1, status)
 

--- a/qa/sc_evm_forging_fee_payments.py
+++ b/qa/sc_evm_forging_fee_payments.py
@@ -1,20 +1,27 @@
 #!/usr/bin/env python3
+import json
 import logging
+import math
+
+from eth_utils import add_0x_prefix
 
 from SidechainTestFramework.account.httpCalls.createEIP1559Transaction import createEIP1559Transaction
+from SidechainTestFramework.sc_boostrap_info import (
+    MCConnectionInfo, SCCreationInfo, SCNetworkConfiguration,
+    SCNodeConfiguration,
+)
+from SidechainTestFramework.sc_forging_util import check_mcreference_presence
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
-    SCNetworkConfiguration
+from SidechainTestFramework.scutil import (
+    AccountModelBlockVersion, EVM_APP_BINARY, bootstrap_sidechain_nodes,
+    computeForgedTxFee, connect_sc_nodes, convertZenToWei, convertZenToZennies, convertZenniesToWei,
+    generate_account_proposition, generate_next_block, get_account_balance, start_sc_nodes,
+)
 from httpCalls.block.getFeePayments import http_block_getFeePayments
-from test_framework.util import initialize_chain_clean, start_nodes, \
-    websocket_port_by_mc_node_index, forward_transfer_to_sidechain
-from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, start_sc_nodes, \
-    connect_sc_nodes, generate_next_block, AccountModelBlockVersion, \
-    EVM_APP_BINARY, convertZenToZennies, convertZenniesToWei, get_account_balance, generate_account_proposition, \
-    convertZenToWei, computeForgedTxFee
-from SidechainTestFramework.sc_forging_util import *
-
-import math
+from test_framework.util import (
+    assert_equal, fail, forward_transfer_to_sidechain, initialize_chain_clean, start_nodes,
+    websocket_port_by_mc_node_index,
+)
 
 """
 Info about forger account block fee payments
@@ -209,7 +216,7 @@ class ScEvmForgingFeePayments(SidechainTestFramework):
       transferred_amount_in_zen_2 = 0.001
       transferred_amount_in_wei_2 = convertZenToWei(transferred_amount_in_zen_2)
 
-      blockJson = sc_node_2.rpc_eth_getBlockByHash(sc_middle_we_block_id, False)['result']
+      blockJson = sc_node_2.rpc_eth_getBlockByHash(add_0x_prefix(sc_middle_we_block_id), False)['result']
       if (blockJson is None):
           raise Exception('Unexpected error: block not found {}'.format(sc_middle_we_block_id))
       baseFeePerGas = int(blockJson['baseFeePerGas'], 16)

--- a/qa/sc_evm_rpc_invalid_txs.py
+++ b/qa/sc_evm_rpc_invalid_txs.py
@@ -4,13 +4,16 @@ from decimal import Decimal
 
 from SidechainTestFramework.account.address_util import format_evm
 from SidechainTestFramework.account.eoa_util import eoa_transaction
-from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, SCCreationInfo, MCConnectionInfo, \
-    SCNetworkConfiguration, LARGE_WITHDRAWAL_EPOCH_LENGTH
+from SidechainTestFramework.sc_boostrap_info import (
+    LARGE_WITHDRAWAL_EPOCH_LENGTH, MCConnectionInfo, SCCreationInfo,
+    SCNetworkConfiguration, SCNodeConfiguration,
+)
 from SidechainTestFramework.sc_test_framework import SidechainTestFramework
-from SidechainTestFramework.scutil import bootstrap_sidechain_nodes, start_sc_nodes, generate_next_block, \
-    EVM_APP_BINARY, AccountModelBlockVersion, assert_true, convertZenToWei
-from test_framework.util import start_nodes, \
-    websocket_port_by_mc_node_index, forward_transfer_to_sidechain
+from SidechainTestFramework.scutil import (
+    AccountModelBlockVersion, EVM_APP_BINARY, assert_true,
+    bootstrap_sidechain_nodes, convertZenToWei, generate_next_block, start_sc_nodes,
+)
+from test_framework.util import forward_transfer_to_sidechain, start_nodes, websocket_port_by_mc_node_index
 
 """
 Check that sending an invalid transaction to the RPC method eth_sendRawTransaction returns an error

--- a/sdk/src/main/java/com/horizen/account/api/rpc/types/Quantity.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/types/Quantity.java
@@ -27,6 +27,10 @@ public class Quantity {
         return value;
     }
 
+    public BigInteger toNumber() {
+        return Numeric.decodeQuantity(value);
+    }
+
     @Override
     public String toString() {
         return String.format("Quantity{value='%s'}", value);

--- a/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
@@ -523,4 +523,15 @@ class EthService(
         .orNull
     }
   }
+
+  @RpcMethod("eth_getStorageAt")
+  @RpcOptionalParameters(1)
+  def getStorageAt(address: Address, key: Quantity, tag: String): Hash = {
+    val storageKey = Numeric.toBytesPadded(key.toNumber, 32)
+    applyOnAccountView { nodeView =>
+      getStateViewAtTag(nodeView, tag) { (stateView, _) =>
+        Hash.FromBytes(stateView.getAccountStorage(address.toBytes, storageKey))
+      }
+    }
+  }
 }

--- a/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
@@ -146,7 +146,7 @@ class EthService(
     applyOnAccountView { nodeView =>
       nodeView.history
         .getStorageBlockById(getBlockId(nodeView))
-        .map(_.transactions.count(_.isInstanceOf[EthereumTransaction]))
+        .map(_.transactions.size)
         .map(new Quantity(_))
         .orNull
     }

--- a/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
@@ -18,7 +18,7 @@ import com.horizen.account.utils.EthereumTransactionDecoder
 import com.horizen.account.wallet.AccountWallet
 import com.horizen.api.http.SidechainTransactionActor.ReceivableMessages.BroadcastTransaction
 import com.horizen.chain.SidechainBlockInfo
-import com.horizen.evm.interop.TraceParams
+import com.horizen.evm.interop.{ProofAccountResult, TraceParams}
 import com.horizen.evm.utils.{Address, Hash}
 import com.horizen.params.NetworkParams
 import com.horizen.transaction.exception.TransactionSemanticValidityException
@@ -531,6 +531,17 @@ class EthService(
     applyOnAccountView { nodeView =>
       getStateViewAtTag(nodeView, tag) { (stateView, _) =>
         Hash.FromBytes(stateView.getAccountStorage(address.toBytes, storageKey))
+      }
+    }
+  }
+
+  @RpcMethod("eth_getProof")
+  @RpcOptionalParameters(1)
+  def getProof(address: Address, keys: Array[Quantity], tag: String): ProofAccountResult = {
+    val storageKeys = keys.map(key => Numeric.toBytesPadded(key.toNumber, 32))
+    applyOnAccountView { nodeView =>
+      getStateViewAtTag(nodeView, tag) { (stateView, _) =>
+        stateView.getProof(address.toBytes, storageKeys)
       }
     }
   }

--- a/sdk/src/main/scala/com/horizen/account/state/AccountStateView.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/AccountStateView.scala
@@ -11,7 +11,7 @@ import com.horizen.account.transaction.EthereumTransaction
 import com.horizen.account.utils._
 import com.horizen.block.{MainchainBlockReferenceData, MainchainTxForwardTransferCrosschainOutput, MainchainTxSidechainCreationCrosschainOutput, WithdrawalEpochCertificate}
 import com.horizen.consensus.{ConsensusEpochNumber, ForgingStakeInfo}
-import com.horizen.evm.interop.EvmLog
+import com.horizen.evm.interop.{EvmLog, ProofAccountResult}
 import com.horizen.evm.{ResourceHandle, StateDB, StateStorageStrategy}
 import com.horizen.proposition.{PublicKey25519Proposition, VrfPublicKey}
 import com.horizen.state.StateView
@@ -19,6 +19,7 @@ import com.horizen.transaction.mainchain.{ForwardTransfer, SidechainCreation}
 import com.horizen.utils.{BytesUtils, WithdrawalEpochInfo}
 import sparkz.core.VersionTag
 import scorex.util.ScorexLogging
+
 import java.math.BigInteger
 import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 import scala.util.Try
@@ -230,17 +231,17 @@ class AccountStateView(
   override def updateAccountStorage(address: Array[Byte], key: Array[Byte], value: Array[Byte]): Unit =
     stateDb.setStorage(address, key, value, StateStorageStrategy.RAW)
 
-
   override def updateAccountStorageBytes(address: Array[Byte], key: Array[Byte], value: Array[Byte]): Unit =
     stateDb.setStorage(address, key, value, StateStorageStrategy.CHUNKED)
-
 
   override def removeAccountStorage(address: Array[Byte], key: Array[Byte]): Unit =
     stateDb.removeStorage(address, key, StateStorageStrategy.RAW)
 
-
   override def removeAccountStorageBytes(address: Array[Byte], key: Array[Byte]): Unit =
     stateDb.removeStorage(address, key, StateStorageStrategy.CHUNKED)
+
+  def getProof(address: Array[Byte], keys: Array[Array[Byte]]): ProofAccountResult =
+    stateDb.getProof(address, keys)
 
   // out-of-the-box helpers
   override def addCertificate(cert: WithdrawalEpochCertificate): Unit =


### PR DESCRIPTION
Implements additional RPC functions:
- eth_getBlockTransactionCountByHash
- eth_getBlockTransactionCountByNumber
- eth_getTransactionByBlockHashAndIndex
- eth_getTransactionByBlockNumberAndIndex
- eth_getStorageAt
- eth_getProof

Also fix python test issues related to missing `0x` hex prefixes when calling RPC apis.