### PR TITLE
eth_getUncle: rpc methods implementation

### DIFF
--- a/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/com/horizen/account/api/rpc/service/EthService.scala
@@ -457,6 +457,26 @@ class EthService(
     }
   }
 
+  // Uncle Blocks RPCs
+  // An uncle block is a block that did not get mined onto the canonical chain.
+  // Only one block can be mined and acknowledged as canonical on the blockchain. The remaining blocks are uncle blocks.
+  // The Sidechains that are created using this sdk DO NOT support uncle blocks.
+  // For this reason:
+  // - eth_getUncleCountByBlockHash and eth_getUncleCountByBlockNumber always return 0x0
+  // - eth_getUncleByBlockHashAndIndex and eth_getUncleByBlockNumberAndIndex always return null (as no block was found)
+  @RpcMethod("eth_getUncleCountByBlockHash")
+  def getUncleCountByBlockHash(hash: Hash) = new Quantity(0L)
+
+  @RpcMethod("eth_getUncleCountByBlockNumber")
+  def eth_getUncleCountByBlockNumber(tag: String) = new Quantity(0L)
+
+  @RpcMethod("eth_getUncleByBlockHashAndIndex")
+  def eth_getUncleByBlockHashAndIndex(hash: Hash, index: Quantity) = null
+
+  @RpcMethod("eth_getUncleByBlockNumberAndIndex")
+  def eth_getUncleByBlockNumberAndIndex(tag: String, index: Quantity) = null
+
+
   @RpcMethod("debug_traceBlockByNumber")
   @RpcOptionalParameters(1)
   def traceBlockByNumber(tag: String, traceParams: TraceParams): DebugTraceBlockView = {

--- a/sdk/src/test/scala/com/horizen/account/api/http/AccountEthRpcRouteTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/api/http/AccountEthRpcRouteTest.scala
@@ -227,6 +227,63 @@ class AccountEthRpcRouteTest extends AccountEthRpcRouteMock {
       }
     }
 
+    // Uncle Blocks RPCs tests
+    val batchRequestJsonGetUncleCountByBlockHash = "{\"id\":\"8\",\"jsonrpc\":\"2.0\",\"method\":\"eth_getUncleCountByBlockHash\",\"params\":[\"0x518637c0ac365cdc5fc7e632aebc386ccea10dddd5e58cdf127b2d48d085f5a5\"]}}"
+    val batchRequestJsonNodeGetUncleCountByBlockHash = mapper.readTree(batchRequestJsonGetUncleCountByBlockHash)
+    "reply at /ethv1 - uncle block - eth_getUncleCountByBlockHash" in {
+      Post(basePath)
+        .withHeaders(apiTokenHeader)
+        .withEntity(SerializationUtil.serialize(batchRequestJsonNodeGetUncleCountByBlockHash)) ~> ethRpcRoute ~> check {
+        status.intValue() shouldBe StatusCodes.OK.intValue
+        responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
+        val rpcResponse = mapper.readTree(entityAs[String])
+        assertEquals(stringFromJsonNode(rpcResponse.get("result").toString), "0x0")
+        assertEquals(stringFromJsonNode(rpcResponse.get("id").toString), "8")
+      }
+    }
+
+    val batchRequestJsonGetUncleCountByBlockNumber = "{\"id\":\"16\",\"jsonrpc\":\"2.0\",\"method\":\"eth_getUncleCountByBlockNumber\",\"params\":[\"0xf8\"]}}"
+    val batchRequestJsonNodeGetUncleCountByBlockNumber = mapper.readTree(batchRequestJsonGetUncleCountByBlockNumber)
+    "reply at /ethv1 - uncle block - eth_getUncleCountByBlockNumber" in {
+      Post(basePath)
+        .withHeaders(apiTokenHeader)
+        .withEntity(SerializationUtil.serialize(batchRequestJsonNodeGetUncleCountByBlockNumber)) ~> ethRpcRoute ~> check {
+        status.intValue() shouldBe StatusCodes.OK.intValue
+        responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
+        val rpcResponse = mapper.readTree(entityAs[String])
+        assertEquals(stringFromJsonNode(rpcResponse.get("result").toString), "0x0")
+        assertEquals(stringFromJsonNode(rpcResponse.get("id").toString), "16")
+      }
+    }
+
+    val batchRequestJsonGetUncleByBlockHashAndIndex = "{\"id\":\"24\",\"jsonrpc\":\"2.0\",\"method\":\"eth_getUncleByBlockHashAndIndex\",\"params\":[\"0x518637c0ac365cdc5fc7e632aebc386ccea10dddd5e58cdf127b2d48d085f5a5\",\"0x0\"]}}"
+    val batchRequestJsonNodeGetUncleByBlockHashAndIndex = mapper.readTree(batchRequestJsonGetUncleByBlockHashAndIndex)
+    "reply at /ethv1 - uncle block - eth_getUncleByBlockHashAndIndex" in {
+      Post(basePath)
+        .withHeaders(apiTokenHeader)
+        .withEntity(SerializationUtil.serialize(batchRequestJsonNodeGetUncleByBlockHashAndIndex)) ~> ethRpcRoute ~> check {
+        status.intValue() shouldBe StatusCodes.OK.intValue
+        responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
+        val rpcResponse = mapper.readTree(entityAs[String])
+        assertEquals(stringFromJsonNode(rpcResponse.get("result").toString), "null")
+        assertEquals(stringFromJsonNode(rpcResponse.get("id").toString), "24")
+      }
+    }
+
+    val batchRequestJsonGetUncleByBlockNumberAndIndex = "{\"id\":\"32\",\"jsonrpc\":\"2.0\",\"method\":\"eth_getUncleByBlockNumberAndIndex\",\"params\":[\"0xf8\",\"0x0\"]}}"
+    val batchRequestJsonNodeGetUncleByBlockNumberAndIndex = mapper.readTree(batchRequestJsonGetUncleByBlockNumberAndIndex)
+    "reply at /ethv1 - uncle block - eth_getUncleByBlockNumberAndIndex" in {
+      Post(basePath)
+        .withHeaders(apiTokenHeader)
+        .withEntity(SerializationUtil.serialize(batchRequestJsonNodeGetUncleByBlockNumberAndIndex)) ~> ethRpcRoute ~> check {
+        status.intValue() shouldBe StatusCodes.OK.intValue
+        responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
+        val rpcResponse = mapper.readTree(entityAs[String])
+        assertEquals(stringFromJsonNode(rpcResponse.get("result").toString), "null")
+        assertEquals(stringFromJsonNode(rpcResponse.get("id").toString), "32")
+      }
+    }
+
   }
 
   private def stringFromJsonNode(jsonString: String): String = {


### PR DESCRIPTION
In this pull request:
implementation of the following rpc methods:
- eth_getUncleCountByBlockHash
- eth_getUncleCountByBlockNumber
- eth_getUncleByBlockHashAndIndex
- eth_getUncleByBlockNumberAndIndex