### PR TITLE
Non-ceasing sidechains: fix certificate validation in the account state.

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -55,7 +55,8 @@
     <dependency>
       <groupId>io.horizen</groupId>
       <artifactId>zendoo-sc-cryptolib</artifactId>
-      <version>0.6.0-SNAPSHOT</version>
+      <!-- 0.6.0-SNAPSHOT without the fixes to circuit with key rotation-->
+      <version>0.6.0-20221202.200901-3</version>
       <scope>compile</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.sparkzfoundation/sparkz-core -->

--- a/sdk/src/main/scala/com/horizen/account/state/AccountState.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/AccountState.scala
@@ -96,7 +96,7 @@ class AccountState(
           // For non-ceasing sidechains certificate must be validated just when it has been received.
           // In case of multiple certificates appeared and at least one of them is invalid (conflicts with the current chain)
           // then the whole block is invalid.
-          mod.topQualityCertificateOpt.foreach(cert => validateTopQualityCertificate(cert, stateView))
+          mod.mainchainBlockReferencesData.flatMap(_.topQualityCertificate).foreach(cert => validateTopQualityCertificate(cert, stateView))
         } else {
           // For ceasing sidechains submission window concept is used.
           // If SC block has reached the certificate submission window end -> check the top quality certificate


### PR DESCRIPTION
Fixed zendoo-sc-cryptolib dependency version to the timestamp