### PR TITLE
EVM-405 - rpc id numeric datatype

### DIFF
--- a/sdk/src/main/java/com/horizen/account/api/rpc/request/RpcId.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/request/RpcId.java
@@ -1,0 +1,38 @@
+package com.horizen.account.api.rpc.request;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class RpcId {
+
+    private Long longId;
+    private String stringId;
+
+    public RpcId(JsonNode jsonId) {
+
+        // manage numeric id input
+        if(jsonId.canConvertToLong()){
+            if(jsonId.asLong()>=0)
+                this.longId = jsonId.asLong();
+            else
+                throw new IllegalStateException("Rpc Id can't be a negative number");
+        } else if(jsonId.isNull())
+            throw new IllegalStateException("Rpc Id can't be null");
+        else
+            this.stringId = jsonId.asText();
+    }
+
+    public Long getLongId() {
+        return longId;
+    }
+
+    public String getStringId() {
+        return stringId;
+    }
+
+    @Override
+    public String toString() {
+        if(longId!=null) return longId.toString();
+        else if(stringId!=null) return stringId;
+        else return null;
+    }
+}

--- a/sdk/src/main/java/com/horizen/account/api/rpc/request/RpcRequest.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/request/RpcRequest.java
@@ -3,11 +3,11 @@ package com.horizen.account.api.rpc.request;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * {"id":"1648039192785","jsonrpc":"2.0","method":"eth_chainId","params":[]}
+ * {"id":1648039192785,"jsonrpc":"2.0","method":"eth_chainId","params":[]}
  */
 public class RpcRequest {
     private String jsonrpc;
-    private String id;
+    private long id;
     private String method;
     private JsonNode params;
 
@@ -15,7 +15,7 @@ public class RpcRequest {
 
     public RpcRequest(JsonNode json) {
         this.jsonrpc = json.get("jsonrpc").asText();
-        this.id = json.get("id").asText();
+        this.id = json.get("id").asLong();
         this.method = json.get("method").asText();
         this.params = json.get("params");
     }
@@ -28,11 +28,11 @@ public class RpcRequest {
         this.jsonrpc = jsonrpc;
     }
 
-    public String getId() {
+    public long getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(long id) {
         this.id = id;
     }
 

--- a/sdk/src/main/java/com/horizen/account/api/rpc/request/RpcRequest.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/request/RpcRequest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public class RpcRequest {
     private String jsonrpc;
-    private long id;
+    private RpcId id;
     private String method;
     private JsonNode params;
 
@@ -15,7 +15,7 @@ public class RpcRequest {
 
     public RpcRequest(JsonNode json) {
         this.jsonrpc = json.get("jsonrpc").asText();
-        this.id = json.get("id").asLong();
+        this.id = new RpcId(json.get("id"));
         this.method = json.get("method").asText();
         this.params = json.get("params");
     }
@@ -28,11 +28,11 @@ public class RpcRequest {
         this.jsonrpc = jsonrpc;
     }
 
-    public long getId() {
+    public RpcId getId() {
         return id;
     }
 
-    public void setId(long id) {
+    public void setId(RpcId id) {
         this.id = id;
     }
 
@@ -54,6 +54,6 @@ public class RpcRequest {
 
     @Override
     public String toString() {
-        return String.format("RpcRequest{jsonrpc='%s', id='%s', method='%s', params=%s}", jsonrpc, id, method, params);
+        return String.format("RpcRequest{jsonrpc='%s', id='%s', method='%s', params=%s}", jsonrpc, id.toString(), method, params);
     }
 }

--- a/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponse.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponse.java
@@ -1,15 +1,22 @@
 package com.horizen.account.api.rpc.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.horizen.account.api.rpc.request.RpcId;
 import com.horizen.api.http.ApiResponse;
+import com.horizen.serialization.RpcIdSerializer;
 import com.horizen.serialization.Views;
 
 @JsonView(Views.Default.class)
 public abstract class RpcResponse implements ApiResponse {
     protected final String jsonrpc;
-    protected final long id;
 
-    public RpcResponse(long id) {
+    @JsonProperty("id")
+    @JsonSerialize(using = RpcIdSerializer.class)
+    protected final RpcId id;
+
+    public RpcResponse(RpcId id) {
         this.jsonrpc = "2.0";
         this.id = id;
     }
@@ -18,7 +25,7 @@ public abstract class RpcResponse implements ApiResponse {
         return jsonrpc;
     }
 
-    public long getId() {
+    public RpcId getId() {
         return id;
     }
 }

--- a/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponse.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponse.java
@@ -7,9 +7,9 @@ import com.horizen.serialization.Views;
 @JsonView(Views.Default.class)
 public abstract class RpcResponse implements ApiResponse {
     protected final String jsonrpc;
-    protected final String id;
+    protected final long id;
 
-    public RpcResponse(String id) {
+    public RpcResponse(long id) {
         this.jsonrpc = "2.0";
         this.id = id;
     }
@@ -18,7 +18,7 @@ public abstract class RpcResponse implements ApiResponse {
         return jsonrpc;
     }
 
-    public String getId() {
+    public long getId() {
         return id;
     }
 }

--- a/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponseError.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponseError.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public class RpcResponseError extends RpcResponse implements ErrorResponse {
     protected final RpcError error;
 
-    public RpcResponseError(String id, RpcError error) {
+    public RpcResponseError(long id, RpcError error) {
         super(id);
         this.error = error;
     }

--- a/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponseError.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponseError.java
@@ -1,6 +1,7 @@
 package com.horizen.account.api.rpc.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.horizen.account.api.rpc.request.RpcId;
 import com.horizen.account.api.rpc.utils.RpcError;
 import com.horizen.api.http.ErrorResponse;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 public class RpcResponseError extends RpcResponse implements ErrorResponse {
     protected final RpcError error;
 
-    public RpcResponseError(long id, RpcError error) {
+    public RpcResponseError(RpcId id, RpcError error) {
         super(id);
         this.error = error;
     }

--- a/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponseSuccess.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponseSuccess.java
@@ -1,12 +1,13 @@
 package com.horizen.account.api.rpc.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.horizen.account.api.rpc.request.RpcId;
 import com.horizen.api.http.SuccessResponse;
 
 public class RpcResponseSuccess extends RpcResponse implements SuccessResponse {
     protected final Object result;
 
-    public RpcResponseSuccess(long id, Object result) {
+    public RpcResponseSuccess(RpcId id, Object result) {
         super(id);
         this.result = result;
     }

--- a/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponseSuccess.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/response/RpcResponseSuccess.java
@@ -6,7 +6,7 @@ import com.horizen.api.http.SuccessResponse;
 public class RpcResponseSuccess extends RpcResponse implements SuccessResponse {
     protected final Object result;
 
-    public RpcResponseSuccess(String id, Object result) {
+    public RpcResponseSuccess(long id, Object result) {
         super(id);
         this.result = result;
     }

--- a/sdk/src/main/scala/com/horizen/serialization/RpcIdSerializer.scala
+++ b/sdk/src/main/scala/com/horizen/serialization/RpcIdSerializer.scala
@@ -1,0 +1,16 @@
+package com.horizen.serialization
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
+import com.horizen.account.api.rpc.request.RpcId
+
+class RpcIdSerializer extends JsonSerializer[RpcId] {
+  override def serialize(rpcId: RpcId, jsonGenerator: JsonGenerator, serializerProvider: SerializerProvider): Unit = {
+    if(rpcId.getLongId!=null) {
+      jsonGenerator.writeNumber(rpcId.getLongId)
+    }
+    if(rpcId.getStringId!=null)
+      jsonGenerator.writeString(rpcId.getStringId)
+  }
+
+}


### PR DESCRIPTION
In this pull request the datatype the id rpc request and response was modified to long (instead of String) to be compliant with the web3.js library