### PR TITLE
fix RPC issues

### DIFF
--- a/sdk/src/main/java/com/horizen/account/api/rpc/service/RpcService.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/service/RpcService.java
@@ -53,15 +53,15 @@ public class RpcService {
         var optionalAnnotation = method.getAnnotation(RpcOptionalParameters.class);
         var optionalParameters = optionalAnnotation == null ? 0 : optionalAnnotation.value();
         var parameters = method.getParameterTypes();
-        if (!args.isArray() ||
-                args.size() > parameters.length ||
-                args.size() < parameters.length - optionalParameters) {
+        var argsCount = args == null ? 0 : args.size();
+        if ((args != null && !args.isArray()) || argsCount > parameters.length ||
+            argsCount < parameters.length - optionalParameters) {
             throw new RpcException(RpcError.fromCode(RpcCode.InvalidParams));
         }
         try {
             var convertedArgs = new Object[parameters.length];
             for (int i = 0; i < parameters.length; i++) {
-                convertedArgs[i] = mapper.convertValue(args.get(i), parameters[i]);
+                convertedArgs[i] = mapper.convertValue(args == null ? null : args.get(i), parameters[i]);
             }
             return convertedArgs;
         } catch (IllegalArgumentException err) {

--- a/sdk/src/main/java/com/horizen/account/api/rpc/types/EthereumBlock.java
+++ b/sdk/src/main/java/com/horizen/account/api/rpc/types/EthereumBlock.java
@@ -40,7 +40,8 @@ public class EthereumBlock {
         this.number = number;
         this.hash = hash;
         this.parentHash = Numeric.prependHexPrefix((String) block.parentId());
-        this.nonce = "0x"; // no nonce
+        // no nonce, but we explicity set it to all zeroes as some RPC clients are very strict (e.g. GETH)
+        this.nonce = "0x0000000000000000";
         this.sha3Uncles = "0x"; // no uncles
         this.logsBloom = Numeric.toHexString(block.header().logsBloom().getBloomFilter());
         this.transactionsRoot = Numeric.toHexString(block.header().sidechainTransactionsMerkleRootHash());


### PR DESCRIPTION
 - fix internal error when RPC request does not contain the `params` property
   - treat it like `params: []`
- fix strict RPC clients falling over our "empty" block nonce `0x`
  - explicitly set it to 8 bytes (16 hex chars ) of zeroes `0x0000000000000000`
  - GETH otherwise throws: `hex string has length 0, want 16 for BlockNonce`