### PR TITLE
estimateGas revert error response

### DIFF
--- a/sdk/src/main/java/com/horizen/account/api/rpc/utils/RpcCode.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/utils/RpcCode.java
@@ -12,6 +12,7 @@ public enum RpcCode {
     Unauthorized(1, "Unauthorized"),
     ActionNotAllowed(2, "Action not allowed"),
     ExecutionError(3, "Execution error"),
+    ExecutionReverted(-32000, "Execution reverted"),
     UnknownBlock(-39001, "Unknown block");
 
     // the range of -32000 to -32099 is reserved for implementation-defined server-errors

--- a/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
@@ -271,6 +271,7 @@ class EthService(
           doCall(nodeView, params, tag)
           true
         } catch {
+          case _: ExecutionRevertedException => true
           case _: ExecutionFailedException => false
           case _: IntrinsicGasException => false
         }

--- a/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
@@ -278,7 +278,7 @@ class EthService(
       // Execute the binary search and hone in on an executable gas limit
       // We need to do a search because the gas required during execution is not necessarily equal to the consumed
       // gas after the execution. See https://github.com/ethereum/go-ethereum/commit/682875adff760a29a2bb0024190883e4b4dd5d72
-      val requiredGasLimit = binarySearch(lowBound, highBound)(x => check(x)._1)
+      val requiredGasLimit = binarySearch(lowBound, highBound)(check(_)._1)
       // Reject the transaction as invalid if it still fails at the highest allowance
       if (requiredGasLimit == highBound) {
         val (success, reverted) = check(highBound)

--- a/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
@@ -222,7 +222,6 @@ class EthService(
   @RpcOptionalParameters(1)
   def estimateGas(params: TransactionArgs, tag: String): Quantity = {
     applyOnAccountView { nodeView =>
-      var reverted: ExecutionRevertedException = null
       // Binary search the gas requirement, as it may be higher than the amount used
       val lowBound = GasUtil.TxGas.subtract(BigInteger.ONE)
       // Determine the highest gas limit can be used during the estimation.
@@ -270,21 +269,25 @@ class EthService(
         try {
           params.gas = gas
           doCall(nodeView, params, tag)
-          true
+          (true, None)
         } catch {
-          case err: ExecutionRevertedException => reverted = err
-          false
-          case _: ExecutionFailedException => false
-          case _: IntrinsicGasException => false
+          case err: ExecutionRevertedException => (false, Some(err))
+          case _: ExecutionFailedException => (false, None)
+          case _: IntrinsicGasException => (false, None)
         }
       // Execute the binary search and hone in on an executable gas limit
       // We need to do a search because the gas required during execution is not necessarily equal to the consumed
       // gas after the execution. See https://github.com/ethereum/go-ethereum/commit/682875adff760a29a2bb0024190883e4b4dd5d72
-      val requiredGasLimit = binarySearch(lowBound, highBound)(check)
+      val requiredGasLimit = binarySearch(lowBound, highBound)(x => check(x)._1)
       // Reject the transaction as invalid if it still fails at the highest allowance
-      if (requiredGasLimit == highBound && !check(highBound)) {
-        if (reverted != null) throw new RpcException(new RpcError(RpcCode.ExecutionReverted.getCode, reverted.getMessage, Numeric.toHexString(reverted.revertReason)))
-        throw new RpcException(RpcError.fromCode(RpcCode.InvalidParams, s"gas required exceeds allowance ($highBound)"))
+      if (requiredGasLimit == highBound) {
+        val (success, reverted) = check(highBound)
+        if (!success) {
+          val error = reverted
+            .map(err => RpcError.fromCode(RpcCode.ExecutionReverted, Numeric.toHexString(err.revertReason)))
+            .getOrElse(RpcError.fromCode(RpcCode.InvalidParams, s"gas required exceeds allowance ($highBound)"))
+          throw new RpcException(error)
+        }
       }
       new Quantity(requiredGasLimit)
     }


### PR DESCRIPTION
This seems to be the correct behavior in comparison to ethereum as this is the output from ethereum testnet using Remix IDE:

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/87695234/195545055-854526db-1ee7-4e30-a88c-ce82081bf724.png">
