### PR TITLE
Minor bugfixes(SDK-464, SDK-369)

### DIFF
--- a/qa/SidechainTestFramework/scutil.py
+++ b/qa/SidechainTestFramework/scutil.py
@@ -423,7 +423,7 @@ def initialize_sc_datadir(dirname, n, bootstrap_info=SCBootstrapInfo, sc_node_co
         "RESTRICT_FORGERS": ("true" if sc_node_config.forger_options.restrict_forgers else "false"),
         "ALLOWED_FORGERS_LIST": sc_node_config.forger_options.allowed_forgers,
         "MAX_PACKET_SIZE": DEFAULT_MAX_PACKET_SIZE,
-        "REMOTE_KEY_MANAGER_ENABLED": ("true" if sc_node_config.remote_keys_manager_enabled else "false"),
+        "REMOTE_KEY_MANAGER_ENABLED": ("true" if sc_node_config.remote_keys_manager_enabled else "false")
     }
     config = config.replace("'", "")
     config = config.replace("NEW_LINE", "\n")
@@ -482,7 +482,8 @@ def initialize_default_sc_datadir(dirname, n, api_key):
         "CSW_VERIFICATION_KEY_PATH": csw_keys_paths.verification_key_path,
         "RESTRICT_FORGERS": "false",
         "ALLOWED_FORGERS_LIST": [],
-        "MAX_PACKET_SIZE": DEFAULT_MAX_PACKET_SIZE
+        "MAX_PACKET_SIZE": DEFAULT_MAX_PACKET_SIZE,
+        "REMOTE_KEY_MANAGER_ENABLED": "false"
     }
 
     configsData.append({

--- a/sdk/src/main/scala/com/horizen/SidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainNodeViewHolder.scala
@@ -554,14 +554,6 @@ object SidechainNodeViewHolder /*extends ScorexLogging with SparkzEncoding*/ {
 
   private[horizen] object InternalReceivableMessages {
     case class ApplyModifier(applied: Seq[SidechainBlock])
-
-    sealed trait NewLocallyGeneratedTransactions[TX <: Transaction] {
-      val txs: Iterable[TX]
-    }
-
-    case class LocallyGeneratedTransaction[TX <: Transaction](tx: TX) extends NewLocallyGeneratedTransactions[TX] {
-      override val txs: Iterable[TX] = Iterable(tx)
-    }
   }
 }
 

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -921,7 +921,7 @@ class SidechainStateTest
     secretList ++= getPrivateKey25519List(10).asScala
     // Set base Box data
     boxList.clear()
-    boxList ++= getZenBoxList(secretList.asJava).asScala.toList
+    boxList ++= getZenBoxList(secretList.asJava, 599).asScala.toList // Transaction with 1 output and 10 withdrawal requests requires at least 599 coins in the box(54*11+5)
     stateVersion.clear()
     stateVersion += getVersion
     transactionList.clear()
@@ -975,8 +975,6 @@ class SidechainStateTest
 
     Mockito.when(mockedBlock.parentId)
       .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
 
     Mockito.when(mockedBlock.timestamp).thenReturn(86401)
 
@@ -1002,11 +1000,6 @@ class SidechainStateTest
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
 
-    Mockito.when(mockedBlock.parentId)
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
-
     validateTry = sidechainState.validate(mockedBlock)
     assertTrue("Block validation must be successful.",
       validateTry.isSuccess)
@@ -1017,11 +1010,6 @@ class SidechainStateTest
 
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
-
-    Mockito.when(mockedBlock.parentId)
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
 
     validateTry = sidechainState.validate(mockedBlock)
     assertFalse("Block validation must fail.",
@@ -1036,11 +1024,6 @@ class SidechainStateTest
 
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
-
-    Mockito.when(mockedBlock.parentId)
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
 
     validateTry = sidechainState.validate(mockedBlock)
     assertFalse("Block validation must fail.",
@@ -1059,11 +1042,6 @@ class SidechainStateTest
 
     Mockito.when(mockedBlock.mainchainBlockReferencesData).thenReturn(Seq(emptyRefData))
 
-    Mockito.when(mockedBlock.parentId)
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
-
     validateTry = sidechainState.validate(mockedBlock)
     assertTrue("Block validation must be successful.",
       validateTry.isSuccess)
@@ -1075,11 +1053,6 @@ class SidechainStateTest
     }
 
     Mockito.when(mockedStateStorage.getWithdrawalRequests(ArgumentMatchers.any[Int]())).thenReturn(wbs.asScala.toList)
-
-    Mockito.when(mockedBlock.parentId)
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
 
     validateTry = sidechainState.validate(mockedBlock)
     assertTrue("Block validation must be successful.",
@@ -1093,11 +1066,6 @@ class SidechainStateTest
 
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
-
-    Mockito.when(mockedBlock.parentId)
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
 
     validateTry = sidechainState.validate(mockedBlock)
     assertFalse("Block validation must fail.",
@@ -1114,15 +1082,11 @@ class SidechainStateTest
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
 
-    Mockito.when(mockedBlock.parentId)
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn(bytesToId(stateVersion.last.data))
-      .thenReturn("00000000000000000000000000000000".asInstanceOf[ModifierId])
-
     validateTry = sidechainState.validate(mockedBlock)
     assertTrue("Block validation must be successful.",
       validateTry.isSuccess)
   }
+
   @Test
   def testCoinBoxFeeBeforeAndAfterFork(): Unit = {
     secretList.clear()

--- a/sdk/src/test/scala/com/horizen/fixtures/BoxFixture.scala
+++ b/sdk/src/test/scala/com/horizen/fixtures/BoxFixture.scala
@@ -56,11 +56,11 @@ trait BoxFixture
     boxList
   }
 
-  def getZenBoxList(secretList: JList[PrivateKey25519]): JList[ZenBox] = {
+  def getZenBoxList(secretList: JList[PrivateKey25519], minBoxAmount:Int = 0): JList[ZenBox] = {
     val boxList: JList[ZenBox] = new JArrayList[ZenBox]()
 
     for (s <- secretList.asScala)
-      boxList.add(getZenBox(s.publicImage(), 1, Random.nextInt(10000)))
+      boxList.add(getZenBox(s.publicImage(), 1, minBoxAmount + Random.nextInt(10000)))
 
     boxList
   }


### PR DESCRIPTION
Fixed maxBTsPerBlockTest unit test.
Removed unused LocallyGeneratedTransaction from SidechainNodeViewHolder.
Fixed default sidechain dir initialization in Python test framework. It fixed sc_nodes_initialize.py and sc_node_api_test.py tests.