### PR TITLE
Non ceasing pending certs

### DIFF
--- a/qa/sc_backward_transfer.py
+++ b/qa/sc_backward_transfer.py
@@ -193,7 +193,7 @@ class SCBackwardTransfer(SidechainTestFramework):
 
         # Verify Certificate for epoch 0 on SC side
         mbrefdata = sc_node.block_best()["result"]["block"]["mainchainBlockReferencesData"][0]
-        we0_sc_cert = mbrefdata["topQualityCertificates"][0]
+        we0_sc_cert = mbrefdata["topQualityCertificate"]
         assert_equal(len(mbrefdata["lowerCertificateLeaves"]), 0)
         assert_equal(self.sc_nodes_bootstrap_info.sidechain_id, we0_sc_cert["sidechainId"],
                      "Sidechain Id in certificate is wrong.")
@@ -318,7 +318,7 @@ class SCBackwardTransfer(SidechainTestFramework):
 
         # Verify Certificate for epoch 1 on SC side
         mbrefdata = sc_node.block_best()["result"]["block"]["mainchainBlockReferencesData"][0]
-        we1_sc_cert = mbrefdata["topQualityCertificates"][0]
+        we1_sc_cert = mbrefdata["topQualityCertificate"]
         assert_equal(len(mbrefdata["lowerCertificateLeaves"]), 0)
         assert_equal(self.sc_nodes_bootstrap_info.sidechain_id, we1_sc_cert["sidechainId"],
                      "Sidechain Id in certificate is wrong.")

--- a/qa/sc_bwt_minimum_value.py
+++ b/qa/sc_bwt_minimum_value.py
@@ -315,7 +315,7 @@ class SCBwtMinValue(SidechainTestFramework):
 
         # Verify Certificate for epoch 1 on SC side
         mbrefdata = sc_node.block_best()["result"]["block"]["mainchainBlockReferencesData"][0]
-        we1_sc_cert = mbrefdata["topQualityCertificates"][0]
+        we1_sc_cert = mbrefdata["topQualityCertificate"]
         assert_equal(len(mbrefdata["lowerCertificateLeaves"]), 0)
         assert_equal(self.sc_nodes_bootstrap_info.sidechain_id, we1_sc_cert["sidechainId"],
                      "Sidechain Id in certificate is wrong.")

--- a/qa/sc_cert_key_rotation.py
+++ b/qa/sc_cert_key_rotation.py
@@ -148,7 +148,7 @@ class SCKeyRotationTest(SidechainTestFramework):
         self.sc_sync_all()
 
         # Call getCertificateSigners endpoint
-        certificate_signers_keys = http_get_certifiers_keys(sc_node, 0)["certifiersKeys"]
+        certificate_signers_keys = http_get_certifiers_keys(sc_node, -1)["certifiersKeys"]
         assert_equal(len(certificate_signers_keys["signingKeys"]), self.cert_max_keys)
         assert_equal(len(certificate_signers_keys["masterKeys"]), self.cert_max_keys)
 
@@ -419,7 +419,7 @@ class SCKeyRotationTest(SidechainTestFramework):
             assert_equal(master_key_rotation_proof, {})
 
         # Verify that we have the updated key
-        certificate_signers_keys = http_get_certifiers_keys(sc_node, 1)["certifiersKeys"]
+        certificate_signers_keys = http_get_certifiers_keys(sc_node, 0)["certifiersKeys"]
         assert_equal(certificate_signers_keys["signingKeys"][0]["publicKey"], new_public_key_2)
         assert_equal(certificate_signers_keys["masterKeys"][0]["publicKey"], new_public_key_3)
 
@@ -494,7 +494,7 @@ class SCKeyRotationTest(SidechainTestFramework):
             assert_equal(master_key_rotation_proof, {})
 
         # Verify that we have the updated key
-        certificate_signers_keys = http_get_certifiers_keys(sc_node, 2)["certifiersKeys"]
+        certificate_signers_keys = http_get_certifiers_keys(sc_node, 1)["certifiersKeys"]
         assert_equal(certificate_signers_keys["signingKeys"][0]["publicKey"], new_public_key_4)
 
         # Change ALL the signing keys and ALL tee master keys
@@ -610,7 +610,7 @@ class SCKeyRotationTest(SidechainTestFramework):
         check_mcreference_presence(we1_2_mcblock_hash, scblock_id, sc_node)
 
         # Verify that we have all the singing keys updated
-        certificate_signers_keys = http_get_certifiers_keys(sc_node, 3)["certifiersKeys"]
+        certificate_signers_keys = http_get_certifiers_keys(sc_node, 2)["certifiersKeys"]
         for i in range(len(certificate_signers_keys["signingKeys"])):
             assert_equal(certificate_signers_keys["signingKeys"][i]["publicKey"], new_signing_keys[i].publicKey)
             assert_equal(certificate_signers_keys["masterKeys"][i]["publicKey"], new_master_keys[i].publicKey)

--- a/qa/sc_cert_key_rotation_across_epoch.py
+++ b/qa/sc_cert_key_rotation_across_epoch.py
@@ -134,7 +134,7 @@ class SCKeyRotationAcrossEpochTest(SidechainTestFramework):
         epoch_mc_blocks_left -= 1
 
         # Call getCertificateKeys endpoint
-        certificate_signers_keys = http_get_certifiers_keys(sc_node, 0)["certifiersKeys"]
+        certificate_signers_keys = http_get_certifiers_keys(sc_node, -1)["certifiersKeys"]
         assert_equal(len(certificate_signers_keys["signingKeys"]), self.cert_max_keys)
         assert_equal(len(certificate_signers_keys["masterKeys"]), self.cert_max_keys)
 
@@ -319,7 +319,7 @@ class SCKeyRotationAcrossEpochTest(SidechainTestFramework):
             assert_equal(master_key_rotation_proof, {})
 
         # Verify that we have the updated key
-        certificate_signers_keys = http_get_certifiers_keys(sc_node, 1)["certifiersKeys"]
+        certificate_signers_keys = http_get_certifiers_keys(sc_node, 0)["certifiersKeys"]
         assert_equal(certificate_signers_keys["signingKeys"][0]["publicKey"], new_public_key_2)
         api_server_thread.terminate()
 

--- a/qa/sc_cert_key_rotation_old_circuit.py
+++ b/qa/sc_cert_key_rotation_old_circuit.py
@@ -81,7 +81,7 @@ class SCKeyRotationOldCircuitTest(SidechainTestFramework):
         epoch_mc_blocks_left -= 1
 
         # Call getCertificateSigners endpoint
-        certificate_signers_keys = http_get_certifiers_keys(sc_node, 0)["certifiersKeys"]
+        certificate_signers_keys = http_get_certifiers_keys(sc_node, -1)["certifiersKeys"]
         assert_equal(len(certificate_signers_keys["signingKeys"]), self.cert_max_keys)
         assert_equal(len(certificate_signers_keys["masterKeys"]), 0)
 

--- a/qa/sc_cert_submission_decentralization.py
+++ b/qa/sc_cert_submission_decentralization.py
@@ -185,7 +185,7 @@ class SCCertSubmissionDecentralization(SidechainTestFramework):
 
         # Verify Certificate quality for epoch 0 on SC side
         mbrefdata = sc_node1.block_best()["result"]["block"]["mainchainBlockReferencesData"][0]
-        assert_equal(7, mbrefdata["topQualityCertificates"][0]["quality"], "Certificate quality is wrong.")
+        assert_equal(7, mbrefdata["topQualityCertificate"]["quality"], "Certificate quality is wrong.")
 
         # Exclude SC Node 4 from the network
         logging.info("Disconnecting SC Node 4 from the network.")
@@ -247,7 +247,7 @@ class SCCertSubmissionDecentralization(SidechainTestFramework):
 
         # Verify Certificate quality for epoch 0 on SC side
         mbrefdata = sc_node1.block_best()["result"]["block"]["mainchainBlockReferencesData"][0]
-        assert_equal(7, mbrefdata["topQualityCertificates"][0]["quality"], "Certificate quality is wrong.")
+        assert_equal(7, mbrefdata["topQualityCertificate"]["quality"], "Certificate quality is wrong.")
 
 
 if __name__ == "__main__":

--- a/qa/sc_csw_disabled.py
+++ b/qa/sc_csw_disabled.py
@@ -206,7 +206,7 @@ class SCCswDisabled(SidechainTestFramework):
         sc_block_id = sc_block["id"]
         check_mcreference_presence(mc_block_hash, sc_block_id, sc_node)
 
-        sc_certificate = sc_block["mainchainBlockReferencesData"][0]["topQualityCertificates"][0]
+        sc_certificate = sc_block["mainchainBlockReferencesData"][0]["topQualityCertificate"]
         assert_true(len(sc_certificate["fieldElementCertificateFields"]) == 0,
                     "Custom Field Elements list should be empty")
 

--- a/qa/sc_genesisinfo_sc_versions.py
+++ b/qa/sc_genesisinfo_sc_versions.py
@@ -216,7 +216,7 @@ class SCGenesisInfoScVersions(SidechainTestFramework):
         mbrefdata = mbref[0]
         logging.info(mbref)
         #input("______")
-        we0_sc_cert = mbrefdata["topQualityCertificates"][0]
+        we0_sc_cert = mbrefdata["topQualityCertificate"]
         assert_equal(len(mbrefdata["lowerCertificateLeaves"]), 0)
         assert_equal(self.sc_nodes_bootstrap_info.sidechain_id, we0_sc_cert["sidechainId"],
                      "Sidechain Id in certificate is wrong.")

--- a/qa/sc_multiple_pending_certs_non_ceasing.py
+++ b/qa/sc_multiple_pending_certs_non_ceasing.py
@@ -37,8 +37,12 @@ Test:
     - Check that certificate submission is in progress on SC node 1
     - Wait for the cert in MC mempool and generate 1 MC block and 1 SC block with that Cert.
     - Check that we started generating certificate for the next epoch in the queue.
+    -- Verify that first certificate endCumulativeScTxCommitmentTreeRoot equals to last one in the withdrawal epoch 0.
     - Repeat previous 2 steps to see that we generated all certificates except the one for epoch 5 (not a moment)
+    -- Verify that certificate endCumulativeScTxCommitmentTreeRoot equals to the one that contains previous epoch cert.
+       Note: due to the certificate timing check in the MC we need to shift the endCumulativeScTxCommitmentTreeRoot.
     - Generate more MC and SC blocks. Check the submission of the Cert for epoch 5.
+    -- Verify that certificate endCumulativeScTxCommitmentTreeRoot equals to last one in the withdrawal epoch 5.
 """
 
 
@@ -169,6 +173,7 @@ class SCMultiplePendingCertsNonCeasing(SidechainTestFramework):
         mc_blocks_left_for_we -= 1  # minus block with FT
         generate_next_block(sc_node1, "first node")
 
+        end_epoch_cum_sc_tx_comm_tree_root = ""
         # Do `total_withdrawal_epochs_number` loops of withdrawal epochs with different BTs size
         half_epoch = int(self.sc_withdrawal_epoch_length / 2)
         for epoch_number in range(0, self.total_withdrawal_epochs_number):
@@ -178,6 +183,13 @@ class SCMultiplePendingCertsNonCeasing(SidechainTestFramework):
             mc_block_after_wrs = half_epoch
             pass_withdrawal_epoch(mc_node, sc_node1, mc_blocks_before_wrs, mc_block_after_wrs, epoch_number)
             mc_blocks_left_for_we = self.sc_withdrawal_epoch_length
+
+            # For the first epoch store the last virtual withdrawal epoch block scCumTreeHash
+            # It should appear as the first certificate endEpochCumScTxCommTreeRoot
+            if epoch_number == 0:
+                mcblock_hash = mc_node.getbestblockhash()
+                mcblock = mc_node.getblock(mcblock_hash)
+                end_epoch_cum_sc_tx_comm_tree_root = mcblock["scCumTreeHash"]
 
         # First node expects to generate its signatures
         # Connect and sync SC nodes
@@ -191,20 +203,34 @@ class SCMultiplePendingCertsNonCeasing(SidechainTestFramework):
             # Check for certificate to be appeared in MC mempool
             check_for_certificate(mc_node, sc_node1)
 
-            mc_node.generate(1)
+            # Get Certificate and verify epoch number and endEpochCumScTxCommTreeRoot
+            cert_hash = mc_node.getrawmempool()[0]
+            cert = mc_node.getrawtransaction(cert_hash, 1)
+            assert_equal(epoch_number, cert["cert"]["epochNumber"], "Sidechain epoch number in certificate is wrong.")
+            assert_equal(end_epoch_cum_sc_tx_comm_tree_root, cert["cert"]["endEpochCumScTxCommTreeRoot"],
+                         "Sidechain endEpochCumScTxCommTreeRoot in certificate is wrong.")
+
+            # Generate MC block and remember its scCumTreeHash
+            # It should appear as the next certificate endEpochCumScTxCommTreeRoot, because the current certificate
+            # had been applied to the MC after the given virtual withdrawal epoch end.
+            mc_block_with_cert_hash = mc_node.generate(1)[0]
             mc_blocks_left_for_we -= 1
+
+            mc_block_with_cert = mc_node.getblock(mc_block_with_cert_hash)
+            end_epoch_cum_sc_tx_comm_tree_root = mc_block_with_cert["scCumTreeHash"]
 
             # After cert appeared only in MC, no next cert attempts expected
             time.sleep(2)
             if sc_node1.submitter_isCertGenerationActive()["result"]["state"]:
                 fail("Cert submission is not expected")
-            # Next SC block triggers WE `epoch_number + 1` certificate submitting
+
+            # Next SC block triggers WE `epoch_number + 1` certificate submission
             generate_next_block(sc_node1, "first node")
             self.sc_sync_all()
 
         # Generate MC blocks and SC blocks to finish the WE
         # Check that after all pending cert were published, Nodes are able to keep processing new epochs
-        mc_node.generate(mc_blocks_left_for_we)
+        mcblock_hash = mc_node.generate(mc_blocks_left_for_we)[-1]
         generate_next_block(sc_node1, "first node")
 
         # Generate one more MC and SC block to trigger cert submission
@@ -213,6 +239,18 @@ class SCMultiplePendingCertsNonCeasing(SidechainTestFramework):
 
         # Check for certificate to be appeared in MC mempool
         check_for_certificate(mc_node, sc_node1)
+
+        # Get Certificate and verify epoch number and endEpochCumScTxCommTreeRoot
+        cert_hash = mc_node.getrawmempool()[0]
+        cert = mc_node.getrawtransaction(cert_hash, 1)
+        assert_equal(self.total_withdrawal_epochs_number, cert["cert"]["epochNumber"],
+                     "Sidechain epoch number in certificate is wrong.")
+        mcblock = mc_node.getblock(mcblock_hash)
+        # Since the previous certificate has been generated in time, the next certificate should specify
+        # endEpochCumScTxCommTreeRoot equals to the one of virtual withdrawal epoch last mc block.
+        end_epoch_cum_sc_tx_comm_tree_root = mcblock["scCumTreeHash"]
+        assert_equal(end_epoch_cum_sc_tx_comm_tree_root, cert["cert"]["endEpochCumScTxCommTreeRoot"],
+                     "Sidechain endEpochCumScTxCommTreeRoot in certificate is wrong.")
 
 
 if __name__ == "__main__":

--- a/qa/sc_multiple_pending_certs_non_ceasing.py
+++ b/qa/sc_multiple_pending_certs_non_ceasing.py
@@ -37,12 +37,12 @@ Test:
     - Check that certificate submission is in progress on SC node 1
     - Wait for the cert in MC mempool and generate 1 MC block and 1 SC block with that Cert.
     - Check that we started generating certificate for the next epoch in the queue.
-    -- Verify that first certificate endCumulativeScTxCommitmentTreeRoot equals to last one in the withdrawal epoch 0.
+    - Verify that first certificate endCumulativeScTxCommitmentTreeRoot equals to last one in the withdrawal epoch 0.
     - Repeat previous 2 steps to see that we generated all certificates except the one for epoch 5 (not a moment)
-    -- Verify that certificate endCumulativeScTxCommitmentTreeRoot equals to the one that contains previous epoch cert.
+    - Verify that certificate endCumulativeScTxCommitmentTreeRoot equals to the one that contains previous epoch cert.
        Note: due to the certificate timing check in the MC we need to shift the endCumulativeScTxCommitmentTreeRoot.
     - Generate more MC and SC blocks. Check the submission of the Cert for epoch 5.
-    -- Verify that certificate endCumulativeScTxCommitmentTreeRoot equals to last one in the withdrawal epoch 5.
+    - Verify that certificate endCumulativeScTxCommitmentTreeRoot equals to last one in the withdrawal epoch 5.
 """
 
 

--- a/qa/sc_versions_and_mc_certs.py
+++ b/qa/sc_versions_and_mc_certs.py
@@ -152,7 +152,7 @@ class SCVersionsAndMCCertificates(SidechainTestFramework):
         mbrefdata = mbref[0]
         logging.info(mbref)
         #input("______")
-        we0_sc_cert = mbrefdata["topQualityCertificates"][0]
+        we0_sc_cert = mbrefdata["topQualityCertificate"]
         assert_equal(len(mbrefdata["lowerCertificateLeaves"]), 0)
         assert_equal(self.sc_nodes_bootstrap_info.sidechain_id, we0_sc_cert["sidechainId"],
                      "Sidechain Id in certificate is wrong.")

--- a/sdk/src/main/java/com/horizen/cryptolibprovider/implementations/SchnorrFunctionsImplZendoo.java
+++ b/sdk/src/main/java/com/horizen/cryptolibprovider/implementations/SchnorrFunctionsImplZendoo.java
@@ -68,6 +68,18 @@ public class SchnorrFunctionsImplZendoo implements SchnorrFunctions {
     }
 
     @Override
+    public byte[] getHash(byte[] publicKeyBytes) {
+        SchnorrPublicKey publicKey = SchnorrPublicKey.deserialize(publicKeyBytes);
+        FieldElement hash = publicKey.getHash();
+        byte[] hashBytes = hash.serializeFieldElement();
+
+        publicKey.freePublicKey();
+        hash.freeFieldElement();
+
+        return hashBytes;
+    }
+
+    @Override
     public int schnorrSecretKeyLength() {
         return Constants.SCHNORR_SK_LENGTH();
     }

--- a/sdk/src/main/java/com/horizen/cryptolibprovider/utils/SchnorrFunctions.java
+++ b/sdk/src/main/java/com/horizen/cryptolibprovider/utils/SchnorrFunctions.java
@@ -19,6 +19,8 @@ public interface SchnorrFunctions {
     //looks like is not used at all in SDK
     boolean verify(byte[] messageBytes, byte[] publicKeyBytes, byte[] signatureBytes);
 
+    byte[] getHash(byte[] publicKeyBytes);
+
     int schnorrSecretKeyLength();
 
     int schnorrPublicKeyLength();

--- a/sdk/src/main/java/com/horizen/proposition/SchnorrProposition.java
+++ b/sdk/src/main/java/com/horizen/proposition/SchnorrProposition.java
@@ -28,7 +28,9 @@ public class SchnorrProposition
     public boolean verify(byte[] message, SchnorrProof signature) {
         return CryptoLibProvider.schnorrFunctions().verify(message, pubKeyBytes(), signature.bytes());
     }
-
+    public byte[] getHash() {
+        return CryptoLibProvider.schnorrFunctions().getHash(publicBytes);
+    }
 
     @JsonProperty("publicKey")
     @Override

--- a/sdk/src/main/resources/api/sidechainApi.yaml
+++ b/sdk/src/main/resources/api/sidechainApi.yaml
@@ -1939,8 +1939,8 @@ paths:
     post:
       tags:
         - submitter
-      summary: returns certificate signer keys
-      description: Accepts number of withdrawal epoch and returns signer keys of certificate signers
+      summary: returns certifiers keys
+      description: Searches for the certifiers keys data actual at the end of the given withdrawal epoch
       operationId: getCertifiersKeys
       requestBody:
         content:
@@ -1953,7 +1953,7 @@ paths:
                 withdrawalEpoch:
                   type: integer
                   format: int32
-                  description: Withdrawal epoch of certificate signer keys
+                  description: Withdrawal epoch number
       responses:
         '200':
           description: successful operation
@@ -1967,7 +1967,7 @@ paths:
                     properties:
                       certifiersKeys:
                         $ref: '#/components/schemas/CertifiersKeys'
-                        description: Signer and master certificate submitter keys
+                        description: Signers and masters certificate submitter keys
                   error:
                     $ref: '#/components/schemas/SidechainApiErrorResponse'
         default:

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -129,6 +129,14 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
     stateStorage.getLastCertificateReferencedEpoch()
   }
 
+  /*
+   * Returns the id of Sidechain block with the last top quality certificate certificate.
+   * Note: has sense only for non-ceasing sidechains. Always returns `None` for ceasing sidechains.
+   */
+  def lastCertificateSidechainBlockId(): Option[ModifierId] = {
+    stateStorage.getLastCertificateSidechainBlockId()
+  }
+
   def getWithdrawalEpochInfo: WithdrawalEpochInfo = {
     stateStorage.getWithdrawalEpochInfo.getOrElse(WithdrawalEpochInfo(0,0))
   }

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -96,6 +96,14 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
     stateStorage.getKeyRotationProof(withdrawalEpoch, indexOfSigner, keyType)
   }
 
+  /**
+   * Searches for the certifiers keys data actual at the end of the given withdrawal epoch
+   * @param withdrawalEpoch
+   *        withdrawal epoch number, at the end of which the certifiers keys where defined/stored
+   * @return certifier keys in case the given withdrawal epoch has been finished and the record is still in the database,
+   *         None otherwise.
+   * @note in case {@code witdrawalEpoch == -1}, than returns the genesis set of certifiers keys from params.
+   */
   def certifiersKeys(withdrawalEpoch: Int): Option[CertifiersKeys] = {
     if (withdrawalEpoch == -1)
       Option.apply(CertifiersKeys(params.signersPublicKeys.toVector, params.mastersPublicKeys.toVector))

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainSubmitterApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainSubmitterApiRoute.scala
@@ -14,11 +14,10 @@ import akka.pattern.ask
 import com.horizen.api.http.SidechainDebugErrorResponse.{ErrorBadCircuit, ErrorRetrieveCertificateSigners, ErrorRetrievingCertGenerationState, ErrorRetrievingCertSignerState, ErrorRetrievingCertSubmitterState}
 import com.horizen.api.http.SidechainDebugRestScheme._
 import com.horizen.certificatesubmitter.keys.{CertifiersKeys, KeyRotationProof}
-import com.horizen.cryptolibprovider.utils.CircuitTypes
 import com.horizen.cryptolibprovider.utils.CircuitTypes.{CircuitTypes, NaiveThresholdSignatureCircuit, NaiveThresholdSignatureCircuitWithKeyRotation}
-import com.horizen.schnorrnative.SchnorrPublicKey
 import com.horizen.utils.BytesUtils
 import com.horizen.api.http.JacksonSupport._
+import com.horizen.proposition.SchnorrProposition
 
 case class SidechainSubmitterApiRoute(override val settings: RESTApiSettings, certSubmitterRef: ActorRef, sidechainNodeViewHolderRef: ActorRef,  circuitType: CircuitTypes)
                                      (implicit val context: ActorRefFactory, override val ec: ExecutionContext) extends SidechainApiRoute {
@@ -86,10 +85,10 @@ case class SidechainSubmitterApiRoute(override val settings: RESTApiSettings, ce
   def getSchnorrPublicKeyHash: Route = (post & path("getSchnorrPublicKeyHash")) {
     entity(as[ReqGetSchnorrPublicKeyHash]) { body =>
       try {
-        val schnorrPublicKey = SchnorrPublicKey.deserialize(BytesUtils.fromHexString(body.schnorrPublicKey))
+        val schnorrPublicKey: SchnorrProposition = new SchnorrProposition(BytesUtils.fromHexString(body.schnorrPublicKey))
         ApiResponseUtil.toResponse(
           RespHashSchnorrPublicKey(
-            BytesUtils.toHexString(schnorrPublicKey.getHash.serializeFieldElement())
+            BytesUtils.toHexString(schnorrPublicKey.getHash)
           )
         )
       } catch {

--- a/sdk/src/main/scala/com/horizen/api/http/SidechainSubmitterApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/SidechainSubmitterApiRoute.scala
@@ -101,11 +101,11 @@ case class SidechainSubmitterApiRoute(override val settings: RESTApiSettings, ce
     try {
       entity(as[ReqGetCertificateSigners]) { body =>
           withView { sidechainNodeView =>
-            sidechainNodeView.state.certifiersKeys(body.withdrawalEpoch -1) match {
+            sidechainNodeView.state.certifiersKeys(body.withdrawalEpoch) match {
               case Some(certifiersKeys) =>
                 ApiResponseUtil.toResponse(RespGetCertificateSigners(certifiersKeys))
               case None =>
-                ApiResponseUtil.toResponse(ErrorRetrieveCertificateSigners("Impossible to find certificate signer keys!", JOptional.empty()))
+                ApiResponseUtil.toResponse(ErrorRetrieveCertificateSigners("Can not find certifiers keys.", JOptional.empty()))
             }
           }
       }
@@ -162,7 +162,7 @@ object SidechainDebugRestScheme {
 
   @JsonView(Array(classOf[Views.Default]))
   private[api] case class ReqGetCertificateSigners(withdrawalEpoch: Int) {
-    require(withdrawalEpoch >= 0, "Withdrawal epoch is negative")
+    require(withdrawalEpoch >= -1, "Withdrawal epoch is smaller than -1")
   }
 
   @JsonView(Array(classOf[Views.Default]))

--- a/sdk/src/main/scala/com/horizen/block/SidechainBlock.scala
+++ b/sdk/src/main/scala/com/horizen/block/SidechainBlock.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 @JsonView(Array(classOf[Views.Default]))
-@JsonIgnoreProperties(Array("messageToSign", "transactions", "version", "serializer", "modifierTypeId", "encoder", "companion", "feeInfo", "topQualityCertificates"))
+@JsonIgnoreProperties(Array("messageToSign", "transactions", "version", "serializer", "modifierTypeId", "encoder", "companion", "feeInfo", "topQualityCertificateOpt"))
 class SidechainBlock(override val header: SidechainBlockHeader,
                       val sidechainTransactions: Seq[SidechainTransaction[Proposition, Box[Proposition]]],
                       val mainchainBlockReferencesData: Seq[MainchainBlockReferenceData],
@@ -35,8 +35,7 @@ class SidechainBlock(override val header: SidechainBlockHeader,
 {
   def forgerPublicKey: PublicKey25519Proposition = header.forgingStakeInfo.blockSignPublicKey
 
-  // Note: can be 0 or 1 in case of ceasing sidechain, and 0+ for non-ceasing sidechain
-  lazy val topQualityCertificates: Seq[WithdrawalEpochCertificate] = mainchainBlockReferencesData.flatMap(_.topQualityCertificates)
+  lazy val topQualityCertificateOpt: Option[WithdrawalEpochCertificate] = mainchainBlockReferencesData.flatMap(_.topQualityCertificate).lastOption
 
   override type M = SidechainBlock
 

--- a/sdk/src/main/scala/com/horizen/certificatesubmitter/strategies/CircuitStrategy.scala
+++ b/sdk/src/main/scala/com/horizen/certificatesubmitter/strategies/CircuitStrategy.scala
@@ -1,6 +1,5 @@
 package com.horizen.certificatesubmitter.strategies
 
-import akka.util.Timeout
 import com.horizen._
 import com.horizen.certificatesubmitter.CertificateSubmitter.SignaturesStatus
 import com.horizen.certificatesubmitter.dataproof.CertificateData
@@ -13,7 +12,6 @@ import scorex.util.ScorexLogging
 import sparkz.core.NodeViewHolder.CurrentView
 
 import scala.compat.java8.OptionConverters.RichOptionalGeneric
-import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 abstract class CircuitStrategy[T <: CertificateData](settings: SidechainSettings, params: NetworkParams) extends ScorexLogging{

--- a/sdk/src/main/scala/com/horizen/certificatesubmitter/strategies/WithKeyRotationCircuitStrategy.scala
+++ b/sdk/src/main/scala/com/horizen/certificatesubmitter/strategies/WithKeyRotationCircuitStrategy.scala
@@ -63,7 +63,7 @@ class WithKeyRotationCircuitStrategy(settings: SidechainSettings, params: Networ
 
     val btrFee: Long = getBtrFee(status.referencedEpoch)
     val ftMinAmount: Long = getFtMinAmount(status.referencedEpoch)
-    val endEpochCumCommTreeHash = lastMainchainBlockCumulativeCommTreeHashForWithdrawalEpochNumber(history, status.referencedEpoch)
+    val endEpochCumCommTreeHash = lastMainchainBlockCumulativeCommTreeHashForWithdrawalEpochNumber(history, state, status.referencedEpoch)
     val sidechainId = params.sidechainId
 
     val previousCertificateOption: Option[WithdrawalEpochCertificate] = state.certificate(status.referencedEpoch - 1)
@@ -101,7 +101,7 @@ class WithKeyRotationCircuitStrategy(settings: SidechainSettings, params: Networ
     val btrFee: Long = getBtrFee(referencedWithdrawalEpochNumber)
     val ftMinAmount: Long = getFtMinAmount(referencedWithdrawalEpochNumber)
 
-    val endEpochCumCommTreeHash: Array[Byte] = lastMainchainBlockCumulativeCommTreeHashForWithdrawalEpochNumber(history, referencedWithdrawalEpochNumber)
+    val endEpochCumCommTreeHash: Array[Byte] = lastMainchainBlockCumulativeCommTreeHashForWithdrawalEpochNumber(history, state, referencedWithdrawalEpochNumber)
     val sidechainId = params.sidechainId
 
     val keysRootHash: Array[Byte] = CryptoLibProvider.thresholdSignatureCircuitWithKeyRotation

--- a/sdk/src/main/scala/com/horizen/certificatesubmitter/strategies/WithoutKeyRotationCircuitStrategy.scala
+++ b/sdk/src/main/scala/com/horizen/certificatesubmitter/strategies/WithoutKeyRotationCircuitStrategy.scala
@@ -53,9 +53,9 @@ class WithoutKeyRotationCircuitStrategy(settings: SidechainSettings, params: Net
     val withdrawalRequests: Seq[WithdrawalRequestBox] = state.withdrawalRequests(status.referencedEpoch)
 
     val btrFee: Long = getBtrFee(status.referencedEpoch)
-    val consensusEpochNumber = lastConsensusEpochNumberForWithdrawalEpochNumber(history, status.referencedEpoch)
+    val consensusEpochNumber = lastConsensusEpochNumberForWithdrawalEpochNumber(history, state, status.referencedEpoch)
     val ftMinAmount: Long = getFtMinAmount(consensusEpochNumber)
-    val endEpochCumCommTreeHash = lastMainchainBlockCumulativeCommTreeHashForWithdrawalEpochNumber(history, status.referencedEpoch)
+    val endEpochCumCommTreeHash = lastMainchainBlockCumulativeCommTreeHashForWithdrawalEpochNumber(history, state, status.referencedEpoch)
     val sidechainId = params.sidechainId
     val utxoMerkleTreeRoot: Option[Array[Byte]] = getUtxoMerkleTreeRoot(status.referencedEpoch, state)
 
@@ -83,10 +83,10 @@ class WithoutKeyRotationCircuitStrategy(settings: SidechainSettings, params: Net
     val withdrawalRequests: Seq[WithdrawalRequestBox] = state.withdrawalRequests(referencedWithdrawalEpochNumber)
 
     val btrFee: Long = getBtrFee(referencedWithdrawalEpochNumber)
-    val consensusEpochNumber = lastConsensusEpochNumberForWithdrawalEpochNumber(history, referencedWithdrawalEpochNumber)
+    val consensusEpochNumber = lastConsensusEpochNumberForWithdrawalEpochNumber(history, state, referencedWithdrawalEpochNumber)
     val ftMinAmount: Long = getFtMinAmount(consensusEpochNumber)
 
-    val endEpochCumCommTreeHash = lastMainchainBlockCumulativeCommTreeHashForWithdrawalEpochNumber(history, referencedWithdrawalEpochNumber)
+    val endEpochCumCommTreeHash = lastMainchainBlockCumulativeCommTreeHashForWithdrawalEpochNumber(history, state, referencedWithdrawalEpochNumber)
     val sidechainId = params.sidechainId
 
     val utxoMerkleTreeRoot: Option[Array[Byte]] = {

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -11,7 +11,6 @@ import com.horizen.forge.ForgerList
 import com.horizen.fork.{ForkManagerUtil, SimpleForkConfigurator}
 import com.horizen.params.MainNetParams
 import com.horizen.proposition.{Proposition, VrfPublicKey}
-import com.horizen.schnorrnative.SchnorrPublicKey
 import com.horizen.secret.{PrivateKey25519, SchnorrKeyGenerator, SchnorrSecret}
 import com.horizen.state.{ApplicationState, SidechainStateReader}
 import com.horizen.storage.{SidechainStateForgerBoxStorage, SidechainStateStorage}
@@ -120,7 +119,7 @@ class SidechainStateTest
 
   def getKeyRotationTransaction(boxesWithSecretToOpen: (ZenBox,PrivateKey25519), typeOfKey: KeyRotationProofTypes.KeyRotationProofType, keyIndex: Int, newKeySecret: SchnorrSecret, oldSigningKeySecret: SchnorrSecret, oldMasterKeySecret: SchnorrSecret, wrongNewKey: Boolean = false): CertificateKeyRotationTransaction = {
     val from: JPair[ZenBox,PrivateKey25519] =  new JPair[ZenBox,PrivateKey25519](boxesWithSecretToOpen._1, boxesWithSecretToOpen._2)
-    val messageToSign = SchnorrPublicKey.deserialize(newKeySecret.publicImage().pubKeyBytes()).getHash.serializeFieldElement()
+    val messageToSign = newKeySecret.publicImage().getHash
     val oldSigningKeySignature = oldSigningKeySecret.sign(messageToSign)
     val newMasterKeySignature = oldMasterKeySecret.sign(messageToSign)
     val newKeySignature = wrongNewKey match {
@@ -208,7 +207,7 @@ class SidechainStateTest
     //Test validate(Block)
     val mockedBlock = mock[SidechainBlock]
 
-    Mockito.when(mockedBlock.topQualityCertificates).thenReturn(Seq())
+    Mockito.when(mockedBlock.topQualityCertificateOpt).thenReturn(None)
 
     Mockito.when(mockedBlock.transactions)
       .thenReturn(transactionList.toList)
@@ -251,7 +250,7 @@ class SidechainStateTest
 
     //test mutuality transaction check
     val mutualityMockedBlock = mock[SidechainBlock]
-    Mockito.when(mutualityMockedBlock.topQualityCertificates).thenReturn(Seq())
+    Mockito.when(mutualityMockedBlock.topQualityCertificateOpt).thenReturn(None)
     Mockito.when(mutualityMockedBlock.mainchainBlockReferencesData).thenReturn(Seq())
     Mockito.when(mutualityMockedBlock.parentId).thenReturn(bytesToId(stateVersion.last.data))
     Mockito.when(mutualityMockedBlock.id).thenReturn(ModifierId @@ "testBlock")
@@ -273,7 +272,7 @@ class SidechainStateTest
 
 
     val doubleSpendTransactionMockedBlock = mock[SidechainBlock]
-    Mockito.when(doubleSpendTransactionMockedBlock.topQualityCertificates).thenReturn(Seq())
+    Mockito.when(doubleSpendTransactionMockedBlock.topQualityCertificateOpt).thenReturn(None)
     Mockito.when(doubleSpendTransactionMockedBlock.mainchainBlockReferencesData).thenReturn(Seq())
     Mockito.when(doubleSpendTransactionMockedBlock.parentId).thenReturn(bytesToId(stateVersion.last.data))
     Mockito.when(doubleSpendTransactionMockedBlock.id).thenReturn(ModifierId @@ "testBlock")
@@ -446,7 +445,7 @@ class SidechainStateTest
     Mockito.when(mockedBlock.mainchainBlockReferencesData)
       .thenAnswer(answer => Seq[MainchainBlockReferenceData]())
 
-    Mockito.when(mockedBlock.topQualityCertificates).thenReturn(Seq())
+    Mockito.when(mockedBlock.topQualityCertificateOpt).thenReturn(None)
 
     Mockito.when(mockedBlock.feeInfo).thenReturn(modBlockFeeInfo)
 
@@ -989,7 +988,7 @@ class SidechainStateTest
     //Test validate block with no empty WB slots accumulated, no new mainchain block references and a transaction with 1 WB
     val mockedBlock = mock[SidechainBlock]
 
-    Mockito.when(mockedBlock.topQualityCertificates).thenReturn(Seq())
+    Mockito.when(mockedBlock.topQualityCertificateOpt).thenReturn(None)
 
     Mockito.when(mockedBlock.transactions).thenReturn(transactionList.toList)
 
@@ -1015,7 +1014,7 @@ class SidechainStateTest
 
 
     //Test validate block with no empty WB slots accumulated, 1 new mainchain block reference and a transaction with 10 WBs
-    val emptyRefData: MainchainBlockReferenceData = MainchainBlockReferenceData(null, sidechainRelatedAggregatedTransaction = None, None, None, Seq(), Seq())
+    val emptyRefData: MainchainBlockReferenceData = MainchainBlockReferenceData(null, sidechainRelatedAggregatedTransaction = None, None, None, Seq(), None)
     Mockito.when(mockedBlock.mainchainBlockReferencesData).thenReturn(Seq(emptyRefData))
 
     transactionList.clear()

--- a/sdk/src/test/scala/com/horizen/SidechainWalletCswDataProviderCSWEnabledTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainWalletCswDataProviderCSWEnabledTest.scala
@@ -74,7 +74,7 @@ class SidechainWalletCswDataProviderCSWEnabledTest
 
 
     // Test 1: RefData without MC2SCAggTx
-    val emptyRefData: MainchainBlockReferenceData = MainchainBlockReferenceData(null, sidechainRelatedAggregatedTransaction = None, None, None, Seq(), Seq())
+    val emptyRefData: MainchainBlockReferenceData = MainchainBlockReferenceData(null, sidechainRelatedAggregatedTransaction = None, None, None, Seq(), None)
     assertTrue("No CSW data expected to be found.", cswDataProviderWithCSW.calculateForwardTransferCswData(Seq(emptyRefData), pubKeys, params).isEmpty)
 
 
@@ -87,7 +87,7 @@ class SidechainWalletCswDataProviderCSWEnabledTest
     var mc2scTransactionsOutputs: Seq[SidechainRelatedMainchainOutput[_ <: Box[_ <: Proposition]]] = Seq(scCr1, ft1, ft2)
     var aggTx = new MC2SCAggregatedTransaction(mc2scTransactionsOutputs.asJava, MC2SCAggregatedTransaction.MC2SC_AGGREGATED_TRANSACTION_VERSION)
 
-    val refData: MainchainBlockReferenceData = MainchainBlockReferenceData(null, Some(aggTx), None, None, Seq(), Seq())
+    val refData: MainchainBlockReferenceData = MainchainBlockReferenceData(null, Some(aggTx), None, None, Seq(), None)
     assertTrue("No CSW data expected to be found.", cswDataProviderWithCSW.calculateForwardTransferCswData(Seq(refData), pubKeys, params).isEmpty)
 
 
@@ -99,7 +99,7 @@ class SidechainWalletCswDataProviderCSWEnabledTest
     mc2scTransactionsOutputs = Seq(walletFt1, ft1, ft2, walletFt2)
     aggTx = new MC2SCAggregatedTransaction(mc2scTransactionsOutputs.asJava, MC2SCAggregatedTransaction.MC2SC_AGGREGATED_TRANSACTION_VERSION)
 
-    val refDataWithFTs: MainchainBlockReferenceData = MainchainBlockReferenceData(null, Some(aggTx), None, None, Seq(), Seq())
+    val refDataWithFTs: MainchainBlockReferenceData = MainchainBlockReferenceData(null, Some(aggTx), None, None, Seq(), None)
 
     val commTree = refDataWithFTs.commitmentTree(params.sidechainId, params.sidechainCreationVersion)
     val expectedCswData = Seq(
@@ -157,7 +157,7 @@ class SidechainWalletCswDataProviderCSWEnabledTest
     val aggTx = new MC2SCAggregatedTransaction(mc2scTransactionsOutputs.asJava, MC2SCAggregatedTransaction.MC2SC_AGGREGATED_TRANSACTION_VERSION)
 
 
-    val refDataWithFTs: MainchainBlockReferenceData = MainchainBlockReferenceData(null, Some(aggTx), None, None, Seq(), Seq())
+    val refDataWithFTs: MainchainBlockReferenceData = MainchainBlockReferenceData(null, Some(aggTx), None, None, Seq(), None)
 
     val commTree = refDataWithFTs.commitmentTree(params.sidechainId, params.sidechainCreationVersion)
     Mockito.when(mockedBlock.mainchainBlockReferencesData).thenReturn(Seq(refDataWithFTs))

--- a/sdk/src/test/scala/com/horizen/block/MainchainBlockReferenceTest.scala
+++ b/sdk/src/test/scala/com/horizen/block/MainchainBlockReferenceTest.scala
@@ -15,7 +15,13 @@ import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 // Most of the tests are executed twice (once for ceasing, once for non-ceasing case)
-// But the cases with multiple certificates for given sidechain are specific to the type of sidechain
+// But the cases with multiple certificates for given sidechain are specific to the ceasing sidechains only:
+// Non-ceasing sidechains can't have more than one certificate for in a single MC block.
+
+// Note: At the earlier version of SDK (0.6.0-SNAPSHOT2) non-ceasing sidechains had a different structure
+// of McBlockRefData compared to ceasing ones: multiple certificates for different epochs were allowed.
+// In 0.6.0-SNAPSHOT3 this modification has been reverted, since became impossible from MC side (zend 4.0.0-beta).
+// Thus, we still keep full coverage of McBlockRefs parsing for both ceasing and non-ceasing sidechains.
 class MainchainBlockReferenceTest extends JUnitSuite {
 
   @Test
@@ -47,7 +53,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertFalse("Old Block occurred, proof of existence expected to be undefined.", block.get.data.existenceProof.isDefined)
     assertFalse("Old Block occurred, proof of absence expected to be undefined.", block.get.data.absenceProof.isDefined)
     assertFalse("Old Block occurred, MC2SCAggTx expected to be undefined.", block.get.data.sidechainRelatedAggregatedTransaction.isDefined)
-    assertTrue("Old Block occurred, Certificate expected to be undefined.", block.get.data.topQualityCertificates.isEmpty)
+    assertTrue("Old Block occurred, Certificate expected to be undefined.", block.get.data.topQualityCertificate.isEmpty)
     assertEquals("Block version = 536870912 expected.", 536870912, block.get.header.version)
     assertEquals("Hash of previous block is different.", "0000000009572f35ecc6e319216b29046fdb6695ad93b3e5d77053285df4af03", BytesUtils.toHexString(block.get.header.hashPrevBlock))
     assertEquals("Merkle root hash is different.", "5bf368ee4fc02f055e8ca5447a21b9758e6435b3214bc10b55f533cc9b3d1a6d", BytesUtils.toHexString(block.get.header.hashMerkleRoot))
@@ -73,7 +79,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertFalse("Old Block occurred, proof of existence expected to be undefined.", block.get.data.existenceProof.isDefined)
     assertFalse("Old Block occurred, proof of absence expected to be undefined.", block.get.data.absenceProof.isDefined)
     assertFalse("Old Block occurred, MC2SCAggTx expected to be undefined.", block.get.data.sidechainRelatedAggregatedTransaction.isDefined)
-    assertTrue("Old Block occurred, Certificate expected to be undefined.", block.get.data.topQualityCertificates.isEmpty)
+    assertTrue("Old Block occurred, Certificate expected to be undefined.", block.get.data.topQualityCertificate.isEmpty)
     assertEquals("Block version = 536870912 expected.", 536870912, block.get.header.version)
     assertEquals("Hash of previous block is different.", "00000000106843ee0119c6db92e38e8655452fd85f638f6640475e8c6a3a3582", BytesUtils.toHexString(block.get.header.hashPrevBlock))
     assertEquals("Merkle root hash is different.", "493232e7d362852c8e3fe6aa5a48d6f6e01220f617c258db511ee2386b6362ea", BytesUtils.toHexString(block.get.header.hashMerkleRoot))
@@ -99,7 +105,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertFalse("Old Block occurred, proof of existence expected to be undefined.", block.get.data.existenceProof.isDefined)
     assertFalse("Old Block occurred, proof of absence expected to be undefined.", block.get.data.absenceProof.isDefined)
     assertFalse("Old Block occurred, MC2SCAggTx expected to be undefined.", block.get.data.sidechainRelatedAggregatedTransaction.isDefined)
-    assertTrue("Old Block occurred, Certificate expected to be undefined.", block.get.data.topQualityCertificates.isEmpty)
+    assertTrue("Old Block occurred, Certificate expected to be undefined.", block.get.data.topQualityCertificate.isEmpty)
     assertEquals("Block version = 536870912 expected.", 536870912, block.get.header.version)
     assertEquals("Hash of previous block is different.", "0000000071076828a1d738dfde576b21ac4e28998ae7a026f631e57d7561a28b", BytesUtils.toHexString(block.get.header.hashPrevBlock))
     assertEquals("Merkle root hash is different.", "7169f926344ff99dbee02ed2429481bbbc0b84cb4773c1dcaee20458e0d0437a", BytesUtils.toHexString(block.get.header.hashMerkleRoot))
@@ -147,7 +153,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     }
 
     assertTrue("Block must not contain transaction.", mcblock.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must not contain certificate.", mcblock.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock.data.topQualityCertificate.isEmpty)
     assertTrue("Block must not contain proof of existence.", mcblock.data.existenceProof.isEmpty)
     assertTrue("Block must not contain proof of absence", mcblock.data.absenceProof.isEmpty)
 
@@ -202,7 +208,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertEquals("Sc creation output id is different", scId, new ByteArrayWrapper(scCreation.sidechainId()))
 
 
-    assertTrue("Block must not contain certificate.", mcblock1.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock1.data.topQualityCertificate.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock1.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock1.data.absenceProof.isEmpty)
 
@@ -247,7 +253,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertEquals("FT output id is different", scId, new ByteArrayWrapper(ft.sidechainId()))
 
 
-    assertTrue("Block must not contain certificate.", mcblock1.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock1.data.topQualityCertificate.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock1.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock1.data.absenceProof.isEmpty)
 
@@ -285,7 +291,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock1.semanticValidity(params1).isSuccess)
 
     assertTrue("Block must contain transaction.", mcblock1.data.sidechainRelatedAggregatedTransaction.isDefined)
-    assertTrue("Block must not contain certificate.", mcblock1.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock1.data.topQualityCertificate.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock1.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock1.data.absenceProof.isEmpty)
 
@@ -305,7 +311,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock2.semanticValidity(params2).isSuccess)
 
     assertTrue("Block must contain transaction.", mcblock2.data.sidechainRelatedAggregatedTransaction.isDefined)
-    assertTrue("Block must not contain certificate.", mcblock2.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock2.data.topQualityCertificate.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock2.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock2.data.absenceProof.isEmpty)
 
@@ -325,7 +331,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock3.semanticValidity(params3).isSuccess)
 
     assertTrue("Block must contain transaction.", mcblock3.data.sidechainRelatedAggregatedTransaction.isDefined)
-    assertTrue("Block must not contain certificate.", mcblock3.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock3.data.topQualityCertificate.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock3.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock3.data.absenceProof.isEmpty)
 
@@ -344,7 +350,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock4.semanticValidity(params4).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock4.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must not contain certificate.", mcblock4.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock4.data.topQualityCertificate.isEmpty)
     assertTrue("Block must not contain proof of existence.", mcblock4.data.existenceProof.isEmpty)
     assertTrue("Block must not contain proof of absence", mcblock4.data.absenceProof.isDefined)
 
@@ -363,7 +369,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock5.semanticValidity(params5).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock5.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must not contain certificate.", mcblock5.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock5.data.topQualityCertificate.isEmpty)
     assertTrue("Block must not contain proof of existence.", mcblock5.data.existenceProof.isEmpty)
     assertTrue("Block must contain proof of absence.", mcblock5.data.absenceProof.isDefined)
 
@@ -383,7 +389,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock6.semanticValidity(params6).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock6.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must not contain certificate.", mcblock6.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock6.data.topQualityCertificate.isEmpty)
     assertTrue("Block must not contain proof of existence.", mcblock6.data.existenceProof.isEmpty)
     assertTrue("Block must contain proof of absence.", mcblock6.data.absenceProof.isDefined)
 
@@ -403,7 +409,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock7.semanticValidity(params7).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock7.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must not contain certificate.", mcblock7.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock7.data.topQualityCertificate.isEmpty)
     assertTrue("Block must not contain proof of existence.", mcblock7.data.existenceProof.isEmpty)
     assertTrue("Block must contain proof of absence.", mcblock7.data.absenceProof.isDefined)
   }
@@ -437,7 +443,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock1.semanticValidity(params1).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock1.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock1.data.topQualityCertificates.nonEmpty)
+    assertTrue("Block must contain certificate.", mcblock1.data.topQualityCertificate.nonEmpty)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock1.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock1.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock1.data.absenceProof.isEmpty)
@@ -457,7 +463,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock2.semanticValidity(params2).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock2.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock2.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must contain certificate.", mcblock2.data.topQualityCertificate.isEmpty)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock2.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock2.data.existenceProof.isEmpty)
     assertTrue("Block must not contain proof of absence", mcblock2.data.absenceProof.isDefined)
@@ -489,10 +495,10 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock1.semanticValidity(params1).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock1.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock1.data.topQualityCertificates.nonEmpty)
+    assertTrue("Block must contain certificate.", mcblock1.data.topQualityCertificate.nonEmpty)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock1.data.lowerCertificateLeaves.isEmpty)
-    assertEquals("Block certificate must contain correct ft fee.", 54, mcblock1.data.topQualityCertificates.head.ftMinAmount)
-    assertEquals("Block certificate must contain correct btr fee.", 0, mcblock1.data.topQualityCertificates.head.btrFee)
+    assertEquals("Block certificate must contain correct ft fee.", 54, mcblock1.data.topQualityCertificate.get.ftMinAmount)
+    assertEquals("Block certificate must contain correct btr fee.", 0, mcblock1.data.topQualityCertificate.get.btrFee)
   }
 
   @Test
@@ -532,7 +538,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock1.semanticValidity(params1).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock1.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock1.data.topQualityCertificates.nonEmpty)
+    assertTrue("Block must contain certificate.", mcblock1.data.topQualityCertificate.nonEmpty)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock1.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock1.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock1.data.absenceProof.isEmpty)
@@ -552,25 +558,13 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock2.semanticValidity(params2).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock2.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock2.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must contain certificate.", mcblock2.data.topQualityCertificate.isEmpty)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock2.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock2.data.existenceProof.isEmpty)
     assertTrue("Block must not contain proof of absence", mcblock2.data.absenceProof.isDefined)
   }
 
-  @Test
   def blockWithMultipleCertificates_Ceasing(): Unit = {
-    blockWithMultipleCertificates(false)
-  }
-
-  @Test
-  def blockWithMultipleCertificates_NonCeasing(): Unit = {
-    // Note: Used MC block actually contains 2 certificates for ceasing case (they both below to the same epoch)
-    // but for current test case it is more than enough.
-    blockWithMultipleCertificates(true)
-  }
-
-  def blockWithMultipleCertificates(isNonCeasing: Boolean): Unit = {
     // Test: parse MC block with 2 certificates.
     val mcBlockHex = Source.fromResource("new_mc_blocks/mc_block_with_2_certificates").getLines().next()
     val mcBlockBytes = BytesUtils.fromHexString(mcBlockHex)
@@ -580,7 +574,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     val scIdHex1 = "1aabf493f8605e78177d71c0aef3b251b2b9aaa66715fc86729a4e86ce566d8e"
     val scId1 = new ByteArrayWrapper(BytesUtils.reverseBytes(BytesUtils.fromHexString(scIdHex1))) // LE
 
-    val params1 = RegTestParams(scId1.data, isNonCeasing = isNonCeasing)
+    val params1 = RegTestParams(scId1.data)
 
     val mcblockTry1 = MainchainBlockReference.create(mcBlockBytes, params1, TestSidechainsVersionsManager(params1))
 
@@ -598,17 +592,9 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     }
 
     assertTrue("Block must not contain transaction.", mcblock1.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    if(isNonCeasing) {
-      assertEquals("For non-ceasing sidechain block must contain 2 top quality certificates.", 2,
-        mcblock1.data.topQualityCertificates.size)
-      assertTrue("For non-ceasing sidechain block must contain NO lower quality certificates.",
-        mcblock1.data.lowerCertificateLeaves.isEmpty)
-    } else {
-      assertEquals("For ceasing sidechain block must contain 1 top quality certificate.", 1,
-        mcblock1.data.topQualityCertificates.size)
-      assertEquals("For ceasing sidechain block must contain 1 low quality certificate.", 1,
-        mcblock1.data.lowerCertificateLeaves.size)
-    }
+    assertTrue("For ceasing sidechain block must contain 1 top quality certificate.", mcblock1.data.topQualityCertificate.isDefined)
+    assertEquals("For ceasing sidechain block must contain 1 low quality certificate.", 1,
+      mcblock1.data.lowerCertificateLeaves.size)
     assertTrue("Block must contain proof of existence.", mcblock1.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence.", mcblock1.data.absenceProof.isEmpty)
 
@@ -617,7 +603,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     val scIdHex2 = "0000000000000000000000000000000000000000000000000000000000000000"
     val scId2 = new ByteArrayWrapper(BytesUtils.reverseBytes(BytesUtils.fromHexString(scIdHex2))) // LE
 
-    val params2 = RegTestParams(scId2.data, isNonCeasing = isNonCeasing)
+    val params2 = RegTestParams(scId2.data)
 
     val mcblockTry2 = MainchainBlockReference.create(mcBlockBytes, params2, TestSidechainsVersionsManager(SidechainVersionZero))
 
@@ -627,7 +613,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock2.semanticValidity(params2).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock2.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must not contain top quality certificate.", mcblock2.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain top quality certificate.", mcblock2.data.topQualityCertificate.isEmpty)
     assertEquals("Block must not contain lower quality certificates.", 0, mcblock2.data.lowerCertificateLeaves.size)
     assertTrue("Block must not contain proof of existence.", mcblock2.data.existenceProof.isEmpty)
     assertTrue("Block must contain proof of absence.", mcblock2.data.absenceProof.isDefined)
@@ -670,9 +656,9 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock1.semanticValidity(params1).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock1.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock1.data.topQualityCertificates.nonEmpty)
-    assertEquals("Block must contain certificate with 3 cert field elements.", 3, mcblock1.data.topQualityCertificates.head.fieldElementCertificateFields.length)
-    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock1.data.topQualityCertificates.head.bitVectorCertificateFields.length)
+    assertTrue("Block must contain certificate.", mcblock1.data.topQualityCertificate.nonEmpty)
+    assertEquals("Block must contain certificate with 3 cert field elements.", 3, mcblock1.data.topQualityCertificate.get.fieldElementCertificateFields.length)
+    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock1.data.topQualityCertificate.get.bitVectorCertificateFields.length)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock1.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock1.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock1.data.absenceProof.isEmpty)
@@ -692,7 +678,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock2.semanticValidity(params2).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock2.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock2.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must contain certificate.", mcblock2.data.topQualityCertificate.isEmpty)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock2.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock2.data.existenceProof.isEmpty)
     assertTrue("Block must not contain proof of absence", mcblock2.data.absenceProof.isDefined)
@@ -775,7 +761,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock1.semanticValidity(params1).isSuccess)
 
     assertTrue("Block must contain transaction.", mcblock1.data.sidechainRelatedAggregatedTransaction.isDefined)
-    assertTrue("Block must not contain certificate.", mcblock1.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock1.data.topQualityCertificate.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock1.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock1.data.absenceProof.isEmpty)
 
@@ -794,7 +780,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock2.semanticValidity(params2).isSuccess)
 
     assertTrue("Block must contain transaction.", mcblock2.data.sidechainRelatedAggregatedTransaction.isDefined)
-    assertTrue("Block must not contain certificate.", mcblock2.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock2.data.topQualityCertificate.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock2.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock2.data.absenceProof.isEmpty)
 
@@ -816,9 +802,9 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock3.semanticValidity(params3).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock3.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock3.data.topQualityCertificates.nonEmpty)
-    assertEquals("Block must contain certificate with 2 cert field elements.", 2, mcblock3.data.topQualityCertificates.head.fieldElementCertificateFields.length)
-    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock3.data.topQualityCertificates.head.bitVectorCertificateFields.length)
+    assertTrue("Block must contain certificate.", mcblock3.data.topQualityCertificate.nonEmpty)
+    assertEquals("Block must contain certificate with 2 cert field elements.", 2, mcblock3.data.topQualityCertificate.get.fieldElementCertificateFields.length)
+    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock3.data.topQualityCertificate.get.bitVectorCertificateFields.length)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock3.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock3.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock3.data.absenceProof.isEmpty)
@@ -841,9 +827,9 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock4.semanticValidity(params4).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock4.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock4.data.topQualityCertificates.nonEmpty)
-    assertEquals("Block must contain certificate with 2 cert field elements.", 2, mcblock4.data.topQualityCertificates.head.fieldElementCertificateFields.length)
-    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock4.data.topQualityCertificates.head.bitVectorCertificateFields.length)
+    assertTrue("Block must contain certificate.", mcblock4.data.topQualityCertificate.nonEmpty)
+    assertEquals("Block must contain certificate with 2 cert field elements.", 2, mcblock4.data.topQualityCertificate.get.fieldElementCertificateFields.length)
+    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock4.data.topQualityCertificate.get.bitVectorCertificateFields.length)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock4.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock4.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock4.data.absenceProof.isEmpty)
@@ -866,9 +852,9 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock5.semanticValidity(params5).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock5.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock5.data.topQualityCertificates.nonEmpty)
-    assertEquals("Block must contain certificate with 2 cert field elements.", 2, mcblock5.data.topQualityCertificates.head.fieldElementCertificateFields.length)
-    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock5.data.topQualityCertificates.head.bitVectorCertificateFields.length)
+    assertTrue("Block must contain certificate.", mcblock5.data.topQualityCertificate.nonEmpty)
+    assertEquals("Block must contain certificate with 2 cert field elements.", 2, mcblock5.data.topQualityCertificate.get.fieldElementCertificateFields.length)
+    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock5.data.topQualityCertificate.get.bitVectorCertificateFields.length)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock5.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock5.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock5.data.absenceProof.isEmpty)
@@ -891,9 +877,9 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock6.semanticValidity(params6).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock6.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock6.data.topQualityCertificates.nonEmpty)
-    assertEquals("Block must contain certificate with 2 cert field elements.", 2, mcblock6.data.topQualityCertificates.head.fieldElementCertificateFields.length)
-    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock6.data.topQualityCertificates.head.bitVectorCertificateFields.length)
+    assertTrue("Block must contain certificate.", mcblock6.data.topQualityCertificate.nonEmpty)
+    assertEquals("Block must contain certificate with 2 cert field elements.", 2, mcblock6.data.topQualityCertificate.get.fieldElementCertificateFields.length)
+    assertEquals("Block must contain certificate with 1 cert bitvector.", 1, mcblock6.data.topQualityCertificate.get.bitVectorCertificateFields.length)
     assertTrue("Block must not-contain lower quality certificate leaves.", mcblock6.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must contain proof of existence.", mcblock6.data.existenceProof.isDefined)
     assertTrue("Block must not contain proof of absence", mcblock6.data.absenceProof.isEmpty)
@@ -913,7 +899,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("Block expected to be semantically valid", mcblock7.semanticValidity(params7).isSuccess)
 
     assertTrue("Block must not contain transaction.", mcblock7.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must not contain certificate.", mcblock7.data.topQualityCertificates.isEmpty)
+    assertTrue("Block must not contain certificate.", mcblock7.data.topQualityCertificate.isEmpty)
     assertTrue("Block must not contain lower quality certificate leaves.", mcblock7.data.lowerCertificateLeaves.isEmpty)
     assertTrue("Block must not contain proof of existence.", mcblock7.data.existenceProof.isEmpty)
     assertTrue("Block must contain proof of absence", mcblock7.data.absenceProof.isDefined)
@@ -1007,7 +993,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     val mcBlockReferenceData = deserializedMcBlockReferenceDataTry.get
 
     assertTrue("Block reference data must not contain transaction.", mcBlockReferenceData.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block reference data must not contain certificate.", mcBlockReferenceData.topQualityCertificates.isEmpty)
+    assertTrue("Block reference data must not contain certificate.", mcBlockReferenceData.topQualityCertificate.isEmpty)
     assertTrue("Block reference data must not contain proof of existence.", mcBlockReferenceData.existenceProof.isEmpty)
     assertTrue("Block reference data must not contain proof of absence", mcBlockReferenceData.absenceProof.isEmpty)
 
@@ -1036,9 +1022,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     val mcBlockReferenceData = deserializedMcBlockReferenceDataTry.get
 
     assertTrue("Block reference data must not contain transaction.", mcBlockReferenceData.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block reference data must contain certificate.", mcBlockReferenceData.topQualityCertificates.nonEmpty)
-    assertEquals("Block reference data must contain 1 top quality certificate.",
-      1, mcBlockReferenceData.topQualityCertificates.size)
+    assertTrue("Block reference data must contain certificate.", mcBlockReferenceData.topQualityCertificate.nonEmpty)
     assertTrue("Block reference data must not-contain lower quality certificate leaves.", mcBlockReferenceData.lowerCertificateLeaves.isEmpty)
     assertTrue("Block reference data must contain proof of existence.", mcBlockReferenceData.existenceProof.isDefined)
     assertTrue("Block reference data must not contain proof of absence", mcBlockReferenceData.absenceProof.isEmpty)
@@ -1067,8 +1051,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
     assertTrue("MainchainBlockReferenceData expected to by parsed.", deserializedMcBlockReferenceDataTry.isSuccess)
     val mcBlockReferenceData = deserializedMcBlockReferenceDataTry.get
 
-    assertEquals("Block reference data must contain 1 top quality certificate.",
-      1, mcBlockReferenceData.topQualityCertificates.size)
+    assertTrue("Block reference data must contain 1 top quality certificate.", mcBlockReferenceData.topQualityCertificate.nonEmpty)
     assertEquals("Block reference data must contain 1 low quality certificate.",
       1, mcBlockReferenceData.lowerCertificateLeaves.size)
     assertTrue("Block reference data must contain proof of existence.", mcBlockReferenceData.existenceProof.isDefined)
@@ -1106,7 +1089,7 @@ class MainchainBlockReferenceTest extends JUnitSuite {
 
     assertEquals("Block hash is different.", blockHash, mcblock.header.hashHex)
     assertTrue("Block must not contain MC2SCAggTx transaction.", mcblock.data.sidechainRelatedAggregatedTransaction.isEmpty)
-    assertTrue("Block must contain certificate.", mcblock.data.topQualityCertificates.nonEmpty)
-    assertEquals("Certificate BTs number is different", 156, mcblock.data.topQualityCertificates.head.backwardTransferOutputs.size)
+    assertTrue("Block must contain certificate.", mcblock.data.topQualityCertificate.nonEmpty)
+    assertEquals("Certificate BTs number is different", 156, mcblock.data.topQualityCertificate.get.backwardTransferOutputs.size)
   }
 }

--- a/sdk/src/test/scala/com/horizen/fixtures/MainchainBlockReferenceFixture.scala
+++ b/sdk/src/test/scala/com/horizen/fixtures/MainchainBlockReferenceFixture.scala
@@ -90,7 +90,7 @@ trait MainchainBlockReferenceFixture extends MainchainHeaderFixture {
       }
     }
 
-    val newReference = new MainchainBlockReference(header, MainchainBlockReferenceData(header.hash, None, None, None, Seq(), Seq())) {
+    val newReference = new MainchainBlockReference(header, MainchainBlockReferenceData(header.hash, None, None, None, Seq(), None)) {
       override def semanticValidity(params: NetworkParams): Try[Unit] = Success(Unit)
     }
 
@@ -117,7 +117,7 @@ trait MainchainBlockReferenceFixture extends MainchainHeaderFixture {
 
 
   def mainchainBlockReferenceWithMockedAggTx(ref: MainchainBlockReference): MainchainBlockReference = {
-    new MainchainBlockReference(ref.header, MainchainBlockReferenceData(ref.header.hash, Some(mock[MC2SCAggregatedTransaction]), None, None, Seq(), Seq())) {
+    new MainchainBlockReference(ref.header, MainchainBlockReferenceData(ref.header.hash, Some(mock[MC2SCAggregatedTransaction]), None, None, Seq(), None)) {
       override def semanticValidity(params: NetworkParams): Try[Unit] = Success(Unit)
     }
   }

--- a/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
@@ -255,7 +255,7 @@ class SidechainStateIntegrationTest
     Mockito.when(mockedBlock.mainchainBlockReferencesData)
       .thenReturn(Seq[MainchainBlockReferenceData](mock[MainchainBlockReferenceData]))
 
-    Mockito.when(mockedBlock.topQualityCertificates).thenReturn(Seq())
+    Mockito.when(mockedBlock.topQualityCertificateOpt).thenReturn(None)
 
     val blockFeeInfo = BlockFeeInfo(307, getPrivateKey25519("mod".getBytes()).publicImage())
     Mockito.when(mockedBlock.feeInfo).thenReturn(blockFeeInfo)

--- a/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
@@ -176,7 +176,7 @@ class SidechainStateStorageTest
     assertEquals("Storage must NOT contain requested Box.", None, stateStorage.getBox("non-existing id".getBytes()))
 
     // Data for Test 1:
-    val version = getVersion
+    val version: ByteArrayWrapper = getVersion
     val toUpdate = new JArrayList[Pair[ByteArrayWrapper, ByteArrayWrapper]]()
     val toRemove = new JArrayList[ByteArrayWrapper]()
     toUpdate.add(storedBoxList.head)
@@ -194,6 +194,9 @@ class SidechainStateStorageTest
 
     toUpdate.add(new Pair(new ByteArrayWrapper(stateStorage.getTopQualityCertificateKey(referenceEpochNumber)),
       new ByteArrayWrapper(WithdrawalEpochCertificateSerializer.toBytes(cert))))
+
+    toUpdate.add(new Pair(new ByteArrayWrapper(stateStorage.getLastCertificateSidechainBlockIdKey), version))
+
     // block fee info
     val nextBlockFeeInfoCounter: Int = 0
     val blockFeeInfo: BlockFeeInfo = BlockFeeInfo(100, getPrivateKey25519("1234".getBytes()).publicImage())
@@ -214,16 +217,16 @@ class SidechainStateStorageTest
       ArgumentMatchers.anyList[Pair[ByteArrayWrapper, ByteArrayWrapper]](),
       ArgumentMatchers.anyList[ByteArrayWrapper]()))
       // For Test 1:
-      .thenAnswer(answer => {
-        val actualVersion = answer.getArgument(0).asInstanceOf[ByteArrayWrapper]
-        val actualToUpdate = answer.getArgument(1).asInstanceOf[java.util.List[Pair[ByteArrayWrapper, ByteArrayWrapper]]]
-        val actualToRemove = answer.getArgument(2).asInstanceOf[java.util.List[ByteArrayWrapper]]
+      .thenAnswer(args => {
+        val actualVersion = args.getArgument(0).asInstanceOf[ByteArrayWrapper]
+        val actualToUpdate = args.getArgument(1).asInstanceOf[java.util.List[Pair[ByteArrayWrapper, ByteArrayWrapper]]]
+        val actualToRemove = args.getArgument(2).asInstanceOf[java.util.List[ByteArrayWrapper]]
         assertEquals("StateStorage.update(...) actual Version is wrong.", version, actualVersion)
         assertEquals("StateStorage.update(...) actual toUpdate list is wrong.", toUpdate, actualToUpdate)
         assertEquals("StateStorage.update(...) actual toRemove list is wrong.", toRemove, actualToRemove)
       })
       // For Test 2:
-      .thenAnswer(answer => throw expectedException)
+      .thenAnswer(_ => throw expectedException)
 
     // Test 1: test successful update
     tryRes = stateStorage.update(version, withdrawalEpochInfo, Set(boxList.head),


### PR DESCRIPTION
Non-ceasing sidechain zen 4.0.0 compatibility fixes:
1) fixing the issue with certificate rejection in case of previous certificate delay).
2) MC block ref data structure has been reverted to be identical to the ceasing case, since no more multiple certificates for different epochs are allowed.
3) memory leak fix for zendoo-sc-cryptolib

Test with MC tag `v4.0.0-rc2`