### PR TITLE
Reject non-zero values when calling fake contract view methods

### DIFF
--- a/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
@@ -315,8 +315,8 @@ case class ForgerStakeMsgProcessor(params: NetworkParams) extends FakeSmartContr
   }
 
   def doGetListOfForgersCmd(msg: Message, view: BaseAccountStateView): Array[Byte] = {
-    if (msg.getValue.compareTo(BigInteger.ZERO) == 1) {
-      throw new ExecutionRevertedException("Call value can't be greater than zero")
+    if (msg.getValue.compareTo(BigInteger.ZERO) != 0) {
+      throw new ExecutionRevertedException("Call value must be zero")
     }
 
     checkGetListOfForgersCmd(msg)
@@ -329,8 +329,8 @@ case class ForgerStakeMsgProcessor(params: NetworkParams) extends FakeSmartContr
       throw new ExecutionRevertedException("Call must include a nonce")
     }
 
-    if (msg.getValue.compareTo(BigInteger.ZERO) == 1) {
-      throw new ExecutionRevertedException("Call value can't be greater than zero")
+    if (msg.getValue.compareTo(BigInteger.ZERO) != 0) {
+      throw new ExecutionRevertedException("Call value must be zero")
     }
 
     val inputParams = getArgumentsFromData(msg.getData)

--- a/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
@@ -315,6 +315,10 @@ case class ForgerStakeMsgProcessor(params: NetworkParams) extends FakeSmartContr
   }
 
   def doGetListOfForgersCmd(msg: Message, view: BaseAccountStateView): Array[Byte] = {
+    if (msg.getValue.compareTo(BigInteger.ZERO) == 1) {
+      throw new ExecutionRevertedException("Call value can't be greater than zero")
+    }
+
     checkGetListOfForgersCmd(msg)
     doUncheckedGetListOfForgersCmd(view)
   }
@@ -323,6 +327,10 @@ case class ForgerStakeMsgProcessor(params: NetworkParams) extends FakeSmartContr
     // check that message contains a nonce, in the context of RPC calls the nonce might be missing
     if (msg.getNonce == null) {
       throw new ExecutionRevertedException("Call must include a nonce")
+    }
+
+    if (msg.getValue.compareTo(BigInteger.ZERO) == 1) {
+      throw new ExecutionRevertedException("Call value can't be greater than zero")
     }
 
     val inputParams = getArgumentsFromData(msg.getData)

--- a/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/ForgerStakeMsgProcessor.scala
@@ -315,7 +315,7 @@ case class ForgerStakeMsgProcessor(params: NetworkParams) extends FakeSmartContr
   }
 
   def doGetListOfForgersCmd(msg: Message, view: BaseAccountStateView): Array[Byte] = {
-    if (msg.getValue.compareTo(BigInteger.ZERO) != 0) {
+    if (msg.getValue.signum() != 0) {
       throw new ExecutionRevertedException("Call value must be zero")
     }
 
@@ -329,7 +329,7 @@ case class ForgerStakeMsgProcessor(params: NetworkParams) extends FakeSmartContr
       throw new ExecutionRevertedException("Call must include a nonce")
     }
 
-    if (msg.getValue.compareTo(BigInteger.ZERO) != 0) {
+    if (msg.getValue.signum() != 0) {
       throw new ExecutionRevertedException("Call value must be zero")
     }
 

--- a/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
@@ -81,6 +81,10 @@ object WithdrawalMsgProcessor extends FakeSmartContractMsgProcessor with Withdra
   }
 
   protected def execGetListOfWithdrawalReqRecords(msg: Message, view: BaseAccountStateView): Array[Byte] = {
+    if (msg.getValue.compareTo(BigInteger.ZERO) == 1) {
+      throw new ExecutionRevertedException("Call value can't be greater than zero")
+    }
+
     //TODO should any length between OP_CODE_LENGTH to OP_CODE_LENGTH + 32 be supported?
     if (msg.getData.length != METHOD_CODE_LENGTH + GetListOfWithdrawalRequestsCmdInputDecoder.getABIDataParamsLengthInBytes)
       throw new ExecutionRevertedException(s"Wrong message data field length: ${msg.getData.length}")

--- a/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
@@ -81,8 +81,8 @@ object WithdrawalMsgProcessor extends FakeSmartContractMsgProcessor with Withdra
   }
 
   protected def execGetListOfWithdrawalReqRecords(msg: Message, view: BaseAccountStateView): Array[Byte] = {
-    if (msg.getValue.compareTo(BigInteger.ZERO) == 1) {
-      throw new ExecutionRevertedException("Call value can't be greater than zero")
+    if (msg.getValue.compareTo(BigInteger.ZERO) != 0) {
+      throw new ExecutionRevertedException("Call value must be zero")
     }
 
     //TODO should any length between OP_CODE_LENGTH to OP_CODE_LENGTH + 32 be supported?

--- a/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/WithdrawalMsgProcessor.scala
@@ -81,7 +81,7 @@ object WithdrawalMsgProcessor extends FakeSmartContractMsgProcessor with Withdra
   }
 
   protected def execGetListOfWithdrawalReqRecords(msg: Message, view: BaseAccountStateView): Array[Byte] = {
-    if (msg.getValue.compareTo(BigInteger.ZERO) != 0) {
+    if (msg.getValue.signum() != 0) {
       throw new ExecutionRevertedException("Call value must be zero")
     }
 

--- a/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
@@ -701,13 +701,13 @@ class ForgerStakeMsgProcessorTest
       val data: Array[Byte] = removeCmdInput.encode()
       var msg = getMessage(contractAddress, BigInteger.ONE, BytesUtils.fromHexString(RemoveStakeCmd) ++ data, nonce)
 
-      assertThrows[ExecutionFailedException] {
+      assertThrows[ExecutionRevertedException] {
         withGas(forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext))
       }
 
       msg = getMessage(contractAddress, BigInteger.valueOf(-1), BytesUtils.fromHexString(RemoveStakeCmd) ++ data, nonce)
 
-      assertThrows[ExecutionFailedException] {
+      assertThrows[ExecutionRevertedException] {
         withGas(forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext))
       }
 
@@ -734,13 +734,13 @@ class ForgerStakeMsgProcessorTest
       withGas { gas =>
         var msg = getMessage(contractAddress, BigInteger.ONE, BytesUtils.fromHexString(GetListOfForgersCmd), randomNonce)
 
-        assertThrows[ExecutionFailedException] {
+        assertThrows[ExecutionRevertedException] {
           forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
         }
 
         msg = getMessage(contractAddress, BigInteger.valueOf(-1), BytesUtils.fromHexString(GetListOfForgersCmd), randomNonce)
 
-        assertThrows[ExecutionFailedException] {
+        assertThrows[ExecutionRevertedException] {
           forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
         }
       }

--- a/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
@@ -657,7 +657,7 @@ class ForgerStakeMsgProcessorTest
   }
 
   @Test
-  def testRejectSendingPositiveValueToWithdraw(): Unit = {
+  def testRejectSendingInvalidValueToWithdraw(): Unit = {
     val expectedBlockSignerProposition = "aa22334455667788112233445586778811223344556677881122334455667788" // 32 bytes
     val blockSignerProposition = new PublicKey25519Proposition(BytesUtils.fromHexString(expectedBlockSignerProposition)) // 32 bytes
     val expectedVrfKey = "aabbccddeeff0099aabb87ddeeff0099aabbccddeeff0099aabbccd2aeff001234"
@@ -699,21 +699,24 @@ class ForgerStakeMsgProcessorTest
       // create command arguments
       val removeCmdInput = RemoveStakeCmdInput(forgingStakeInfo.stakeId, msgSignature)
       val data: Array[Byte] = removeCmdInput.encode()
-      val msg = getMessage(contractAddress, BigInteger.ONE, BytesUtils.fromHexString(RemoveStakeCmd) ++ data, nonce)
+      var msg = getMessage(contractAddress, BigInteger.ONE, BytesUtils.fromHexString(RemoveStakeCmd) ++ data, nonce)
 
-      // try processing the removal of stake, should succeed
-      val returnData = intercept[ExecutionRevertedException] {
+      assertThrows[ExecutionFailedException] {
         withGas(forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext))
       }
 
-      assert(returnData.getMessage === "Call value must be zero")
+      msg = getMessage(contractAddress, BigInteger.valueOf(-1), BytesUtils.fromHexString(RemoveStakeCmd) ++ data, nonce)
+
+      assertThrows[ExecutionFailedException] {
+        withGas(forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext))
+      }
 
       view.commit(bytesToVersion(getVersion.data()))
     }
   }
 
   @Test
-  def testRejectSendingNegativeValueToWithdraw(): Unit = {
+  def testRejectSendingInvalidValueToGetAllForgerStakes(): Unit = {
     val expectedBlockSignerProposition = "aa22334455667788112233445586778811223344556677881122334455667788" // 32 bytes
     val blockSignerProposition = new PublicKey25519Proposition(BytesUtils.fromHexString(expectedBlockSignerProposition)) // 32 bytes
     val expectedVrfKey = "aabbccddeeff0099aabb87ddeeff0099aabbccddeeff0099aabbccd2aeff001234"
@@ -728,94 +731,18 @@ class ForgerStakeMsgProcessorTest
 
       forgerStakeMessageProcessor.init(view)
 
-      // create sender account with some fund in it
-      // val initialAmount = BigInteger.valueOf(10).multiply(validWeiAmount)
-      val initialAmount = ZenWeiConverter.MAX_MONEY_IN_WEI
-      createSenderAccount(view, initialAmount)
-
-      val cmdInput = AddNewStakeCmdInput(
-        ForgerPublicKeys(blockSignerProposition, vrfPublicKey),
-        ownerAddressProposition
-      )
-      val addNewStakeData: Array[Byte] = cmdInput.encode()
-
-      val stakeAmount = validWeiAmount
-      val addNewStakeMsg = getMessage(contractAddress, stakeAmount, BytesUtils.fromHexString(AddNewStakeCmd) ++ addNewStakeData, randomNonce)
-      val expStakeId = forgerStakeMessageProcessor.getStakeId(addNewStakeMsg)
-      val forgingStakeInfo = AccountForgingStakeInfo(expStakeId, ForgerStakeData(ForgerPublicKeys(blockSignerProposition, vrfPublicKey), ownerAddressProposition, stakeAmount))
-      val addNewStakeReturnData = withGas(forgerStakeMessageProcessor.process(addNewStakeMsg, view, _, defaultBlockContext))
-      assertNotNull(addNewStakeReturnData)
-
-
-      val nonce = randomNonce
-      val msgToSign = ForgerStakeMsgProcessor.getMessageToSign(forgingStakeInfo.stakeId, origin, nonce.toByteArray)
-      val msgSignatureData = Sign.signMessage(msgToSign, pair, true)
-      val msgSignature = new SignatureSecp256k1(msgSignatureData)
-
-      // create command arguments
-      val removeCmdInput = RemoveStakeCmdInput(forgingStakeInfo.stakeId, msgSignature)
-      val data: Array[Byte] = removeCmdInput.encode()
-      val msg = getMessage(contractAddress, BigInteger.valueOf(-1), BytesUtils.fromHexString(RemoveStakeCmd) ++ data, nonce)
-
-      // try processing the removal of stake, should succeed
-      val returnData = intercept[ExecutionRevertedException] {
-        withGas(forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext))
-      }
-
-      assert(returnData.getMessage === "Call value must be zero")
-
-      view.commit(bytesToVersion(getVersion.data()))
-    }
-  }
-
-  @Test
-  def testRejectSendingPositiveValueToGetAllForgerStakes(): Unit = {
-    val expectedBlockSignerProposition = "aa22334455667788112233445586778811223344556677881122334455667788" // 32 bytes
-    val blockSignerProposition = new PublicKey25519Proposition(BytesUtils.fromHexString(expectedBlockSignerProposition)) // 32 bytes
-    val expectedVrfKey = "aabbccddeeff0099aabb87ddeeff0099aabbccddeeff0099aabbccd2aeff001234"
-    val vrfPublicKey = new VrfPublicKey(BytesUtils.fromHexString(expectedVrfKey)) // 33 bytes
-
-    Mockito.when(mockNetworkParams.restrictForgers).thenReturn(true)
-    Mockito.when(mockNetworkParams.allowedForgersList).thenReturn(Seq(
-      (blockSignerProposition, vrfPublicKey)
-    ))
-
-    usingView(forgerStakeMessageProcessor) { view =>
-
-      forgerStakeMessageProcessor.init(view)
-
-      val msg = getMessage(contractAddress, BigInteger.ONE, BytesUtils.fromHexString(GetListOfForgersCmd), randomNonce)
       withGas { gas =>
-        val returnData = intercept[ExecutionRevertedException] {
+        var msg = getMessage(contractAddress, BigInteger.ONE, BytesUtils.fromHexString(GetListOfForgersCmd), randomNonce)
+
+        assertThrows[ExecutionFailedException] {
           forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
         }
-        assert(returnData.getMessage === "Call value must be zero")
-      }
-    }
-  }
 
-  @Test
-  def testRejectSendingNegativeValueToGetAllForgerStakes(): Unit = {
-    val expectedBlockSignerProposition = "aa22334455667788112233445586778811223344556677881122334455667788" // 32 bytes
-    val blockSignerProposition = new PublicKey25519Proposition(BytesUtils.fromHexString(expectedBlockSignerProposition)) // 32 bytes
-    val expectedVrfKey = "aabbccddeeff0099aabb87ddeeff0099aabbccddeeff0099aabbccd2aeff001234"
-    val vrfPublicKey = new VrfPublicKey(BytesUtils.fromHexString(expectedVrfKey)) // 33 bytes
+        msg = getMessage(contractAddress, BigInteger.valueOf(-1), BytesUtils.fromHexString(GetListOfForgersCmd), randomNonce)
 
-    Mockito.when(mockNetworkParams.restrictForgers).thenReturn(true)
-    Mockito.when(mockNetworkParams.allowedForgersList).thenReturn(Seq(
-      (blockSignerProposition, vrfPublicKey)
-    ))
-
-    usingView(forgerStakeMessageProcessor) { view =>
-
-      forgerStakeMessageProcessor.init(view)
-
-      val msg = getMessage(contractAddress, BigInteger.valueOf(-1), BytesUtils.fromHexString(GetListOfForgersCmd), randomNonce)
-      withGas { gas =>
-        val returnData = intercept[ExecutionRevertedException] {
+        assertThrows[ExecutionFailedException] {
           forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
         }
-        assert(returnData.getMessage === "Call value must be zero")
       }
     }
   }

--- a/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
@@ -656,8 +656,91 @@ class ForgerStakeMsgProcessorTest
     }
   }
 
+  @Test
+  def testRejectSendingValueToWithdraw(): Unit = {
+    val expectedBlockSignerProposition = "aa22334455667788112233445586778811223344556677881122334455667788" // 32 bytes
+    val blockSignerProposition = new PublicKey25519Proposition(BytesUtils.fromHexString(expectedBlockSignerProposition)) // 32 bytes
+    val expectedVrfKey = "aabbccddeeff0099aabb87ddeeff0099aabbccddeeff0099aabbccd2aeff001234"
+    val vrfPublicKey = new VrfPublicKey(BytesUtils.fromHexString(expectedVrfKey)) // 33 bytes
+
+    Mockito.when(mockNetworkParams.restrictForgers).thenReturn(true)
+    Mockito.when(mockNetworkParams.allowedForgersList).thenReturn(Seq(
+      (blockSignerProposition, vrfPublicKey)
+    ))
+
+    usingView(forgerStakeMessageProcessor) { view =>
+
+      forgerStakeMessageProcessor.init(view)
+
+      // create sender account with some fund in it
+      // val initialAmount = BigInteger.valueOf(10).multiply(validWeiAmount)
+      val initialAmount = ZenWeiConverter.MAX_MONEY_IN_WEI
+      createSenderAccount(view, initialAmount)
+
+      val cmdInput = AddNewStakeCmdInput(
+        ForgerPublicKeys(blockSignerProposition, vrfPublicKey),
+        ownerAddressProposition
+      )
+      val addNewStakeData: Array[Byte] = cmdInput.encode()
+
+      val stakeAmount = validWeiAmount
+      val addNewStakeMsg = getMessage(contractAddress, stakeAmount, BytesUtils.fromHexString(AddNewStakeCmd) ++ addNewStakeData, randomNonce)
+      val expStakeId = forgerStakeMessageProcessor.getStakeId(addNewStakeMsg)
+      val forgingStakeInfo = AccountForgingStakeInfo(expStakeId, ForgerStakeData(ForgerPublicKeys(blockSignerProposition, vrfPublicKey), ownerAddressProposition, stakeAmount))
+      val addNewStakeReturnData = withGas(forgerStakeMessageProcessor.process(addNewStakeMsg, view, _, defaultBlockContext))
+      assertNotNull(addNewStakeReturnData)
+
+
+      val nonce = randomNonce
+      val msgToSign = ForgerStakeMsgProcessor.getMessageToSign(forgingStakeInfo.stakeId, origin, nonce.toByteArray)
+      val msgSignatureData = Sign.signMessage(msgToSign, pair, true)
+      val msgSignature = new SignatureSecp256k1(msgSignatureData)
+
+      // create command arguments
+      val removeCmdInput = RemoveStakeCmdInput(forgingStakeInfo.stakeId, msgSignature)
+      val data: Array[Byte] = removeCmdInput.encode()
+      val msg = getMessage(contractAddress, BigInteger.ONE, BytesUtils.fromHexString(RemoveStakeCmd) ++ data, nonce)
+
+      // try processing the removal of stake, should succeed
+      val returnData = intercept[ExecutionRevertedException] {
+        withGas(forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext))
+      }
+
+      assert(returnData.getMessage === "Call value can't be greater than zero")
+
+      view.commit(bytesToVersion(getVersion.data()))
+    }
+  }
+
+  @Test
+  def testRejectSendingValueToGetAllForgerStakes(): Unit = {
+    val expectedBlockSignerProposition = "aa22334455667788112233445586778811223344556677881122334455667788" // 32 bytes
+    val blockSignerProposition = new PublicKey25519Proposition(BytesUtils.fromHexString(expectedBlockSignerProposition)) // 32 bytes
+    val expectedVrfKey = "aabbccddeeff0099aabb87ddeeff0099aabbccddeeff0099aabbccd2aeff001234"
+    val vrfPublicKey = new VrfPublicKey(BytesUtils.fromHexString(expectedVrfKey)) // 33 bytes
+
+    Mockito.when(mockNetworkParams.restrictForgers).thenReturn(true)
+    Mockito.when(mockNetworkParams.allowedForgersList).thenReturn(Seq(
+      (blockSignerProposition, vrfPublicKey)
+    ))
+
+    usingView(forgerStakeMessageProcessor) { view =>
+
+      forgerStakeMessageProcessor.init(view)
+
+      val msg = getMessage(contractAddress, BigInteger.ONE, BytesUtils.fromHexString(GetListOfForgersCmd), randomNonce)
+      withGas { gas =>
+        val returnData = intercept[ExecutionRevertedException] {
+          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
+        }
+        assert(returnData.getMessage === "Call value can't be greater than zero")
+      }
+    }
+  }
+
   def checkRemoveItemFromList(stateView: AccountStateView, inputList: java.util.List[AccountForgingStakeInfo],
                               itemPosition: Int): Unit = {
+
     // get the info related to the item to remove
     val stakeInfo = inputList.remove(itemPosition)
     val stakeIdToRemove = stakeInfo.stakeId

--- a/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorTest.scala
@@ -182,7 +182,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
       BytesUtils.fromHexString(WithdrawalMsgProcessor.GetListOfWithdrawalReqsCmdSig)
     )
 
-    assertThrows[ExecutionFailedException] {
+    assertThrows[ExecutionRevertedException] {
       withGas(WithdrawalMsgProcessor.process(msg, mockStateView, _, defaultBlockContext))
     }
 
@@ -192,7 +192,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
       BytesUtils.fromHexString(WithdrawalMsgProcessor.GetListOfWithdrawalReqsCmdSig)
     )
 
-    assertThrows[ExecutionFailedException] {
+    assertThrows[ExecutionRevertedException] {
       withGas(WithdrawalMsgProcessor.process(msg, mockStateView, _, defaultBlockContext))
     }
   }

--- a/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorTest.scala
@@ -173,36 +173,28 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
   }
 
   @Test
-  def testRejectSendingPositiveValueToGetListOfWithdrawal(): Unit = {
+  def testRejectSendingInvalidValueToGetListOfWithdrawal(): Unit = {
     val mockStateView = mock[AccountStateView]
 
-    val msg = getMessage(
+    var msg = getMessage(
       WithdrawalMsgProcessor.contractAddress,
       BigInteger.ONE,
       BytesUtils.fromHexString(WithdrawalMsgProcessor.GetListOfWithdrawalReqsCmdSig)
     )
 
-    val returnData = intercept[ExecutionRevertedException] {
+    assertThrows[ExecutionFailedException] {
       withGas(WithdrawalMsgProcessor.process(msg, mockStateView, _, defaultBlockContext))
     }
-    assert(returnData.getMessage === "Call value must be zero")
 
-  }
-
-  @Test
-  def testRejectSendingNegativeValueToGetListOfWithdrawal(): Unit = {
-    val mockStateView = mock[AccountStateView]
-
-    val msg = getMessage(
+    msg = getMessage(
       WithdrawalMsgProcessor.contractAddress,
       BigInteger.valueOf(-1),
       BytesUtils.fromHexString(WithdrawalMsgProcessor.GetListOfWithdrawalReqsCmdSig)
     )
 
-    val returnData = intercept[ExecutionRevertedException] {
+    assertThrows[ExecutionFailedException] {
       withGas(WithdrawalMsgProcessor.process(msg, mockStateView, _, defaultBlockContext))
     }
-    assert(returnData.getMessage === "Call value must be zero")
-
   }
+
 }

--- a/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorTest.scala
@@ -173,7 +173,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
   }
 
   @Test
-  def testRejectSendingValueToGetListOfWithdrawal(): Unit = {
+  def testRejectSendingPositiveValueToGetListOfWithdrawal(): Unit = {
     val mockStateView = mock[AccountStateView]
 
     val msg = getMessage(
@@ -185,6 +185,24 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
     val returnData = intercept[ExecutionRevertedException] {
       withGas(WithdrawalMsgProcessor.process(msg, mockStateView, _, defaultBlockContext))
     }
-    assert(returnData.getMessage === "Call value can't be greater than zero")
+    assert(returnData.getMessage === "Call value must be zero")
+
+  }
+
+  @Test
+  def testRejectSendingNegativeValueToGetListOfWithdrawal(): Unit = {
+    val mockStateView = mock[AccountStateView]
+
+    val msg = getMessage(
+      WithdrawalMsgProcessor.contractAddress,
+      BigInteger.valueOf(-1),
+      BytesUtils.fromHexString(WithdrawalMsgProcessor.GetListOfWithdrawalReqsCmdSig)
+    )
+
+    val returnData = intercept[ExecutionRevertedException] {
+      withGas(WithdrawalMsgProcessor.process(msg, mockStateView, _, defaultBlockContext))
+    }
+    assert(returnData.getMessage === "Call value must be zero")
+
   }
 }


### PR DESCRIPTION
Reject calling view methods of fake smart contracts with msg.value greater than 0