### PR TITLE
Sc2sc/sdk 644

### DIFF
--- a/sdk/src/main/java/com/horizen/box/CoreBoxesIdsEnum.java
+++ b/sdk/src/main/java/com/horizen/box/CoreBoxesIdsEnum.java
@@ -3,7 +3,8 @@ package com.horizen.box;
 public enum CoreBoxesIdsEnum {
     ZenBoxId((byte)1),
     WithdrawalRequestBoxId((byte)2),
-    ForgerBoxId((byte)3);
+    ForgerBoxId((byte)3),
+    CrossChainMessageBoxId((byte)4);
 
     private final byte id;
 

--- a/sdk/src/main/java/com/horizen/box/CrossChainMessageBox.java
+++ b/sdk/src/main/java/com/horizen/box/CrossChainMessageBox.java
@@ -1,0 +1,49 @@
+package com.horizen.box;
+
+import com.horizen.box.data.CrossChainMessageBoxData;
+import com.horizen.proposition.PublicKey25519Proposition;
+import com.horizen.sc2sc.CrossChainProtocolVersion;
+
+import static com.horizen.box.CoreBoxesIdsEnum.CrossChainMessageBoxId;
+
+public final class CrossChainMessageBox
+        extends AbstractBox<PublicKey25519Proposition, CrossChainMessageBoxData, CrossChainMessageBox>
+{
+    public CrossChainMessageBox(CrossChainMessageBoxData boxData, long nonce) {
+        super(boxData, nonce);
+    }
+
+    public CrossChainProtocolVersion getProtocolVersion(){
+        return boxData.getProtocolVersion();
+    }
+
+    public Integer getMessageType() {
+        return boxData.getMessageType();
+    }
+
+    public byte[] getReceiverSidechain() {
+        return boxData.getReceiverSidechain();
+    }
+
+    public byte[] getReceiverAddress() {
+        return boxData.getReceiverAddress();
+    }
+
+    public byte[] getPayload() {
+        return boxData.getPayload();
+    }
+
+    @Override
+    public byte boxTypeId() {
+        return CrossChainMessageBoxId.id();
+    }
+
+    @Override
+    public BoxSerializer serializer() {
+        return CrossChainMessageBoxSerializer.getSerializer();
+    }
+
+    @Override
+    public Boolean isCustom() { return false; }
+}
+

--- a/sdk/src/main/java/com/horizen/box/CrossChainMessageBoxSerializer.java
+++ b/sdk/src/main/java/com/horizen/box/CrossChainMessageBoxSerializer.java
@@ -1,0 +1,36 @@
+package com.horizen.box;
+
+import com.horizen.box.data.CrossChainMessageBoxData;
+import com.horizen.box.data.CrossChainMessageBoxDataSerializer;
+import scorex.util.serialization.Reader;
+import scorex.util.serialization.Writer;
+
+public final class CrossChainMessageBoxSerializer implements BoxSerializer<CrossChainMessageBox> {
+
+    private static CrossChainMessageBoxSerializer serializer;
+
+    static {
+        serializer = new CrossChainMessageBoxSerializer();
+    }
+
+    private CrossChainMessageBoxSerializer() {
+        super();
+    }
+
+    public static CrossChainMessageBoxSerializer getSerializer() {
+        return serializer;
+    }
+
+    @Override
+    public void serialize(CrossChainMessageBox box, Writer writer) {
+        writer.putLong(box.nonce);
+        box.boxData.serializer().serialize(box.boxData, writer);
+    }
+
+    @Override
+    public CrossChainMessageBox parse(Reader reader) {
+        Long nonce = reader.getLong();
+        CrossChainMessageBoxData boxData = CrossChainMessageBoxDataSerializer.getSerializer().parse(reader);
+        return new CrossChainMessageBox(boxData, nonce);
+    }
+}

--- a/sdk/src/main/java/com/horizen/box/data/CrossChainMessageBoxData.java
+++ b/sdk/src/main/java/com/horizen/box/data/CrossChainMessageBoxData.java
@@ -1,6 +1,7 @@
 package com.horizen.box.data;
 
 import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Shorts;
 import com.horizen.box.CrossChainMessageBox;
 import com.horizen.proposition.PublicKey25519Proposition;
 import com.horizen.sc2sc.CrossChainProtocolVersion;
@@ -67,7 +68,8 @@ public final class CrossChainMessageBoxData extends AbstractBoxData<PublicKey255
 
     @Override
     public byte[] customFieldsHash() {
-        return Blake2b256.hash(Bytes.concat(new byte[]{messageType.byteValue()}, receiverSidechain, receiverAddress, payload));
+        return Blake2b256.hash(Bytes.concat(Shorts.toByteArray(protocolVersion.getVal()),
+                new byte[]{messageType.byteValue()}, receiverSidechain, receiverAddress, payload));
     }
 }
 

--- a/sdk/src/main/java/com/horizen/box/data/CrossChainMessageBoxData.java
+++ b/sdk/src/main/java/com/horizen/box/data/CrossChainMessageBoxData.java
@@ -1,0 +1,73 @@
+package com.horizen.box.data;
+
+import com.google.common.primitives.Bytes;
+import com.horizen.box.CrossChainMessageBox;
+import com.horizen.proposition.PublicKey25519Proposition;
+import com.horizen.sc2sc.CrossChainProtocolVersion;
+import scorex.crypto.hash.Blake2b256;
+
+import java.util.Objects;
+
+public final class CrossChainMessageBoxData extends AbstractBoxData<PublicKey25519Proposition, CrossChainMessageBox, CrossChainMessageBoxData> {
+
+    private CrossChainProtocolVersion protocolVersion;
+    private final Integer messageType;
+    private final byte[]  receiverSidechain;
+    private final byte[]  receiverAddress;
+    private final byte[]  payload;
+
+    public CrossChainMessageBoxData(PublicKey25519Proposition proposition,
+                         CrossChainProtocolVersion protocolVersion,
+                         Integer messageType,
+                         byte[] receiverSidechain,
+                         byte[] receiverAddress,
+                         byte[] payload) {
+        super(proposition, 0);
+        Objects.requireNonNull(protocolVersion, "protocol version must be defined");
+        Objects.requireNonNull(messageType, "messageType must be defined");
+        Objects.requireNonNull(receiverSidechain, "receiverSidechain must be defined");
+        Objects.requireNonNull(receiverAddress, "receiverAddress must be defined");
+        Objects.requireNonNull(payload, "payload must be defined");
+        this.protocolVersion = protocolVersion;
+        this.messageType = messageType;
+        this.receiverSidechain = receiverSidechain;
+        this.receiverAddress = receiverAddress;
+        this.payload = payload;
+    }
+
+    public CrossChainProtocolVersion getProtocolVersion() {
+        return protocolVersion;
+    }
+
+    public Integer getMessageType() {
+        return messageType;
+    }
+
+    public byte[] getReceiverSidechain() {
+        return receiverSidechain;
+    }
+
+    public byte[] getReceiverAddress() {
+        return receiverAddress;
+    }
+
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    @Override
+    public CrossChainMessageBox getBox(long nonce) {
+        return new CrossChainMessageBox(this, nonce);
+    }
+
+    @Override
+    public BoxDataSerializer serializer() {
+        return CrossChainMessageBoxDataSerializer.getSerializer();
+    }
+
+    @Override
+    public byte[] customFieldsHash() {
+        return Blake2b256.hash(Bytes.concat(new byte[]{messageType.byteValue()}, receiverSidechain, receiverAddress, payload));
+    }
+}
+

--- a/sdk/src/main/java/com/horizen/box/data/CrossChainMessageBoxDataSerializer.java
+++ b/sdk/src/main/java/com/horizen/box/data/CrossChainMessageBoxDataSerializer.java
@@ -1,0 +1,47 @@
+package com.horizen.box.data;
+
+import com.horizen.proposition.PublicKey25519Proposition;
+import com.horizen.proposition.PublicKey25519PropositionSerializer;
+import com.horizen.proposition.VrfPublicKey;
+import com.horizen.proposition.VrfPublicKeySerializer;
+import com.horizen.sc2sc.CrossChainProtocolVersion;
+import scorex.util.serialization.Reader;
+import scorex.util.serialization.Writer;
+
+
+public final class CrossChainMessageBoxDataSerializer implements BoxDataSerializer<CrossChainMessageBoxData> {
+
+    private final static CrossChainMessageBoxDataSerializer serializer = new CrossChainMessageBoxDataSerializer();
+
+    private CrossChainMessageBoxDataSerializer() {
+        super();
+    }
+
+    public static CrossChainMessageBoxDataSerializer getSerializer() {
+        return serializer;
+    }
+
+    @Override
+    public void serialize(CrossChainMessageBoxData boxData, Writer writer) {
+        boxData.proposition().serializer().serialize(boxData.proposition(), writer);
+        writer.putShort(boxData.getProtocolVersion().getVal());
+        writer.putInt(boxData.getMessageType());
+        writer.putInt(boxData.getReceiverSidechain().length);
+        writer.putBytes(boxData.getReceiverSidechain());
+        writer.putInt(boxData.getReceiverAddress().length);
+        writer.putBytes(boxData.getReceiverAddress());
+        writer.putInt(boxData.getPayload().length);
+        writer.putBytes(boxData.getPayload());
+    }
+
+    @Override
+    public CrossChainMessageBoxData parse(Reader reader) {
+        PublicKey25519Proposition proposition = PublicKey25519PropositionSerializer.getSerializer().parse(reader);
+        CrossChainProtocolVersion protocolVersion = CrossChainProtocolVersion.fromShort(reader.getShort());
+        Integer messageType = reader.getInt();
+        byte[]  receiverSidechain = reader.getBytes(reader.getInt());
+        byte[]  receiverAddress = reader.getBytes(reader.getInt());
+        byte[]  payload = reader.getBytes(reader.getInt());
+        return new CrossChainMessageBoxData(proposition, protocolVersion, messageType, receiverSidechain, receiverAddress, payload);
+    }
+}

--- a/sdk/src/main/java/com/horizen/cryptolibprovider/CommonCircuit.java
+++ b/sdk/src/main/java/com/horizen/cryptolibprovider/CommonCircuit.java
@@ -39,6 +39,7 @@ public class  CommonCircuit {
     // For example, for Latus circuit (at least 13 custom fields for own needs) with SC2SC support.
     public static final int CUSTOM_FIELDS_NUMBER_WITH_DISABLED_CSW_WITH_KEY_ROTATION = 32;
 
+
     public boolean generateCoboundaryMarlinDLogKeys() {
         return ProvingSystem.generateDLogKeys(
                 ProvingSystemType.COBOUNDARY_MARLIN,
@@ -68,6 +69,12 @@ public class  CommonCircuit {
                 cert.btrFee(),
                 Arrays.stream(cert.customFieldsOpt(sidechainCreationVersion).get()).map(FieldElement::deserialize).collect(Collectors.toList())
         );
+    }
+
+    public byte[] getCertDataHash(WithdrawalEpochCertificate cert, Enumeration.Value sidechainCreationVersion) throws Exception {
+        try(WithdrawalCertificate wc = createWithdrawalCertificate(cert, sidechainCreationVersion); FieldElement hashFe = wc.getHash()) {
+            return hashFe.serializeFieldElement();
+        }
     }
 
     public static List<SchnorrSignature> getSignatures(List<Optional<byte[]>> schnorrSignatureBytesList){

--- a/sdk/src/main/java/com/horizen/cryptolibprovider/CustomFieldsReservedPositions.java
+++ b/sdk/src/main/java/com/horizen/cryptolibprovider/CustomFieldsReservedPositions.java
@@ -1,0 +1,17 @@
+package com.horizen.cryptolibprovider;
+
+public enum CustomFieldsReservedPositions {
+
+    Sc2sc_message_tree_root((byte)1),
+    Sc2sc_previus_certificate_hash((byte)2);
+
+    private final int position;
+
+    CustomFieldsReservedPositions(int position) {
+        this.position = position;
+    }
+
+    public int position() {
+        return position;
+    }
+}

--- a/sdk/src/main/java/com/horizen/cryptolibprovider/Sc2scCircuit.java
+++ b/sdk/src/main/java/com/horizen/cryptolibprovider/Sc2scCircuit.java
@@ -17,7 +17,7 @@ public interface Sc2scCircuit {
 
     byte[] getCrossChainMessageTreeRoot(List<CrossChainMessage> messages);
 
-    MerklePath gerCrossChainMessageMerklePath(List<CrossChainMessage> messages, CrossChainMessage leaf);
+    MerklePath getCrossChainMessageMerklePath(List<CrossChainMessage> messages, CrossChainMessage leaf);
 
     byte[] createRedeemProof(CrossChainMessageHash messageHash,
                              MerklePath messageMerkePath,

--- a/sdk/src/main/java/com/horizen/cryptolibprovider/Sc2scCircuit.java
+++ b/sdk/src/main/java/com/horizen/cryptolibprovider/Sc2scCircuit.java
@@ -1,0 +1,38 @@
+package com.horizen.cryptolibprovider;
+
+
+import com.horizen.certnative.WithdrawalCertificate;
+import com.horizen.librustsidechains.FieldElement;
+import com.horizen.merkletreenative.MerklePath;
+import com.horizen.sc2sc.CrossChainMessage;
+import com.horizen.sc2sc.CrossChainMessageHash;
+
+import java.util.List;
+
+public interface Sc2scCircuit {
+
+    int getMaxMessagesPerCertificate();
+
+    CrossChainMessageHash getCrossChainMessageHash(CrossChainMessage msg);
+
+    byte[] getCrossChainMessageTreeRoot(List<CrossChainMessage> messages);
+
+    MerklePath gerCrossChainMessageMerklePath(List<CrossChainMessage> messages, CrossChainMessage leaf);
+
+    byte[] createRedeemProof(CrossChainMessageHash messageHash,
+                             MerklePath messageMerkePath,
+                             WithdrawalCertificate topQuality_cert_epochN,
+                             MerklePath merklePath_topQuality_cert_epochN,
+                             FieldElement sc_tx_commitment_root_cert_epochN,
+                             WithdrawalCertificate cert_epoch_N1,
+                             MerklePath merklePath_cert_epochN1,
+                             FieldElement sc_tx_commitment_root_cert_epochN1
+                             );
+
+    boolean verifyRedeemProof(CrossChainMessageHash messageHash,
+                              FieldElement sc_tx_commitment_root_cert_epochN,
+                              MerklePath merklePath_topQuality_cert_epochN1,
+                              byte[] proof
+    );
+
+}

--- a/sdk/src/main/java/com/horizen/cryptolibprovider/implementations/CswCircuitImplZendoo.java
+++ b/sdk/src/main/java/com/horizen/cryptolibprovider/implementations/CswCircuitImplZendoo.java
@@ -4,6 +4,7 @@ import com.horizen.block.WithdrawalEpochCertificate;
 import com.horizen.box.Box;
 import com.horizen.certnative.WithdrawalCertificate;
 import com.horizen.cryptolibprovider.CommonCircuit;
+import com.horizen.cryptolibprovider.CryptoLibProvider;
 import com.horizen.cryptolibprovider.CswCircuit;
 import com.horizen.cswnative.CswFtProverData;
 import com.horizen.cswnative.CswProof;
@@ -48,9 +49,7 @@ public class CswCircuitImplZendoo implements CswCircuit {
 
     @Override
     public byte[] getCertDataHash(WithdrawalEpochCertificate cert, Enumeration.Value sidechainCreationVersion) throws Exception {
-        try(WithdrawalCertificate wc = CommonCircuit.createWithdrawalCertificate(cert, sidechainCreationVersion); FieldElement hashFe = wc.getHash()) {
-            return hashFe.serializeFieldElement();
-        }
+        return CryptoLibProvider.commonCircuitFunctions().getCertDataHash(cert, sidechainCreationVersion);
     }
 
     @Override

--- a/sdk/src/main/java/com/horizen/cryptolibprovider/implementations/Sc2scImplZendoo.java
+++ b/sdk/src/main/java/com/horizen/cryptolibprovider/implementations/Sc2scImplZendoo.java
@@ -1,0 +1,55 @@
+package com.horizen.cryptolibprovider.implementations;
+
+import com.horizen.certnative.WithdrawalCertificate;
+import com.horizen.cryptolibprovider.Sc2scCircuit;
+import com.horizen.librustsidechains.FieldElement;
+import com.horizen.merkletreenative.MerklePath;
+import com.horizen.sc2sc.CrossChainMessage;
+import com.horizen.sc2sc.CrossChainMessageHash;
+import com.horizen.sc2sc.CrossChainMessageHashImpl;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+//TODO: tobe implemented..
+public class Sc2scImplZendoo implements Sc2scCircuit {
+
+    @Override
+    public int getMaxMessagesPerCertificate() {
+        return 10;
+    }
+
+    @Override
+    public byte[] getCrossChainMessageTreeRoot(List<CrossChainMessage> messages){
+        return new byte[1];
+    }
+    @Override
+    public MerklePath gerCrossChainMessageMerklePath(List<CrossChainMessage> messages, CrossChainMessage leaf){
+        return  MerklePath.deserialize(new byte[0]);
+    }
+
+    @Override
+    public byte[] createRedeemProof(CrossChainMessageHash messageHash,
+                                    MerklePath messageMerkePath,
+                                    WithdrawalCertificate topQuality_cert_epochN,
+                                    MerklePath merklePath_topQuality_cert_epochN,
+                                    FieldElement sc_tx_commitment_root_cert_epochN,
+                                    WithdrawalCertificate cert_epoch_N1,
+                                    MerklePath merklePath_topQuality_cert_epochN1,
+                                    FieldElement sc_tx_commitment_root_cert_epochN1) {
+        return new byte[0];
+    }
+
+    @Override
+    public boolean verifyRedeemProof(CrossChainMessageHash messageHash,
+                                     FieldElement sc_tx_commitment_root_cert_epochN,
+                                     MerklePath merklePath_topQuality_cert_epochN1,
+                                     byte[] proof) {
+        return false;
+    }
+
+    @Override
+    public CrossChainMessageHash getCrossChainMessageHash(CrossChainMessage msg) {
+        return new CrossChainMessageHashImpl(new byte[0]);
+    }
+}

--- a/sdk/src/main/java/com/horizen/cryptolibprovider/implementations/Sc2scImplZendoo.java
+++ b/sdk/src/main/java/com/horizen/cryptolibprovider/implementations/Sc2scImplZendoo.java
@@ -24,7 +24,7 @@ public class Sc2scImplZendoo implements Sc2scCircuit {
         return new byte[1];
     }
     @Override
-    public MerklePath gerCrossChainMessageMerklePath(List<CrossChainMessage> messages, CrossChainMessage leaf){
+    public MerklePath getCrossChainMessageMerklePath(List<CrossChainMessage> messages, CrossChainMessage leaf){
         return  MerklePath.deserialize(new byte[0]);
     }
 

--- a/sdk/src/main/java/com/horizen/sc2sc/CrossChainMessageImpl.java
+++ b/sdk/src/main/java/com/horizen/sc2sc/CrossChainMessageImpl.java
@@ -1,11 +1,5 @@
 package com.horizen.sc2sc;
-
-import com.horizen.proposition.Proposition;
 import com.horizen.utils.BytesUtils;
-import sparkz.core.serialization.BytesSerializable;
-import sparkz.core.serialization.SparkzSerializer;
-
-import java.util.Arrays;
 
 public class CrossChainMessageImpl implements CrossChainMessage{
 

--- a/sdk/src/main/java/com/horizen/sc2sc/CrossChainMessageImpl.java
+++ b/sdk/src/main/java/com/horizen/sc2sc/CrossChainMessageImpl.java
@@ -1,6 +1,9 @@
 package com.horizen.sc2sc;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.horizen.serialization.Views;
 import com.horizen.utils.BytesUtils;
 
+@JsonView(Views.Default.class)
 public class CrossChainMessageImpl implements CrossChainMessage{
 
     private CrossChainProtocolVersion version;

--- a/sdk/src/main/java/com/horizen/sc2sc/CrossChainRedeemMessageImpl.java
+++ b/sdk/src/main/java/com/horizen/sc2sc/CrossChainRedeemMessageImpl.java
@@ -2,8 +2,6 @@ package com.horizen.sc2sc;
 
 import com.horizen.utils.BytesUtils;
 
-import java.util.Arrays;
-
 public class CrossChainRedeemMessageImpl implements CrossChainRedeemMessage {
 
     private CrossChainMessage message;
@@ -12,6 +10,20 @@ public class CrossChainRedeemMessageImpl implements CrossChainRedeemMessage {
     private byte[] scCommitmentTreeRoot;
     private byte[] nextScCommitmentTreeRoot;
     private byte[] proof;
+
+    public CrossChainRedeemMessageImpl(CrossChainMessage message,
+             byte[] certificateDataHash,
+             byte[] nextCertificateDataHash,
+             byte[] scCommitmentTreeRoot,
+             byte[] nextScCommitmentTreeRoot,
+             byte[] proof){
+        this.message = message;
+        this.certificateDataHash = certificateDataHash;
+        this.nextCertificateDataHash = nextCertificateDataHash;
+        this.scCommitmentTreeRoot = scCommitmentTreeRoot;
+        this.nextScCommitmentTreeRoot = nextScCommitmentTreeRoot;
+        this.proof = proof;
+    }
 
     @Override
     public CrossChainMessage getMessage() {

--- a/sdk/src/main/java/com/horizen/sc2sc/CrossChainRedeemMessageImpl.java
+++ b/sdk/src/main/java/com/horizen/sc2sc/CrossChainRedeemMessageImpl.java
@@ -1,7 +1,10 @@
 package com.horizen.sc2sc;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import com.horizen.serialization.Views;
 import com.horizen.utils.BytesUtils;
 
+@JsonView(Views.Default.class)
 public class CrossChainRedeemMessageImpl implements CrossChainRedeemMessage {
 
     private CrossChainMessage message;

--- a/sdk/src/main/scala/com/horizen/AbstractState.scala
+++ b/sdk/src/main/scala/com/horizen/AbstractState.scala
@@ -1,13 +1,21 @@
 package com.horizen
 
-import com.horizen.block.{SidechainBlockBase, SidechainBlockHeaderBase, WithdrawalEpochCertificate}
+import java.util
+
+import com.horizen.block.SidechainCreationVersions.SidechainCreationVersion
+import com.horizen.block.{MainchainBlockReferenceData, SidechainBlockBase, SidechainBlockHeaderBase, WithdrawalEpochCertificate}
 import com.horizen.certificatesubmitter.keys.{CertifiersKeys, KeyRotationProof}
 import com.horizen.certnative.BackwardTransfer
 import com.horizen.consensus.ConsensusEpochInfo
+import com.horizen.cryptolibprovider.{CommonCircuit, CryptoLibProvider, CustomFieldsReservedPositions}
+import com.horizen.librustsidechains.FieldElement
+import com.horizen.sc2sc.{CrossChainMessage, CrossChainMessageHash}
 import com.horizen.transaction.Transaction
 import com.horizen.utils.WithdrawalEpochInfo
 import scorex.util.ModifierId
 import sparkz.core.transaction.state.MinimalState
+
+import scala.collection.JavaConverters._
 
 abstract class AbstractState[
   TX <: Transaction,
@@ -30,13 +38,53 @@ abstract class AbstractState[
   def isForgingOpen: Boolean
 
   def lastCertificateReferencedEpoch: Option[Int]
+
   def lastCertificateSidechainBlockId(): Option[ModifierId]
+
   def keyRotationProof(withdrawalEpoch: Int, indexOfSigner: Int, keyType: Int): Option[KeyRotationProof]
+
   def certifiersKeys(withdrawalEpoch: Int): Option[CertifiersKeys]
   def backwardTransfers(withdrawalEpoch: Int): Seq[BackwardTransfer]
 
   def certificate(referencedWithdrawalEpoch: Int): Option[WithdrawalEpochCertificate]
+
   def utxoMerkleTreeRoot(withdrawalEpoch: Int): Option[Array[Byte]]
+
+  //methods needed for Sidechain2Sidechian:
+  def getCrossChainMessages(withdrawalEpoch: Int): Seq[CrossChainMessage]
+
+  def getCrossChainMessageHashEpoch(messageHash: CrossChainMessageHash): Option[Int]
+
+  //hash of mainchain block that published the top quality cert of this epoch
+  def getTopCertificateMainchainHash(withdrawalEpoch: Int): Option[Array[Byte]];
+
+  protected def validateTopQualityCertificateForSc2Sc(topQualityCertificate: WithdrawalEpochCertificate,
+                                                      certReferencedEpochNumber: Int,
+                                                      sidechainCreationVersion: SidechainCreationVersion): Unit = {
+
+    val certificateCustomFields = topQualityCertificate.fieldElementCertificateFields
+    if (certificateCustomFields.size != CommonCircuit.CUSTOM_FIELDS_NUMBER_WITH_DISABLED_CSW_WITH_KEY_ROTATION) {
+      throw new IllegalArgumentException(s"Top quality certificate should contain exactly ${CommonCircuit.CUSTOM_FIELDS_NUMBER_WITH_DISABLED_CSW_WITH_KEY_ROTATION} custom fields when sidechain2sidechain messaging is enabled.")
+    }
+    val messageTreeRoot = certificateCustomFields(CustomFieldsReservedPositions.Sc2sc_message_tree_root.position()).rawData
+    val previousCertificateHash = certificateCustomFields(CustomFieldsReservedPositions.Sc2sc_previus_certificate_hash.position()).rawData
+
+    val expectedPreviousCertificateHash: Array[Byte] = certificate(topQualityCertificate.epochNumber - 1) match {
+      case None => FieldElement.createFromLong(0).serializeFieldElement()
+      case Some(value) => CryptoLibProvider.commonCircuitFunctions.getCertDataHash(value, sidechainCreationVersion)
+    }
+    if (!util.Arrays.equals(previousCertificateHash, expectedPreviousCertificateHash)) {
+      throw new IllegalStateException(s"Epoch $certReferencedEpochNumber top quality certificate has incorrect previousCertificateHash field")
+    }
+    val expectedCrosschainMessages = getCrossChainMessages(certReferencedEpochNumber)
+    val expectedMessageTreeroot = CryptoLibProvider.sc2scCircuitFunctions.getCrossChainMessageTreeRoot(expectedCrosschainMessages.toList.asJava)
+    if (!util.Arrays.equals(messageTreeRoot, expectedMessageTreeroot)) {
+      throw new IllegalStateException(s"Epoch $certReferencedEpochNumber top quality certificate has incorrect crosschain message tree root field")
+    }
+  }
+
 }
+
+
 
 

--- a/sdk/src/main/scala/com/horizen/SidechainApp.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainApp.scala
@@ -88,7 +88,7 @@ class SidechainApp @Inject()
   log.info(s"Starting application with settings \n$sidechainSettings")
 
   override protected lazy val sidechainTransactionsCompanion: SidechainTransactionsCompanion = SidechainTransactionsCompanion(customTransactionSerializers, circuitType)
-  protected lazy val sidechainBoxesCompanion: SidechainBoxesCompanion =  SidechainBoxesCompanion(customBoxSerializers)
+  protected lazy val sidechainBoxesCompanion: SidechainBoxesCompanion =  SidechainBoxesCompanion(customBoxSerializers, sc2scConfigurator.canSendMessages)
 
   // Deserialize genesis block bytes
   override lazy val genesisBlock: SidechainBlock = new SidechainBlockSerializer(sidechainTransactionsCompanion).parseBytes(

--- a/sdk/src/main/scala/com/horizen/SidechainApp.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainApp.scala
@@ -191,7 +191,7 @@ class SidechainApp @Inject()
         SidechainSyncInfoMessageSpec, settings.network, timeProvider, modifierSerializers))
 
   // Init Forger with a proper web socket client
-  val sidechainBlockForgerActorRef: ActorRef = ForgerRef("Forger", sidechainSettings, nodeViewHolderRef,  mainchainSynchronizer, sidechainTransactionsCompanion, timeProvider, params)
+  val sidechainBlockForgerActorRef: ActorRef = ForgerRef("Forger", sidechainSettings, nodeViewHolderRef,  mainchainSynchronizer, sidechainTransactionsCompanion, timeProvider, sc2scConfigurator, params)
 
   // Init Transactions and Block actors for Api routes classes
   val sidechainTransactionActorRef: ActorRef = SidechainTransactionActorRef(nodeViewHolderRef)

--- a/sdk/src/main/scala/com/horizen/SidechainApp.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainApp.scala
@@ -174,6 +174,7 @@ class SidechainApp @Inject()
     sidechainWalletCswDataProvider,
     backupStorage,
     params,
+    sc2scConfigurator,
     timeProvider,
     applicationWallet,
     applicationState,
@@ -197,7 +198,7 @@ class SidechainApp @Inject()
 
   // Init Certificate Submitter
   // Depends on params.isNonCeasing submitter will choose a proper strategy.
-  val certificateSubmitterRef: ActorRef = CertificateSubmitterRef(sidechainSettings, nodeViewHolderRef, secureEnclaveApiClient, params, mainchainNodeChannel)
+  val certificateSubmitterRef: ActorRef = CertificateSubmitterRef(sidechainSettings, sc2scConfigurator, nodeViewHolderRef, secureEnclaveApiClient, params, mainchainNodeChannel)
   val certificateSignaturesManagerRef: ActorRef = CertificateSignaturesManagerRef(networkControllerRef, certificateSubmitterRef, params, sidechainSettings.sparkzSettings.network)
 
   // Init CSW manager

--- a/sdk/src/main/scala/com/horizen/SidechainBackup.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainBackup.scala
@@ -24,7 +24,7 @@ class SidechainBackup @Inject()
    @Named("Params") val params : NetworkParams
   ) extends ScorexLogging
   {
-    protected val sidechainBoxesCompanion: SidechainBoxesCompanion =  SidechainBoxesCompanion(customBoxSerializers)
+    protected val sidechainBoxesCompanion: SidechainBoxesCompanion =  SidechainBoxesCompanion(customBoxSerializers, true)
     protected val backupStorage = new BackupStorage(backUpStorage, sidechainBoxesCompanion)
 
 

--- a/sdk/src/main/scala/com/horizen/SidechainState.scala
+++ b/sdk/src/main/scala/com/horizen/SidechainState.scala
@@ -283,7 +283,7 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
           }
         })
         //crosschain messages validation: check max number of boxes per epoch
-        checkCrosschainMessagesBoxesAllowed(mod, allCrossMessagesBox.size)
+        checkCrosschainMessagesBoxesAllowed(mod.mainchainBlockReferencesData.size, allCrossMessagesBox.size)
       }
     }
 
@@ -336,9 +336,8 @@ class SidechainState private[horizen] (stateStorage: SidechainStateStorage,
       (params.maxWBsAllowed * (getWithdrawalEpochInfo.lastEpochIndex + numberOfMainchainBlockReferenceInBlock)) / (params.withdrawalEpochLength - 1))
   }
 
-  private def checkCrosschainMessagesBoxesAllowed(mod: SidechainBlock, boxInThisBlock: Int): Unit = {
+  private def checkCrosschainMessagesBoxesAllowed(mainchainBlockReferenceInBlock: Int, boxInThisBlock: Int): Unit = {
     val alreadyMined = getAlreadyMinedCrosschainMessagesInCurrentEpoch
-    val mainchainBlockReferenceInBlock = mod.mainchainBlockReferencesData.size
     val allowed = getAllowedCrosschainMessageBoxes(mainchainBlockReferenceInBlock, CryptoLibProvider.sc2scCircuitFunctions.getMaxMessagesPerCertificate)
     val total = alreadyMined + boxInThisBlock
     if (total > allowed) {

--- a/sdk/src/main/scala/com/horizen/account/AccountSidechainApp.scala
+++ b/sdk/src/main/scala/com/horizen/account/AccountSidechainApp.scala
@@ -124,6 +124,7 @@ class AccountSidechainApp @Inject()
     customMessageProcessors.asScala,
     sidechainSecretStorage,
     params,
+    sc2scConfigurator,
     timeProvider,
     genesisBlock
     ) // TO DO: why not to put genesisBlock as a part of params? REVIEW Params structure
@@ -145,7 +146,7 @@ class AccountSidechainApp @Inject()
   val sidechainBlockActorRef: ActorRef = SidechainBlockActorRef[PMOD, SidechainSyncInfo, AccountHistory]("AccountBlock", sidechainSettings, sidechainBlockForgerActorRef)
 
   // Init Certificate Submitter
-  val certificateSubmitterRef: ActorRef = AccountCertificateSubmitterRef(sidechainSettings, nodeViewHolderRef, secureEnclaveApiClient, params, mainchainNodeChannel)
+  val certificateSubmitterRef: ActorRef = AccountCertificateSubmitterRef(sidechainSettings, sc2scConfigurator, nodeViewHolderRef, secureEnclaveApiClient, params, mainchainNodeChannel)
   val certificateSignaturesManagerRef: ActorRef = CertificateSignaturesManagerRef(networkControllerRef, certificateSubmitterRef, params, sidechainSettings.sparkzSettings.network)
 
 

--- a/sdk/src/main/scala/com/horizen/account/events/AddCrossChainMessage.scala
+++ b/sdk/src/main/scala/com/horizen/account/events/AddCrossChainMessage.scala
@@ -1,0 +1,35 @@
+package com.horizen.account.events
+
+import com.horizen.account.event.annotation.{Indexed, Parameter}
+import org.web3j.abi.datatypes.{Address, DynamicBytes}
+import org.web3j.abi.datatypes.generated.{Bytes20, Uint256, Uint32}
+
+import scala.annotation.meta.getter
+
+
+case class AddCrossChainMessage(@(Parameter@getter)(1) @(Indexed@getter) sender: Address,
+                                @(Parameter@getter)(2) @(Indexed@getter) messageType: Uint32,
+                                @(Parameter@getter)(3) receiverSidechain: DynamicBytes,
+                                @(Parameter@getter)(4) receiver: DynamicBytes,
+                                @(Parameter@getter)(5) payload: DynamicBytes
+                               ) {
+}
+
+object AddCrossChainMessage {
+  def apply(sender: Address,
+            messageType: Int,
+            receiverSidechain: Array[Byte],
+            receiver: Array[Byte],
+            payload: Array[Byte]): AddCrossChainMessage = {
+    new AddCrossChainMessage(
+      sender,
+      new Uint32(messageType),
+      new DynamicBytes(receiverSidechain),
+      new DynamicBytes(receiver),
+      new DynamicBytes(payload)
+
+    )
+  }
+}
+
+

--- a/sdk/src/main/scala/com/horizen/account/sc2sc/AbstractCrossChainMessageProcessor.scala
+++ b/sdk/src/main/scala/com/horizen/account/sc2sc/AbstractCrossChainMessageProcessor.scala
@@ -1,0 +1,173 @@
+package com.horizen.account.sc2sc
+
+import java.math.BigInteger
+import java.util
+
+import com.google.common.primitives.{Bytes, Ints}
+import com.horizen.account.abi.{ABIDecoder, ABIEncodable, ABIListEncoder}
+import com.horizen.account.abi.ABIUtil.{METHOD_ID_LENGTH, getABIMethodId, getArgumentsFromData}
+import com.horizen.account.events.{AddCrossChainMessage}
+import com.horizen.account.state.{BaseAccountStateView, ExecutionRevertedException, FakeSmartContractMsgProcessor,  Message}
+import com.horizen.account.utils.ZenWeiConverter
+import com.horizen.utils.ZenCoinsUtils
+import com.horizen.cryptolibprovider.CryptoLibProvider
+import org.web3j.abi.TypeReference
+import org.web3j.abi.datatypes.{Address, StaticStruct, Type}
+import org.web3j.abi.datatypes.generated.Uint32
+import scorex.crypto.hash.Keccak256
+import scala.collection.JavaConverters.seqAsJavaListConverter
+import com.horizen.account.state.AccountStateView
+import com.horizen.account.state.FakeSmartContractMsgProcessor.NULL_HEX_STRING_32
+import com.horizen.params.NetworkParams
+import com.horizen.sc2sc.{CrossChainMessage, CrossChainMessageHash, CrossChainMessageImpl, CrossChainProtocolVersion}
+
+trait CrossChainMessageProvider {
+  private[horizen] def getCrossChainMesssages(epochNum: Int, view: BaseAccountStateView): Seq[CrossChainMessage]
+  private[horizen] def getCrossChainMessageHashEpoch(msgHash: CrossChainMessageHash, view: BaseAccountStateView): Option[Int]
+}
+
+abstract class AbstractCrossChainMessageProcessor(networkParams: NetworkParams)  extends FakeSmartContractMsgProcessor with CrossChainMessageProvider  {
+
+  val MaxCrosschainMessagesPerEpoch = CryptoLibProvider.sc2scCircuitFunctions.getMaxMessagesPerCertificate
+  val DustThresholdInWei: BigInteger = ZenWeiConverter.convertZenniesToWei(ZenCoinsUtils.getMinDustThreshold(ZenCoinsUtils.MC_DEFAULT_FEE_RATE))
+
+  protected def execGetListOfCrosschainMessages(msg: Message, view: BaseAccountStateView): Array[Byte] = {
+    if (msg.getValue.signum() != 0) {
+      throw new ExecutionRevertedException("Call value must be zero")
+    }
+
+    if (msg.getData.length != METHOD_ID_LENGTH + GetListOfCrosschainMessagesCmdInputDecoder.getABIDataParamsLengthInBytes)
+      throw new ExecutionRevertedException(s"Wrong message data field length: ${msg.getData.length}")
+    val inputParams = GetListOfCrosschainMessagesCmdInputDecoder.decode(getArgumentsFromData(msg.getData))
+    val list = getListOfCrossChainMessagesRecords(inputParams.epochNum, view)
+    CrosschainMessagesListEncoder.encode(list.asJava)
+  }
+
+  override def getCrossChainMesssages(epochNum: Int, view: BaseAccountStateView): Seq[CrossChainMessage] = {
+    getListOfCrossChainMessagesRecords(epochNum, view).map(msg => AbstractCrossChainMessageProcessor.buildCrosschainMessageFromAccount(msg, networkParams))
+  }
+
+  private[horizen] def getListOfCrossChainMessagesRecords(epochNum: Int, view: BaseAccountStateView): Seq[AccountCrossChainMessage] = {
+    val num: Int = getMessageEpochCounter(view, epochNum)
+
+    val list = (1 to num).map(index => {
+      val currentKey = getMessageKey(epochNum, index)
+      AccountCrossChainMessageSerializer.parseBytes(view.getAccountStorageBytes(contractAddress, currentKey))
+    })
+    list
+  }
+
+
+  override private[horizen] def getCrossChainMessageHashEpoch(messageHash: CrossChainMessageHash,  view: BaseAccountStateView) : Option[Int] =  {
+    val data = view.getAccountStorage(contractAddress, messageHash.bytes)
+    if (data.sameElements(NULL_HEX_STRING_32)){
+      Option.empty
+    } else {
+      Some(Ints.fromByteArray(data))
+    }
+  }
+
+
+  protected def addCrossChahinMessage(messageType: Int,
+                                      sender: Address,
+                                      receiverSidechain:  Array[Byte],
+                                      receiver: Array[Byte],
+                                      payload:  Array[Byte],
+                                      view: AccountStateView,
+                                      currentEpochNum: Int): Array[Byte] = {
+    val numOfReqs = getMessageEpochCounter(view, currentEpochNum)
+    if (numOfReqs >= MaxCrosschainMessagesPerEpoch) {
+      throw new ExecutionRevertedException("Reached maximum number of CrosschainMessages per epoch: request is invalid")
+    }
+
+    val request = AccountCrossChainMessage(messageType, sender.toUint.getValue.toByteArray, receiverSidechain, receiver, payload)
+    val messageHash = CryptoLibProvider.sc2scCircuitFunctions.getCrossChainMessageHash(AbstractCrossChainMessageProcessor.buildCrosschainMessageFromAccount(request, networkParams))
+
+    //check for duplicates in this and other message processor, in any epoch
+    if (view.getCrossChainMessageHashEpoch(messageHash).nonEmpty){
+      throw new ExecutionRevertedException("Dupicate crosschain message")
+    }
+
+    val nextNum: Int = numOfReqs + 1
+    setMessageEpochCounter(view, currentEpochNum, nextNum)
+
+
+    val requestInBytes = request.bytes
+    val messageKey = getMessageKey(currentEpochNum, nextNum)
+    view.updateAccountStorageBytes(contractAddress, messageKey, requestInBytes)
+    //we store also the mapping [message hash, epochnumber]
+    view.updateAccountStorageBytes(contractAddress, messageHash.bytes, Ints.toByteArray(currentEpochNum))
+
+    val event = AddCrossChainMessage(sender, messageType, receiverSidechain, receiver, payload)
+    val evmLog = getEvmLog(event)
+    view.addLog(evmLog)
+    request.encode
+  }
+
+  private[horizen]  def getMessageEpochCounter(view: BaseAccountStateView, epochNum: Int) = {
+    val key = getMessageEpochCounterKey(epochNum)
+    val counterInBytesPadded = view.getAccountStorage(contractAddress, key)
+    val counterInBytes = counterInBytesPadded.drop(counterInBytesPadded.length - Ints.BYTES)
+    val num = Ints.fromByteArray(counterInBytes)
+    num
+  }
+
+  private[horizen] def setMessageEpochCounter(view: BaseAccountStateView, currentEpochNum: Int, nextNumOfCrossChainMessages: Int): Unit = {
+    val nextNumOfCrossChainMessagesBytes = Ints.toByteArray(nextNumOfCrossChainMessages)
+    val paddedNextNumOfCrossChainMessages = Bytes.concat(new Array[Byte](32 - nextNumOfCrossChainMessagesBytes.length), nextNumOfCrossChainMessagesBytes)
+    val wrCounterKey = getMessageEpochCounterKey(currentEpochNum)
+    view.updateAccountStorage(contractAddress, wrCounterKey, paddedNextNumOfCrossChainMessages)
+  }
+
+  private[horizen] def calculateKey(keySeed: Array[Byte]): Array[Byte] = {
+    Keccak256.hash(keySeed)
+  }
+
+  private[horizen] def getMessageEpochCounterKey(withdrawalEpoch: Int): Array[Byte] = {
+    calculateKey(Bytes.concat("crossChainMsgEpochCounter".getBytes, Ints.toByteArray(withdrawalEpoch)))
+  }
+  private[horizen] def getMessageKey(withdrawalEpoch: Int, counter: Int): Array[Byte] = {
+    calculateKey(Bytes.concat("crossChainMsg".getBytes, Ints.toByteArray(withdrawalEpoch), Ints.toByteArray(counter)))
+  }
+}
+
+object AbstractCrossChainMessageProcessor {
+  private[horizen] def buildCrosschainMessageFromAccount(data: AccountCrossChainMessage, params: NetworkParams): CrossChainMessage = {
+    new CrossChainMessageImpl(
+      CrossChainProtocolVersion.VERSION_1,
+      data.messageType,
+      params.sidechainId,
+      data.sender,
+      data.receiverSidechain,
+      data.receiver,
+      data.payload
+    )
+  }
+}
+
+object GetListOfCrosschainMessagesCmdInputDecoder extends ABIDecoder[GetListOfCrosschainMessagesInputCmd] {
+  override def getListOfABIParamTypes: util.List[TypeReference[Type[_]]] = org.web3j.abi.Utils.convert(util.Arrays.asList(new TypeReference[Uint32]() {}))
+
+  override def createType(listOfParams: util.List[Type[_]]): GetListOfCrosschainMessagesInputCmd = {
+    GetListOfCrosschainMessagesInputCmd(listOfParams.get(0).asInstanceOf[Uint32].getValue.intValueExact())
+  }
+
+}
+
+case class GetListOfCrosschainMessagesInputCmd(epochNum: Int) extends ABIEncodable[StaticStruct] {
+  override def asABIType(): StaticStruct = {
+    new StaticStruct(
+      new Uint32(epochNum)
+    )
+  }
+}
+
+object CrosschainMessagesListEncoder extends ABIListEncoder[AccountCrossChainMessage, StaticStruct]{
+  override def getAbiClass: Class[StaticStruct] = classOf[StaticStruct]
+}
+
+abstract class CrossChainMessageProcessorConstants {
+  val GetListOfCrosschainMessagesCmdSig: String = getABIMethodId("getCrossChainMessages(uint32)")
+  val contractAddress: Array[Byte]
+  val contractCode: Array[Byte]
+}

--- a/sdk/src/main/scala/com/horizen/account/sc2sc/AccountCrossChainMessage.scala
+++ b/sdk/src/main/scala/com/horizen/account/sc2sc/AccountCrossChainMessage.scala
@@ -1,0 +1,60 @@
+package com.horizen.account.sc2sc
+
+import com.horizen.account.abi.ABIEncodable
+import org.web3j.abi.datatypes.{DynamicBytes, StaticStruct}
+import org.web3j.abi.datatypes.generated.Uint32
+import scorex.util.serialization.{Reader, Writer}
+import sparkz.core.serialization.{BytesSerializable, SparkzSerializer}
+
+case class AccountCrossChainMessage
+(
+  messageType: Int,
+  sender: Array[Byte], //we keep it generic because the format is dependant on the sidechain type
+  receiverSidechain:  Array[Byte],
+  receiver: Array[Byte], //we keep it generic because  the format is dependant on the sidechain type
+  payload:  Array[Byte]
+) extends BytesSerializable with ABIEncodable[StaticStruct] {
+
+  override type M = AccountCrossChainMessage
+
+  override def serializer: SparkzSerializer[AccountCrossChainMessage] = AccountCrossChainMessageSerializer
+
+  private[horizen] def asABIType(): StaticStruct = {
+    new StaticStruct(
+      new Uint32(messageType),
+      new DynamicBytes(sender),
+      new DynamicBytes(receiverSidechain),
+      new DynamicBytes(receiver),
+      new DynamicBytes(payload)
+    )
+  }
+}
+
+object AccountCrossChainMessageSerializer extends SparkzSerializer[AccountCrossChainMessage] {
+  override def serialize(obj: AccountCrossChainMessage, writer: Writer): Unit = {
+    writer.putUInt(obj.messageType)
+    writeBytes(writer, obj.sender)
+    writeBytes(writer, obj.receiverSidechain)
+    writeBytes(writer, obj.receiver)
+    writeBytes(writer, obj.payload)
+  }
+
+  override def parse(reader: Reader): AccountCrossChainMessage = {
+    val messageType = reader.getUInt().toInt
+    val sender = parseNextBytes(reader)
+    val receiverSidechain = parseNextBytes(reader)
+    val receiver = parseNextBytes(reader)
+    val payload = parseNextBytes(reader)
+    AccountCrossChainMessage(messageType, sender, receiverSidechain, receiver, payload)
+  }
+
+  private def writeBytes(writer: Writer, value: Array[Byte]): Unit = {
+    writer.putUInt(value.length)
+    writer.putBytes(value)
+  }
+
+  private def parseNextBytes(reader: Reader): Array[Byte] = {
+    val valueByteArrayLength = reader.getUInt().toInt
+    reader.getBytes(valueByteArrayLength)
+  }
+}

--- a/sdk/src/main/scala/com/horizen/account/state/AccountState.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/AccountState.scala
@@ -3,7 +3,7 @@ package com.horizen.account.state
 import com.horizen.SidechainTypes
 import com.horizen.account.block.AccountBlock
 import com.horizen.account.node.NodeAccountState
-import com.horizen.account.receipt.EthereumReceipt
+import com.horizen.account.receipt.{Bloom, EthereumReceipt}
 import com.horizen.account.storage.AccountStateMetadataStorage
 import com.horizen.account.transaction.EthereumTransaction
 import com.horizen.account.utils.{AccountBlockFeeInfo, AccountFeePaymentsUtils, AccountPayment}
@@ -11,7 +11,7 @@ import com.horizen.account.validation.InvalidTransactionChainIdException
 import com.horizen.account.receipt.Bloom
 import com.horizen.account.utils.FeeUtils
 import com.horizen.account.utils.Account.generateContractAddress
-import com.horizen.block.WithdrawalEpochCertificate
+import com.horizen.block.{SidechainBlockBase, WithdrawalEpochCertificate}
 import com.horizen.certificatesubmitter.keys.{CertifiersKeys, KeyRotationProof}
 import com.horizen.certnative.BackwardTransfer
 import com.horizen.consensus.{ConsensusEpochInfo, ConsensusEpochNumber, ForgingStakeInfo, intToConsensusEpochNumber}
@@ -27,12 +27,17 @@ import sparkz.core.utils.NetworkTimeProvider
 import scorex.util.bytesToId
 import java.math.BigInteger
 import java.util
+
+import com.horizen.account.sc2sc.AccountCrossChainMessage
+import com.horizen.sc2sc.{CrossChainMessage, CrossChainMessageHash, CrossChainMessageImpl, CrossChainProtocolVersion, Sc2ScConfigurator}
+
 import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Success, Try}
 
 class AccountState(
     val params: NetworkParams,
+    val sc2scConfig : Sc2ScConfigurator,
     timeProvider: NetworkTimeProvider,
     override val version: VersionTag,
     stateMetadataStorage: AccountStateMetadataStorage,
@@ -219,6 +224,7 @@ class AccountState(
 
       new AccountState(
         params,
+        sc2scConfig,
         timeProvider,
         idToVersion(mod.id),
         stateMetadataStorage,
@@ -292,6 +298,10 @@ class AccountState(
           )
         }
     }
+    //sc2sc validation
+    if (sc2scConfig.canSendMessages){
+      validateTopQualityCertificateForSc2Sc(topQualityCertificate, certReferencedEpochNumber, params.sidechainCreationVersion)
+    }
   }
 
   // Note: Equal to SidechainState.isSwitchingConsensusEpoch
@@ -305,7 +315,7 @@ class AccountState(
   override def rollbackTo(version: VersionTag): Try[AccountState] = Try {
     require(version != null, "Version to rollback to must be NOT NULL.")
     val newMetaState = stateMetadataStorage.rollback(new ByteArrayWrapper(versionToBytes(version))).get
-    new AccountState(params, timeProvider, version, newMetaState, stateDbStorage, messageProcessors)
+    new AccountState(params, sc2scConfig, timeProvider, version, newMetaState, stateDbStorage, messageProcessors)
   } recoverWith { case exception =>
     log.error("Exception was thrown during rollback.", exception)
     Failure(exception)
@@ -334,6 +344,17 @@ class AccountState(
   override def backwardTransfers(withdrawalEpoch: Int): Seq[BackwardTransfer] =
     using(getView)(_.getWithdrawalRequests(withdrawalEpoch))
       .map(wr => new BackwardTransfer(wr.proposition.bytes(), wr.valueInZennies))
+
+  override def getCrossChainMessages(withdrawalEpoch: Int): Seq[CrossChainMessage] = {
+    if (sc2scConfig.canSendMessages) using(getView)(_.getCrossChainMessages(withdrawalEpoch)) else Seq()
+  }
+
+  override def getCrossChainMessageHashEpoch(messageHash: CrossChainMessageHash): Option[Int] =
+    if (sc2scConfig.canSendMessages) using(getView)(_.getCrossChainMessageHashEpoch(messageHash)) else None
+
+  def getTopCertificateMainchainHash(withdrawalEpoch: Int): Option[Array[Byte]] =
+    using(getView)(_.getTopCertificateMainchainHash(withdrawalEpoch))
+
 
   override def keyRotationProof(withdrawalEpoch: Int, indexOfSigner: Int, keyType: Int): Option[KeyRotationProof] = {
     using(getView)(_.keyRotationProof(withdrawalEpoch, indexOfSigner, keyType))
@@ -502,6 +523,7 @@ object AccountState extends ScorexLogging {
       stateDbStorage: Database,
       messageProcessors: Seq[MessageProcessor],
       params: NetworkParams,
+      sc2ScConfigurator: Sc2ScConfigurator,
       timeProvider: NetworkTimeProvider
   ): Option[AccountState] = {
 
@@ -511,6 +533,7 @@ object AccountState extends ScorexLogging {
       Some(
         new AccountState(
           params,
+          sc2ScConfigurator,
           timeProvider,
           bytesToVersion(stateMetadataStorage.lastVersionId.get.data),
           stateMetadataStorage,
@@ -526,6 +549,7 @@ object AccountState extends ScorexLogging {
       stateDbStorage: Database,
       messageProcessors: Seq[MessageProcessor],
       params: NetworkParams,
+      sc2ScConfigurator: Sc2ScConfigurator,
       timeProvider: NetworkTimeProvider,
       genesisBlock: AccountBlock
   ): Try[AccountState] = Try {
@@ -534,6 +558,7 @@ object AccountState extends ScorexLogging {
 
     new AccountState(
       params,
+      sc2ScConfigurator,
       timeProvider,
       idToVersion(genesisBlock.parentId),
       stateMetadataStorage,

--- a/sdk/src/main/scala/com/horizen/account/state/AccountStateReader.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/AccountStateReader.scala
@@ -3,34 +3,50 @@ package com.horizen.account.state
 import com.horizen.certificatesubmitter.keys.{CertifiersKeys, KeyRotationProof}
 import com.horizen.evm.ResourceHandle
 import com.horizen.evm.interop.EvmLog
-
 import java.math.BigInteger
+import com.horizen.sc2sc.{CrossChainMessage, CrossChainMessageHash}
+
 
 trait AccountStateReader {
   def getStateDbHandle: ResourceHandle
+
   def getAccountStorage(address: Array[Byte], key: Array[Byte]): Array[Byte]
+
   def getAccountStorageBytes(address: Array[Byte], key: Array[Byte]): Array[Byte]
 
   def accountExists(address: Array[Byte]): Boolean
+
   def isEoaAccount(address: Array[Byte]): Boolean
+
   def isSmartContractAccount(address: Array[Byte]): Boolean
 
   def getNonce(address: Array[Byte]): BigInteger
+
   def getBalance(address: Array[Byte]): BigInteger
+
   def getCodeHash(address: Array[Byte]): Array[Byte]
+
   def getCode(address: Array[Byte]): Array[Byte]
 
   def getWithdrawalRequests(withdrawalEpoch: Int): Seq[WithdrawalRequest]
 
   def getListOfForgersStakes: Seq[AccountForgingStakeInfo]
+
   def getForgerStakeData(stakeId: String): Option[ForgerStakeData]
+
   def isForgingOpen: Boolean
+
   def getAllowedForgerList: Seq[Int]
 
   def getLogs(txHash: Array[Byte]): Array[EvmLog]
+
   def getIntermediateRoot: Array[Byte]
 
   def certifiersKeys(withdrawalEpoch: Int): Option[CertifiersKeys]
+
   def keyRotationProof(withdrawalEpoch: Int, indexOfSigner: Int, keyType: Int): Option[KeyRotationProof]
 
+  def getCrossChainMessages(withdrawalEpoch: Int): Seq[CrossChainMessage]
+
+  def getCrossChainMessageHashEpoch(msgHash: CrossChainMessageHash): Option[Int]
 }

--- a/sdk/src/main/scala/com/horizen/account/state/AccountStateViewGasTracked.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/AccountStateViewGasTracked.scala
@@ -3,8 +3,8 @@ package com.horizen.account.state
 import com.horizen.certificatesubmitter.keys.{CertifiersKeys, KeyRotationProof}
 import com.horizen.evm.ResourceHandle
 import com.horizen.evm.interop.EvmLog
-
 import java.math.BigInteger
+import com.horizen.sc2sc.{CrossChainMessageHash, CrossChainMessage}
 
 /**
  * Wrapper for AccountStateView to help with tracking gas consumption.
@@ -129,4 +129,8 @@ class AccountStateViewGasTracked(view: BaseAccountStateView, gas: GasPool) exten
   override def certifiersKeys(withdrawalEpoch: Int): Option[CertifiersKeys] = view.certifiersKeys(withdrawalEpoch)
 
   override def keyRotationProof(withdrawalEpoch: Int, indexOfSigner: Int, keyType: Int): Option[KeyRotationProof] = view.keyRotationProof(withdrawalEpoch, indexOfSigner, keyType)
+
+  override def getCrossChainMessages(withdrawalEpoch: Int): Seq[CrossChainMessage] = view.getCrossChainMessages(withdrawalEpoch)
+
+  override def getCrossChainMessageHashEpoch(msgHash: CrossChainMessageHash): Option[Int] = view.getCrossChainMessageHashEpoch(msgHash)
 }

--- a/sdk/src/main/scala/com/horizen/account/storage/AccountStateMetadataStorage.scala
+++ b/sdk/src/main/scala/com/horizen/account/storage/AccountStateMetadataStorage.scala
@@ -53,5 +53,7 @@ class AccountStateMetadataStorage(storage: Storage)
   override def getAccountStateRoot: Array[Byte] = getView.getAccountStateRoot
 
   override def getTransactionReceipt(txHash: Array[Byte]): Option[EthereumReceipt] = getView.getTransactionReceipt(txHash)
+  
+  override def getTopCertificateMainchainHash(referencedWithdrawalEpoch: Int): Option[Array[Byte]] = getView.getTopCertificateMainchainHash(referencedWithdrawalEpoch)
 
 }

--- a/sdk/src/main/scala/com/horizen/account/storage/AccountStateMetadataStorageReader.scala
+++ b/sdk/src/main/scala/com/horizen/account/storage/AccountStateMetadataStorageReader.scala
@@ -16,6 +16,8 @@ trait AccountStateMetadataStorageReader {
 
   def getTopQualityCertificate(referencedWithdrawalEpoch: Int): Option[WithdrawalEpochCertificate]
 
+  def getTopCertificateMainchainHash(referencedWithdrawalEpoch: Int): Option[Array[Byte]]
+
   def lastCertificateReferencedEpoch: Option[Int]
 
   def lastCertificateSidechainBlockId: Option[ModifierId]

--- a/sdk/src/main/scala/com/horizen/account/storage/AccountStateMetadataStorageView.scala
+++ b/sdk/src/main/scala/com/horizen/account/storage/AccountStateMetadataStorageView.scala
@@ -12,7 +12,6 @@ import com.horizen.utils.{ByteArrayWrapper, WithdrawalEpochInfo, WithdrawalEpoch
 import scorex.crypto.hash.Blake2b256
 import scorex.util.{ModifierId, ScorexLogging, bytesToId, idToBytes}
 import sparkz.core.{VersionTag, versionToBytes}
-
 import java.math.BigInteger
 import java.util.{ArrayList => JArrayList}
 import scala.collection.mutable.ListBuffer
@@ -31,6 +30,10 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
   private[horizen] val accountStateRootKey = calculateKey("accountStateRoot".getBytes)
   private[horizen] val baseFeeKey = calculateKey("baseFee".getBytes)
 
+  private[horizen] def topCertificateMainchainHasheKey(referencedWithdrawalEpoch: Int): ByteArrayWrapper = {
+    calculateKey(Bytes.concat("topCertificateMainchainHash".getBytes, Ints.toByteArray(referencedWithdrawalEpoch)))
+  }
+
   private val undefinedBlockFeeInfoCounter: Int = -1
 
   private[horizen] var hasCeasedOpt: Option[Boolean] = None
@@ -43,10 +46,15 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
   private[horizen] var consensusEpochOpt: Option[ConsensusEpochNumber] = None
   private[horizen] var accountStateRootOpt: Option[Array[Byte]] = None
   private[horizen] var receiptsOpt: Option[Seq[EthereumReceipt]] = None
+  private[horizen] var topCertificateMainchainHashes: Map[Int, Array[Byte]] = Map()
   //Contains the base fee to be used when forging the next block
   private[horizen] var nextBaseFeeOpt: Option[BigInteger] = None
 
   // all getters same as in StateMetadataStorage, but looking first in the cached/dirty entries in memory
+
+  def addTopCertificateMainchainHash(hash: Int, mainchainHash: Array[Byte]) = {
+    topCertificateMainchainHashes = topCertificateMainchainHashes + (hash -> mainchainHash)
+  }
 
   override def getWithdrawalEpochInfo: WithdrawalEpochInfo = {
     withdrawalEpochInfoOpt.orElse(getWithdrawalEpochInfoFromStorage).getOrElse(WithdrawalEpochInfo(0, 0))
@@ -90,7 +98,6 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
     blockFees
   }
 
-
   override def getTopQualityCertificate(referencedWithdrawalEpoch: Int): Option[WithdrawalEpochCertificate] = {
     topQualityCertificateOpt match {
       case Some(certificate) if certificate.epochNumber == referencedWithdrawalEpoch => topQualityCertificateOpt
@@ -100,6 +107,10 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
 
   override def lastCertificateReferencedEpoch: Option[Int] = {
     lastCertificateReferencedEpochOpt.orElse(lastCertificateReferencedEpochFromStorage)
+  }
+
+  override def getTopCertificateMainchainHash(referencedWithdrawalEpoch: Int): Option[Array[Byte]] = {
+    topCertificateMainchainHashes.get(referencedWithdrawalEpoch).orElse(getTopCertificateMainchainHashesFromStorage(referencedWithdrawalEpoch))
   }
 
   private[horizen] def lastCertificateReferencedEpochFromStorage: Option[Int] = {
@@ -115,6 +126,7 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
         }
       }
   }
+
 
   override def lastCertificateSidechainBlockId: Option[ModifierId] = {
     lastCertificateSidechainBlockIdOpt.orElse(lastCertificateSidechainBlockIdFromStorage)
@@ -134,7 +146,7 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
       }
   }
 
-  private[horizen] def getTopQualityCertificateFromStorage(referencedWithdrawalEpoch: Int): Option[WithdrawalEpochCertificate] = {
+    private[horizen] def getTopQualityCertificateFromStorage(referencedWithdrawalEpoch: Int): Option[WithdrawalEpochCertificate] = {
     storage.get(getTopQualityCertificateKey(referencedWithdrawalEpoch)).asScala match {
       case Some(baw) =>
         WithdrawalEpochCertificateSerializer.parseBytesTry(baw.data) match {
@@ -143,6 +155,13 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
             log.error("Error while withdrawal epoch certificate information parsing.", exception)
             Option.empty
         }
+      case _ => Option.empty
+    }
+  }
+
+  private[horizen] def getTopCertificateMainchainHashesFromStorage(referencedWithdrawalEpoch: Int): Option[Array[Byte]] = {
+    storage.get(topCertificateMainchainHasheKey(referencedWithdrawalEpoch)).asScala  match {
+      case Some(baw) => Some(baw.data)
       case _ => Option.empty
     }
   }
@@ -206,7 +225,6 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
 
   def updateTopQualityCertificate(topQualityCertificate: WithdrawalEpochCertificate): Unit =
     topQualityCertificateOpt = Some(topQualityCertificate)
-
   def updateLastCertificateReferencedEpoch(lastCertificateReferencedEpoch: Int): Unit =
     lastCertificateReferencedEpochOpt = Some(lastCertificateReferencedEpoch)
 
@@ -263,6 +281,7 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
     hasCeasedOpt = None
     withdrawalEpochInfoOpt = None
     topQualityCertificateOpt = None
+    topCertificateMainchainHashes = Map()
     lastCertificateReferencedEpochOpt = None
     lastCertificateSidechainBlockIdOpt = None
     blockFeeInfoOpt = None
@@ -290,6 +309,7 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
       updateList.add(new JPair(getTopQualityCertificateKey(certificate.epochNumber),
         WithdrawalEpochCertificateSerializer.toBytes(certificate)))
     })
+
 
     // Store the last certificate referenced epoch if present
     lastCertificateReferencedEpochOpt.foreach(epoch => {
@@ -366,6 +386,10 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
     })
 
     nextBaseFeeOpt.foreach(baseFee => updateList.add(new JPair(baseFeeKey, new ByteArrayWrapper(baseFee.toByteArray))))
+
+    topCertificateMainchainHashes.foreach(ele =>
+      updateList.add(new JPair(topCertificateMainchainHasheKey(ele._1), ele._2))
+    )
 
     storage.update(version, updateList, removeList)
 

--- a/sdk/src/main/scala/com/horizen/api/http/Sc2scApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/Sc2scApiRoute.scala
@@ -46,7 +46,7 @@ case class Sc2scApiRoute(override val settings: RESTApiSettings,
 
 
   /**
-    * Return a redeem message from  a previouslt posted CrossChainMessage
+    * Return a redeem message from  a previously posted CrossChainMessage
     */
   def createRedeemMessage: Route = (post & path("createRedeemMessage")) {
     withAuth {

--- a/sdk/src/main/scala/com/horizen/api/http/Sc2scApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/api/http/Sc2scApiRoute.scala
@@ -1,0 +1,82 @@
+package com.horizen.api.http
+
+import java.util.{Optional => JOptional}
+import akka.actor.{ActorRef, ActorRefFactory}
+import akka.http.scaladsl.server.Route
+import com.fasterxml.jackson.annotation.JsonView
+import com.horizen.SidechainTypes
+import com.horizen.api.http.JacksonSupport._
+import com.horizen.api.http.Sc2scApiRouteRestScheme.{ReqCreateRedeemMessage, RespCreateRedeemMessage}
+import com.horizen.block.{SidechainBlock, SidechainBlockHeader}
+import com.horizen.chain.SidechainFeePaymentsInfo
+import com.horizen.node._
+import com.horizen.sc2sc.{CrossChainMessage, CrossChainRedeemMessage}
+import com.horizen.serialization.Views
+import sparkz.core.settings.RESTApiSettings
+import scala.concurrent.Await
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success}
+import com.horizen.sc2sc.Sc2scProver.ReceivableMessages.BuildRedeemMessage
+import akka.pattern.ask
+import com.horizen.api.http.Sc2scApiErrorResponse.GenericSc2ScApiError
+
+case class Sc2scApiRoute(override val settings: RESTApiSettings,
+                         sidechainNodeViewHolderRef: ActorRef,
+                         sc2scProver: ActorRef
+                         )
+                        (implicit val context: ActorRefFactory, override val ec: ExecutionContext)
+  extends SidechainApiRoute[
+  SidechainTypes#SCBT,
+  SidechainBlockHeader,
+  SidechainBlock,
+  SidechainFeePaymentsInfo,
+  NodeHistory,
+  NodeState,
+  NodeWallet,
+  NodeMemoryPool,
+  SidechainNodeView]
+{
+  override implicit val tag: ClassTag[SidechainNodeView] = ClassTag[SidechainNodeView](classOf[SidechainNodeView])
+
+  override val route: Route = pathPrefix("sc2sc") {
+    createRedeemMessage
+  }
+
+
+  /**
+    * Return a redeem message from  a previouslt posted CrossChainMessage
+    */
+  def createRedeemMessage: Route = (post & path("createRedeemMessage")) {
+    withAuth {
+      entity(as[ReqCreateRedeemMessage]) { body =>
+        val future = sc2scProver ? BuildRedeemMessage(body.message)
+        Await.result(future, timeout.duration).asInstanceOf[Try[CrossChainRedeemMessage]] match {
+          case Success(ret) => {
+           ApiResponseUtil.toResponse(RespCreateRedeemMessage(ret))
+          }
+          case Failure(e) =>
+            ApiResponseUtil.toResponse(GenericSc2ScApiError("Failed to create redeem message", JOptional.of(e)))
+        }
+      }
+    }
+  }
+}
+
+object Sc2scApiRouteRestScheme {
+  @JsonView(Array(classOf[Views.Default]))
+  private[api] case class ReqCreateRedeemMessage(message: CrossChainMessage)
+
+  @JsonView(Array(classOf[Views.Default]))
+  private[api] case class RespCreateRedeemMessage(message: CrossChainRedeemMessage) extends SuccessResponse
+}
+
+object Sc2scApiErrorResponse {
+  case class GenericSc2ScApiError(description: String, exception: JOptional[Throwable]) extends ErrorResponse {
+    override val code: String = "0700"
+  }
+}
+
+
+

--- a/sdk/src/main/scala/com/horizen/block/SidechainBlockBase.scala
+++ b/sdk/src/main/scala/com/horizen/block/SidechainBlockBase.scala
@@ -1,6 +1,8 @@
 package com.horizen.block
 
 
+import java.util
+
 import com.horizen.params.NetworkParams
 import com.horizen.utils.{MerkleTree, Utils}
 import com.horizen.validation.{InconsistentSidechainBlockDataException, InvalidSidechainBlockDataException}
@@ -211,4 +213,9 @@ object SidechainBlockBase {
     else
       Utils.ZEROS_HASH
   }
+
+  def getTopQualityCertsWithMainChainHash(mainchainBlockReferencesData: Seq[MainchainBlockReferenceData]): Seq[(WithdrawalEpochCertificate,Array[Byte])] = {
+    mainchainBlockReferencesData.filter(_.topQualityCertificate.nonEmpty).map( brefData =>  (brefData.topQualityCertificate.get, brefData.headerHash))
+  }
+
 }

--- a/sdk/src/main/scala/com/horizen/certificatesubmitter/dataproof/CertificateData.scala
+++ b/sdk/src/main/scala/com/horizen/certificatesubmitter/dataproof/CertificateData.scala
@@ -1,14 +1,15 @@
 package com.horizen.certificatesubmitter.dataproof
 
-import com.horizen.box.WithdrawalRequestBox
 import com.horizen.certnative.BackwardTransfer
 import com.horizen.proof.SchnorrProof
 import com.horizen.proposition.SchnorrProposition
+import com.horizen.sc2sc.Sc2ScDataForCertificate
 
 abstract class CertificateData(val referencedEpochNumber: Int,
                                val sidechainId: Array[Byte],
                                val backwardTransfers: Seq[BackwardTransfer],
                                val endEpochCumCommTreeHash: Array[Byte],
+                               val sc2ScDataForCertificate: Option[Sc2ScDataForCertificate],
                                val btrFee: Long,
                                val ftMinAmount: Long,
                                val schnorrKeyPairs: Seq[(SchnorrProposition, Option[SchnorrProof])],

--- a/sdk/src/main/scala/com/horizen/certificatesubmitter/dataproof/CertificateDataWithKeyRotation.scala
+++ b/sdk/src/main/scala/com/horizen/certificatesubmitter/dataproof/CertificateDataWithKeyRotation.scala
@@ -1,12 +1,12 @@
 package com.horizen.certificatesubmitter.dataproof
 
 import com.horizen.block.WithdrawalEpochCertificate
-import com.horizen.box.WithdrawalRequestBox
 import com.horizen.certificatesubmitter.keys.SchnorrKeysSignatures
 import com.horizen.certnative.BackwardTransfer
 import com.horizen.cryptolibprovider.CryptoLibProvider
 import com.horizen.proof.SchnorrProof
 import com.horizen.proposition.SchnorrProposition
+import com.horizen.sc2sc.Sc2ScDataForCertificate
 import com.horizen.utils.BytesUtils
 
 import scala.collection.JavaConverters._
@@ -16,6 +16,7 @@ case class CertificateDataWithKeyRotation(override val referencedEpochNumber: In
                                           override val sidechainId: Array[Byte],
                                           override val backwardTransfers: Seq[BackwardTransfer],
                                           override val endEpochCumCommTreeHash: Array[Byte],
+                                          override val sc2ScDataForCertificate: Option[Sc2ScDataForCertificate],
                                           override val btrFee: Long,
                                           override val ftMinAmount: Long,
                                           override val schnorrKeyPairs: Seq[(SchnorrProposition, Option[SchnorrProof])],
@@ -23,11 +24,11 @@ case class CertificateDataWithKeyRotation(override val referencedEpochNumber: In
                                           previousCertificateOption: Option[WithdrawalEpochCertificate],
                                           genesisKeysRootHash: Array[Byte]
                                          )
-  extends CertificateData(referencedEpochNumber, sidechainId, backwardTransfers, endEpochCumCommTreeHash, btrFee, ftMinAmount, schnorrKeyPairs) {
+  extends CertificateData(referencedEpochNumber, sidechainId, backwardTransfers, endEpochCumCommTreeHash, sc2ScDataForCertificate, btrFee, ftMinAmount, schnorrKeyPairs) {
 
   override def getCustomFields: Seq[Array[Byte]] = {
+    //TODO: use sc2ScDataForCertificate to add custom fields for sc2sc
     val keysRootHash: Array[Byte] = CryptoLibProvider.thresholdSignatureCircuitWithKeyRotation.getSchnorrKeysHash(schnorrKeysSignatures)
-
     CryptoLibProvider.thresholdSignatureCircuitWithKeyRotation.getCertificateCustomFields(keysRootHash).asScala
   }
 

--- a/sdk/src/main/scala/com/horizen/certificatesubmitter/dataproof/CertificateDataWithoutKeyRotation.scala
+++ b/sdk/src/main/scala/com/horizen/certificatesubmitter/dataproof/CertificateDataWithoutKeyRotation.scala
@@ -4,6 +4,7 @@ import com.horizen.certnative.BackwardTransfer
 import com.horizen.cryptolibprovider.CryptoLibProvider
 import com.horizen.proof.SchnorrProof
 import com.horizen.proposition.SchnorrProposition
+import com.horizen.sc2sc.Sc2ScDataForCertificate
 import com.horizen.utils.BytesUtils
 
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
@@ -13,13 +14,15 @@ case class CertificateDataWithoutKeyRotation(override val referencedEpochNumber:
                                              override val sidechainId: Array[Byte],
                                              override val backwardTransfers: Seq[BackwardTransfer],
                                              override val endEpochCumCommTreeHash: Array[Byte],
+                                             override val sc2ScDataForCertificate: Option[Sc2ScDataForCertificate],
                                              override val btrFee: Long,
                                              override val ftMinAmount: Long,
                                              override val schnorrKeyPairs: Seq[(SchnorrProposition, Option[SchnorrProof])],
                                              utxoMerkleTreeRoot: Option[Array[Byte]])
-  extends CertificateData (referencedEpochNumber, sidechainId, backwardTransfers, endEpochCumCommTreeHash, btrFee, ftMinAmount, schnorrKeyPairs) {
+  extends CertificateData (referencedEpochNumber, sidechainId, backwardTransfers, endEpochCumCommTreeHash, sc2ScDataForCertificate, btrFee, ftMinAmount, schnorrKeyPairs) {
 
   override def getCustomFields: Seq[Array[Byte]] = {
+    //TODO: use sc2ScDataForCertificate to add custom fields for sc2sc
     CryptoLibProvider.sigProofThresholdCircuitFunctions.getCertificateCustomFields(utxoMerkleTreeRoot.asJava).toSeq
   }
 

--- a/sdk/src/main/scala/com/horizen/certificatesubmitter/strategies/CircuitStrategy.scala
+++ b/sdk/src/main/scala/com/horizen/certificatesubmitter/strategies/CircuitStrategy.scala
@@ -8,6 +8,7 @@ import com.horizen.chain.{MainchainHeaderInfo, SidechainBlockInfo}
 import com.horizen.consensus.ConsensusEpochNumber
 import com.horizen.fork.ForkManager
 import com.horizen.params.NetworkParams
+import com.horizen.sc2sc.{Sc2ScConfigurator, Sc2ScUtils}
 import com.horizen.transaction.Transaction
 import com.horizen.utils.{BytesUtils, TimeToEpochUtils}
 import scorex.util.ScorexLogging
@@ -21,8 +22,8 @@ abstract class CircuitStrategy[
   PM <: SidechainBlockBase[TX, H],
   HIS <: AbstractHistory[TX, H, PM, _, _, _],
   MS <: AbstractState[TX, H, PM, MS],
-  T <: CertificateData](settings: SidechainSettings, params: NetworkParams) extends ScorexLogging{
-  
+  T <: CertificateData](settings: SidechainSettings, sc2scConfig: Sc2ScConfigurator, params: NetworkParams) extends ScorexLogging   with Sc2ScUtils[TX, H, PM, MS, HIS]{
+
   def generateProof(certificateData: T, provingFileAbsolutePath: String): com.horizen.utils.Pair[Array[Byte], java.lang.Long]
 
   def buildCertificateData(history: HIS, state: MS, status: SignaturesStatus): T

--- a/sdk/src/main/scala/com/horizen/companion/SidechainBoxesCompanion.scala
+++ b/sdk/src/main/scala/com/horizen/companion/SidechainBoxesCompanion.scala
@@ -15,6 +15,7 @@ case class SidechainBoxesCompanion(customBoxSerializers: JHashMap[JByte, BoxSeri
         put(ZenBoxId.id(), ZenBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
         put(WithdrawalRequestBoxId.id(), WithdrawalRequestBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
         put(ForgerBoxId.id(), ForgerBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
+        put(CrossChainMessageBoxId.id(), CrossChainMessageBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
     }},
     customBoxSerializers)
 

--- a/sdk/src/main/scala/com/horizen/companion/SidechainBoxesCompanion.scala
+++ b/sdk/src/main/scala/com/horizen/companion/SidechainBoxesCompanion.scala
@@ -9,13 +9,16 @@ import com.horizen.box._
 import com.horizen.utils.DynamicTypedSerializer
 
 
-case class SidechainBoxesCompanion(customBoxSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]])
-  extends DynamicTypedSerializer[SidechainTypes#SCB, BoxSerializer[SidechainTypes#SCB]](
-    new JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]]() {{
-        put(ZenBoxId.id(), ZenBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-        put(WithdrawalRequestBoxId.id(), WithdrawalRequestBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-        put(ForgerBoxId.id(), ForgerBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-        put(CrossChainMessageBoxId.id(), CrossChainMessageBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-    }},
+case class SidechainBoxesCompanion(customBoxSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]], isSc2scEnabled: Boolean)
+  extends DynamicTypedSerializer[SidechainTypes#SCB, BoxSerializer[SidechainTypes#SCB]]({
+      val hashMap = new JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]]() {
+          put(ZenBoxId.id(), ZenBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
+          put(WithdrawalRequestBoxId.id(), WithdrawalRequestBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
+          put(ForgerBoxId.id(), ForgerBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
+      }
+      if (isSc2scEnabled)
+          hashMap.put(CrossChainMessageBoxId.id(), CrossChainMessageBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
+      hashMap
+     },
     customBoxSerializers)
 

--- a/sdk/src/main/scala/com/horizen/cryptolibprovider/CryptoLibProvider.scala
+++ b/sdk/src/main/scala/com/horizen/cryptolibprovider/CryptoLibProvider.scala
@@ -1,6 +1,6 @@
 package com.horizen.cryptolibprovider
 
-import com.horizen.cryptolibprovider.implementations.{CswCircuitImplZendoo, SchnorrFunctionsImplZendoo, ThresholdSignatureCircuitImplZendoo, ThresholdSignatureCircuitWithKeyRotationImplZendoo, VrfFunctionsImplZendoo}
+import com.horizen.cryptolibprovider.implementations.{CswCircuitImplZendoo, Sc2scImplZendoo, SchnorrFunctionsImplZendoo, ThresholdSignatureCircuitImplZendoo, ThresholdSignatureCircuitWithKeyRotationImplZendoo, VrfFunctionsImplZendoo}
 import com.horizen.cryptolibprovider.utils.SchnorrFunctions
 
 object CryptoLibProvider {
@@ -10,5 +10,6 @@ object CryptoLibProvider {
   val thresholdSignatureCircuitWithKeyRotation: ThresholdSignatureCircuitWithKeyRotation =
     new ThresholdSignatureCircuitWithKeyRotationImplZendoo()
   val cswCircuitFunctions: CswCircuit = new CswCircuitImplZendoo()
+  val sc2scCircuitFunctions: Sc2scCircuit = new Sc2scImplZendoo()
   val commonCircuitFunctions: CommonCircuit = new CommonCircuit()
 }

--- a/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
@@ -2,10 +2,11 @@ package com.horizen.forge
 
 
 import com.horizen.block._
-import com.horizen.box.Box
+import com.horizen.box.{Box, CrossChainMessageBox, WithdrawalRequestBox}
 import com.horizen.chain.SidechainFeePaymentsInfo
 import com.horizen.companion.SidechainTransactionsCompanion
 import com.horizen.consensus._
+import com.horizen.cryptolibprovider.CryptoLibProvider
 import com.horizen.params.NetworkParams
 import com.horizen.proof.{Signature25519, VrfProof}
 import com.horizen.proposition.Proposition
@@ -15,6 +16,8 @@ import com.horizen.transaction.{SidechainTransaction, TransactionSerializer}
 import com.horizen.utils.{DynamicTypedSerializer, FeePaymentsUtils, ForgingStakeMerklePathInfo, ListSerializer, MerklePath, MerkleTree, TimeToEpochUtils, WithdrawalEpochInfo, WithdrawalEpochUtils}
 import scorex.util.ModifierId
 import com.horizen.fork.ForkManager
+import com.horizen.mempool.{MempoolTakeFilter, MempoolTakeFilterWithMaxBoxType}
+import com.horizen.sc2sc.Sc2ScConfigurator
 import com.horizen.{SidechainHistory, SidechainMemoryPool, SidechainState, SidechainTypes, SidechainWallet}
 
 import scala.collection.JavaConverters._
@@ -22,10 +25,12 @@ import sparkz.core.NodeViewModifier
 import sparkz.core.block.Block
 import sparkz.core.block.Block.BlockId
 
+import scala.:+
 import scala.util.{Failure, Success, Try}
 
 class ForgeMessageBuilder(mainchainSynchronizer: MainchainSynchronizer,
                           companion: SidechainTransactionsCompanion,
+                          sc2ScConfigurator: Sc2ScConfigurator,
                           params: NetworkParams,
                           allowNoWebsocketConnectionInRegtest: Boolean)
   extends AbstractForgeMessageBuilder[
@@ -145,12 +150,20 @@ class ForgeMessageBuilder(mainchainSynchronizer: MainchainSynchronizer,
     var blockSize: Int = blockSizeIn
 
     var txsCounter: Int = 0
-    val allowedWithdrawalRequestBoxes = nodeView.state.getAllowedWithdrawalRequestBoxes(mainchainBlockReferenceData.size) - nodeView.state.getAlreadyMinedWithdrawalRequestBoxesInCurrentEpoch
     val consensusEpochNumber = TimeToEpochUtils.timeStampToEpochNumber(params, timestamp)
-    val mempoolTx =
-      if (ForkManager.getSidechainConsensusEpochFork(consensusEpochNumber).backwardTransferLimitEnabled())
+    var takeFilters : Seq[MempoolTakeFilter] = Seq()
+    if (ForkManager.getSidechainConsensusEpochFork(consensusEpochNumber).backwardTransferLimitEnabled()) {
       //In case we reached the Sidechain Fork1 we filter the mempool txs considering also the WithdrawalBoxes allowed to be mined in the current block.
-        nodeView.pool.takeWithWithdrawalBoxesLimit(allowedWithdrawalRequestBoxes)
+      val allowedWithdrawalRequestBoxes = nodeView.state.getAllowedWithdrawalRequestBoxes(mainchainBlockReferenceData.size) - nodeView.state.getAlreadyMinedWithdrawalRequestBoxesInCurrentEpoch
+      takeFilters = takeFilters :+ new MempoolTakeFilterWithMaxBoxType[WithdrawalRequestBox](allowedWithdrawalRequestBoxes)
+    }
+    if (sc2ScConfigurator.canSendMessages) {
+      val allowedCrossChainMessageBoxes = nodeView.state.getAllowedCrosschainMessageBoxes(mainchainBlockReferenceData.size, CryptoLibProvider.sc2scCircuitFunctions.getMaxMessagesPerCertificate) - nodeView.state.getAlreadyMinedCrosschainMessagesInCurrentEpoch
+      takeFilters = takeFilters :+ new MempoolTakeFilterWithMaxBoxType[CrossChainMessageBox](allowedCrossChainMessageBoxes)
+    }
+    val mempoolTx =
+      if (takeFilters.size > 0)
+        nodeView.pool.takeWithFilterLimit(takeFilters)
       else
         nodeView.pool.take(nodeView.pool.size)
     (mempoolTx

--- a/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/com/horizen/forge/ForgeMessageBuilder.scala
@@ -155,11 +155,11 @@ class ForgeMessageBuilder(mainchainSynchronizer: MainchainSynchronizer,
     if (ForkManager.getSidechainConsensusEpochFork(consensusEpochNumber).backwardTransferLimitEnabled()) {
       //In case we reached the Sidechain Fork1 we filter the mempool txs considering also the WithdrawalBoxes allowed to be mined in the current block.
       val allowedWithdrawalRequestBoxes = nodeView.state.getAllowedWithdrawalRequestBoxes(mainchainBlockReferenceData.size) - nodeView.state.getAlreadyMinedWithdrawalRequestBoxesInCurrentEpoch
-      takeFilters = takeFilters :+ new MempoolTakeFilterWithMaxBoxType[WithdrawalRequestBox](allowedWithdrawalRequestBoxes)
+      takeFilters = takeFilters :+ new MempoolTakeFilterWithMaxBoxType[WithdrawalRequestBox](classOf[WithdrawalRequestBox],allowedWithdrawalRequestBoxes)
     }
     if (sc2ScConfigurator.canSendMessages) {
       val allowedCrossChainMessageBoxes = nodeView.state.getAllowedCrosschainMessageBoxes(mainchainBlockReferenceData.size, CryptoLibProvider.sc2scCircuitFunctions.getMaxMessagesPerCertificate) - nodeView.state.getAlreadyMinedCrosschainMessagesInCurrentEpoch
-      takeFilters = takeFilters :+ new MempoolTakeFilterWithMaxBoxType[CrossChainMessageBox](allowedCrossChainMessageBoxes)
+      takeFilters = takeFilters :+ new MempoolTakeFilterWithMaxBoxType[CrossChainMessageBox](classOf[CrossChainMessageBox],allowedCrossChainMessageBoxes)
     }
     val mempoolTx =
       if (takeFilters.size > 0)

--- a/sdk/src/main/scala/com/horizen/forge/Forger.scala
+++ b/sdk/src/main/scala/com/horizen/forge/Forger.scala
@@ -6,6 +6,7 @@ import com.horizen.block.{SidechainBlock, SidechainBlockHeader}
 import com.horizen.chain.SidechainFeePaymentsInfo
 import com.horizen.companion.SidechainTransactionsCompanion
 import com.horizen.params.NetworkParams
+import com.horizen.sc2sc.Sc2ScConfigurator
 import com.horizen.storage.SidechainHistoryStorage
 import sparkz.core.utils.NetworkTimeProvider
 
@@ -34,9 +35,9 @@ object ForgerRef {
             mainchainSynchronizer: MainchainSynchronizer,
             companion: SidechainTransactionsCompanion,
             timeProvider: NetworkTimeProvider,
+            sc2ScConfigurator: Sc2ScConfigurator,
             params: NetworkParams): Props = {
-    val forgeMessageBuilder: ForgeMessageBuilder = new ForgeMessageBuilder(mainchainSynchronizer, companion, params, settings.websocket.allowNoConnectionInRegtest)
-
+    val forgeMessageBuilder: ForgeMessageBuilder = new ForgeMessageBuilder(mainchainSynchronizer, companion, sc2ScConfigurator, params,  settings.websocket.allowNoConnectionInRegtest)
     Props(new Forger(settings, viewHolderRef, forgeMessageBuilder, timeProvider, params))
   }
 
@@ -45,9 +46,10 @@ object ForgerRef {
             mainchainSynchronizer: MainchainSynchronizer,
             companion: SidechainTransactionsCompanion,
             timeProvider: NetworkTimeProvider,
+            sc2ScConfigurator: Sc2ScConfigurator,
             params: NetworkParams)
            (implicit system: ActorSystem): ActorRef = {
-    val ref = system.actorOf(props(settings, viewHolderRef, mainchainSynchronizer, companion, timeProvider, params))
+    val ref = system.actorOf(props(settings, viewHolderRef, mainchainSynchronizer, companion, timeProvider, sc2ScConfigurator, params))
     system.eventStream.subscribe(ref, SidechainAppEvents.SidechainApplicationStart.getClass)
     ref
 
@@ -59,9 +61,10 @@ object ForgerRef {
             mainchainSynchronizer: MainchainSynchronizer,
             companion: SidechainTransactionsCompanion,
             timeProvider: NetworkTimeProvider,
+            sc2ScConfigurator: Sc2ScConfigurator,
             params: NetworkParams)
            (implicit system: ActorSystem): ActorRef = {
-    val ref = system.actorOf(props(settings, viewHolderRef, mainchainSynchronizer, companion, timeProvider, params), name)
+    val ref = system.actorOf(props(settings, viewHolderRef, mainchainSynchronizer, companion, timeProvider, sc2ScConfigurator, params), name)
     system.eventStream.subscribe(ref, SidechainAppEvents.SidechainApplicationStart.getClass)
     ref
   }

--- a/sdk/src/main/scala/com/horizen/mempool/MempoolTakeFilter.scala
+++ b/sdk/src/main/scala/com/horizen/mempool/MempoolTakeFilter.scala
@@ -1,0 +1,14 @@
+package com.horizen.mempool
+import com.horizen.SidechainTypes
+
+/**
+ * Filter that can be used to take tx from the mempool.
+ * For every tx in the mempool evaluateTx is called.
+ * If we have multiple filters applied, all of them are called.
+ * If every filter returns true, the tx is taken, and accumulateTx is called
+ * @see SidechainMemoryPool.takeWithFilterLimit
+ */
+trait MempoolTakeFilter {
+  def evaluateTx(tx: SidechainTypes#SCBT): Boolean
+  def accumulateTx(tx: SidechainTypes#SCBT)
+}

--- a/sdk/src/main/scala/com/horizen/mempool/MempoolTakeFilterWithMaxBoxType.scala
+++ b/sdk/src/main/scala/com/horizen/mempool/MempoolTakeFilterWithMaxBoxType.scala
@@ -1,0 +1,19 @@
+package com.horizen.mempool
+import com.horizen.SidechainTypes
+import com.horizen.box.Box
+import scala.collection.JavaConverters._
+
+class MempoolTakeFilterWithMaxBoxType[B <: Box[_]](maxCount: Int) extends MempoolTakeFilter {
+
+  var totCount = 0;
+
+  override def evaluateTx(tx: SidechainTypes#SCBT): Boolean = {
+    val boxesOfTypes = tx.newBoxes().asScala.count(box => box.isInstanceOf[B])
+    totCount + boxesOfTypes <= maxCount
+  }
+
+  override def accumulateTx(tx: SidechainTypes#SCBT): Unit = {
+    val boxesOfTypes = tx.newBoxes().asScala.count(box => box.isInstanceOf[B])
+    totCount = totCount + boxesOfTypes
+  }
+}

--- a/sdk/src/main/scala/com/horizen/mempool/MempoolTakeFilterWithMaxBoxType.scala
+++ b/sdk/src/main/scala/com/horizen/mempool/MempoolTakeFilterWithMaxBoxType.scala
@@ -3,17 +3,20 @@ import com.horizen.SidechainTypes
 import com.horizen.box.Box
 import scala.collection.JavaConverters._
 
-class MempoolTakeFilterWithMaxBoxType[B <: Box[_]](maxCount: Int) extends MempoolTakeFilter {
+/**
+ * A filter that accoumulate txs until the number of output boxes created by them reaches a limit
+ */
+class MempoolTakeFilterWithMaxBoxType[B <: Box[_]](boxClass: Class[B], maxCount: Int) extends MempoolTakeFilter {
 
   var totCount = 0;
 
   override def evaluateTx(tx: SidechainTypes#SCBT): Boolean = {
-    val boxesOfTypes = tx.newBoxes().asScala.count(box => box.isInstanceOf[B])
+    val boxesOfTypes = tx.newBoxes().asScala.count(box => box.getClass.isAssignableFrom(boxClass))
     totCount + boxesOfTypes <= maxCount
   }
 
   override def accumulateTx(tx: SidechainTypes#SCBT): Unit = {
-    val boxesOfTypes = tx.newBoxes().asScala.count(box => box.isInstanceOf[B])
+    val boxesOfTypes = tx.newBoxes().asScala.count(box => box.getClass.isAssignableFrom(boxClass))
     totCount = totCount + boxesOfTypes
   }
 }

--- a/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScDataForCertificate.scala
+++ b/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScDataForCertificate.scala
@@ -1,0 +1,4 @@
+package com.horizen.sc2sc
+
+case class Sc2ScDataForCertificate(messagesTreeRoot: Array[Byte],
+                                   previousTopQualityCertificateHash: Option[Array[Byte]])

--- a/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScException.java
+++ b/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScException.java
@@ -1,0 +1,12 @@
+package com.horizen.sc2sc;
+
+public class Sc2ScException extends Exception {
+
+    public Sc2ScException(String message) {
+        super(message);
+    }
+
+    public Sc2ScException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScProver.scala
+++ b/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScProver.scala
@@ -1,0 +1,100 @@
+package com.horizen.sc2sc
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props, Timers}
+import akka.pattern.ask
+import akka.util.Timeout
+import com.horizen.{AbstractHistory, AbstractState, SidechainAppEvents, SidechainHistory, SidechainSettings, SidechainState, SidechainTypes, Wallet}
+import com.horizen.api.http.client.SecureEnclaveApiClient
+import com.horizen.block.{SidechainBlock, SidechainBlockBase, SidechainBlockHeader, SidechainBlockHeaderBase}
+import com.horizen.certificatesubmitter.AbstractCertificateSubmitter.{CertificateSignatureFromRemoteInfo, SignaturesStatus}
+import com.horizen.certificatesubmitter.AbstractCertificateSubmitter.InternalReceivableMessages.LocallyGeneratedSignature
+import com.horizen.certificatesubmitter.CertificateSubmitter
+import com.horizen.certificatesubmitter.dataproof.CertificateData
+import com.horizen.certificatesubmitter.strategies.{CeasingSidechain, CertificateSubmissionStrategy, CircuitStrategy, NonCeasingSidechain, SubmissionWindowStatus, WithKeyRotationCircuitStrategy, WithoutKeyRotationCircuitStrategy}
+import com.horizen.chain.AbstractFeePaymentsInfo
+import com.horizen.cryptolibprovider.CryptoLibProvider
+import com.horizen.cryptolibprovider.utils.CircuitTypes
+import com.horizen.mainchain.api.MainchainNodeCertificateApi
+import com.horizen.params.NetworkParams
+import com.horizen.sc2sc.Sc2scProver.ReceivableMessages.BuildRedeemMessage
+import com.horizen.storage.AbstractHistoryStorage
+import com.horizen.transaction.Transaction
+import com.horizen.websocket.client.MainchainNodeChannel
+import scorex.util.ScorexLogging
+import sparkz.core.NodeViewHolder.CurrentView
+import sparkz.core.NodeViewHolder.ReceivableMessages.GetDataFromCurrentView
+import sparkz.core.transaction.MemoryPool
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{Await, ExecutionContext}
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
+
+class Sc2ScProver [
+  TX <: Transaction,
+  H <: SidechainBlockHeaderBase,
+  PM <: SidechainBlockBase[TX, H] : ClassTag,
+  FPI <: AbstractFeePaymentsInfo,
+  HSTOR <: AbstractHistoryStorage[PM, FPI, HSTOR],
+  HIS <: AbstractHistory[TX, H, PM, FPI, HSTOR, HIS],
+  MS <: AbstractState[TX, H, PM, MS],
+  VL <: Wallet[SidechainTypes#SCS, SidechainTypes#SCP, TX, PM, VL],
+  MP <: MemoryPool[TX, MP],
+  T <: CertificateData](settings: SidechainSettings,
+                        sidechainNodeViewHolderRef: ActorRef,
+                        params: NetworkParams,
+                        )
+                       (implicit ec: ExecutionContext) extends Actor
+  with Timers
+  with ScorexLogging
+  with Sc2ScUtils[TX, H, PM, MS, HIS]
+{
+
+  type View = CurrentView[HIS, MS, VL, MP]
+  val timeoutDuration: FiniteDuration = settings.sparkzSettings.restApi.timeout
+  implicit val timeout: Timeout = Timeout(timeoutDuration)
+
+  override def receive: Receive = {
+    case BuildRedeemMessage(message: CrossChainMessage) =>
+      sender() ! buildRedeemMessage(message)
+  }
+
+  def buildRedeemMessage(message: CrossChainMessage): Try[CrossChainRedeemMessage] = {
+    Await.result(sidechainNodeViewHolderRef ? GetDataFromCurrentView((view: View) =>
+      buildRedeemMessage(message, view.state, view.history, params)),timeoutDuration)
+      .asInstanceOf[Try[CrossChainRedeemMessage]]
+  }
+}
+
+object Sc2ScProverRef {
+  def props(settings: SidechainSettings,
+            sidechainNodeViewHolderRef: ActorRef,
+            params: NetworkParams
+           )
+           (implicit ec: ExecutionContext): Props = {
+    Props(new Sc2ScProver(settings, sidechainNodeViewHolderRef, params))
+  }
+
+  def apply(settings: SidechainSettings, sidechainNodeViewHolderRef: ActorRef, params: NetworkParams)
+           (implicit system: ActorSystem, ec: ExecutionContext): ActorRef = {
+    val ref = system.actorOf(props(settings, sidechainNodeViewHolderRef, params))
+    system.eventStream.subscribe(ref, SidechainAppEvents.SidechainApplicationStart.getClass)
+    ref
+  }
+
+  def apply(name: String, settings: SidechainSettings,sidechainNodeViewHolderRef: ActorRef, params: NetworkParams)
+           (implicit system: ActorSystem, ec: ExecutionContext): ActorRef = {
+    val ref = system.actorOf(props(settings,  sidechainNodeViewHolderRef,  params), name)
+    system.eventStream.subscribe(ref, SidechainAppEvents.SidechainApplicationStart.getClass)
+    ref
+  }
+}
+
+
+object Sc2scProver {
+  // Public interface
+  object ReceivableMessages {
+    case class BuildRedeemMessage(crossChainMessage: CrossChainMessage)
+  }
+}

--- a/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScUtils.scala
+++ b/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScUtils.scala
@@ -53,7 +53,7 @@ trait Sc2ScUtils[
           throw new Sc2ScException("Unable to build redeem message, epoch too recent")
         }else{
           //collect all the data needed for proof creation
-          val messageMerklePath : MerklePath = sc2scCircuitFunctions.gerCrossChainMessageMerklePath(
+          val messageMerklePath : MerklePath = sc2scCircuitFunctions.getCrossChainMessageMerklePath(
               state.getCrossChainMessages(messagePostedEpoch).asJava, sourceMessage);
           val topCertInfos =  getTopCertInfoByEpoch(messagePostedEpoch, state, history, true).getOrElse(
             throw new Sc2ScException("Unable to retrieve certificate associated with this message epoch")

--- a/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScUtils.scala
+++ b/sdk/src/main/scala/com/horizen/sc2sc/Sc2ScUtils.scala
@@ -1,0 +1,126 @@
+package com.horizen.sc2sc
+
+import com.horizen.{AbstractHistory, AbstractState}
+
+import scala.collection.JavaConverters._
+import com.horizen.block.{SidechainBlockBase, SidechainBlockHeaderBase, WithdrawalEpochCertificate}
+import com.horizen.cryptolibprovider.{CommonCircuit, CryptoLibProvider, Sc2scCircuit}
+import com.horizen.librustsidechains.FieldElement
+import com.horizen.merkletreenative.MerklePath
+import com.horizen.params.NetworkParams
+import com.horizen.transaction.Transaction
+import scala.compat.java8.OptionConverters._
+import scala.util.{Success, Try}
+
+trait Sc2ScUtils[
+  TX <: Transaction,
+  H <: SidechainBlockHeaderBase,
+  PM <: SidechainBlockBase[TX, H],
+  MS <: AbstractState[TX, H, PM, MS],
+  HIS <: AbstractHistory[TX, H, PM, _, _, _]
+] {
+
+  var sc2scCircuitFunctions :  Sc2scCircuit  = CryptoLibProvider.sc2scCircuitFunctions
+  var commonCircuitFunctions :  CommonCircuit  = CryptoLibProvider.commonCircuitFunctions
+
+  /**
+   * Get all the the additional data to be inserted in a certificate for sidechain2sidechain pourpuses
+   * Note: Certificates are searched in the history and not using state.certificate() because in the latter
+   * we keep only the most recent ones.
+   */
+  def getDataForCertificateCreation(epoch: Int, state: MS, history: HIS, params: NetworkParams): Sc2ScDataForCertificate = {
+    val crossChainMessages: Seq[CrossChainMessage] = state.getCrossChainMessages(epoch)
+    val messageRootHash: Array[Byte] = sc2scCircuitFunctions.getCrossChainMessageTreeRoot(crossChainMessages.toList.asJava);
+    val previousCertificateHash : Option[Array[Byte]]   = getTopCertInfoByEpoch(epoch - 1, state, history, false) match {
+      case Some(certInfo) => Some(CryptoLibProvider.commonCircuitFunctions.getCertDataHash(certInfo.certificate, params.sidechainCreationVersion))
+      case _ => None
+    }
+    Sc2ScDataForCertificate(messageRootHash,previousCertificateHash)
+  }
+
+  /**
+   * Giving a CrossChainMessage previously published on this sidechain, this method will build its redeem message
+   */
+  def buildRedeemMessage(sourceMessage: CrossChainMessage, state: MS, history: HIS, params: NetworkParams): Try[CrossChainRedeemMessage] = {
+    //check the message has been previously posted and we are in the correct epoch
+    val currentEpoch = state.getWithdrawalEpochInfo.epoch
+    val messageHash = sc2scCircuitFunctions.getCrossChainMessageHash(sourceMessage)
+
+    state.getCrossChainMessageHashEpoch(messageHash) match {
+      case None => throw new Sc2ScException("Message was not found inside state")
+      case Some(messagePostedEpoch) =>
+        if (currentEpoch < messagePostedEpoch+2) {
+          throw new Sc2ScException("Unable to build redeem message, epoch too recent")
+        }else{
+          //collect all the data needed for proof creation
+          val messageMerklePath : MerklePath = sc2scCircuitFunctions.gerCrossChainMessageMerklePath(
+              state.getCrossChainMessages(messagePostedEpoch).asJava, sourceMessage);
+          val topCertInfos =  getTopCertInfoByEpoch(messagePostedEpoch, state, history, true).getOrElse(
+            throw new Sc2ScException("Unable to retrieve certificate associated with this message epoch")
+          )
+          val nextTopCertInfos = getTopCertInfoByEpoch(messagePostedEpoch+1, state, history, true).getOrElse(
+            throw new Sc2ScException("Unable to retrieve certificate associated with this message epoch+1")
+          )
+          val topCertMerklePath = MerklePath.deserialize(topCertInfos.merklePath)
+          val topCertscCommitmentRoot = FieldElement.deserialize(topCertInfos.scCommitmentRoot)
+          val nextCertMerklePath = MerklePath.deserialize(nextTopCertInfos.merklePath)
+          val nextCertscCommitmentRoot = FieldElement.deserialize(nextTopCertInfos.scCommitmentRoot)
+
+
+          //compute proof
+          val proof :Array[Byte]= sc2scCircuitFunctions.createRedeemProof(
+             messageHash,
+             messageMerklePath,
+             CommonCircuit.createWithdrawalCertificate(topCertInfos.certificate, params.sidechainCreationVersion),
+             topCertMerklePath,
+             topCertscCommitmentRoot,
+             CommonCircuit.createWithdrawalCertificate(nextTopCertInfos.certificate, params.sidechainCreationVersion),
+             nextCertMerklePath,
+             nextCertscCommitmentRoot,
+          )
+
+          //build and return final message
+          val retMessage = new CrossChainRedeemMessageImpl(
+             sourceMessage,
+             CryptoLibProvider.commonCircuitFunctions.getCertDataHash(topCertInfos.certificate, params.sidechainCreationVersion),
+             CryptoLibProvider.commonCircuitFunctions.getCertDataHash(nextTopCertInfos.certificate, params.sidechainCreationVersion),
+             topCertInfos.scCommitmentRoot,
+             nextTopCertInfos.scCommitmentRoot,
+             proof
+          )
+          Success(retMessage)
+
+        }
+    }
+  }
+
+  private def getTopCertInfoByEpoch(epoch: Int, state: MS, history: HIS, calculateMerklePath: Boolean): Option[TopQualityCertificateInfos] ={
+    state.getTopCertificateMainchainHash(epoch) match {
+      case Some(mainchainHeaderHash) => {
+        history.getMainchainBlockReferenceByHash(mainchainHeaderHash).asScala match {
+          case Some(ele) => {
+            ele.data.topQualityCertificate match {
+              case Some(topCert) =>
+                val certPath: Array[Byte] = null
+                if (calculateMerklePath){
+                  //TODO: add this method: ele.data.commitmentTree(sidechainId, sidechainCreationVersion).getCertMerklePath(topCert).get
+                }
+                Some(TopQualityCertificateInfos(topCert, ele.header.hashScTxsCommitment, certPath))
+              case None => Option.empty
+            }
+          }
+          case None => Option.empty
+        }
+      }
+      case None => Option.empty
+    }
+  }
+
+}
+
+case class TopQualityCertificateInfos(
+                                       certificate: WithdrawalEpochCertificate,
+                                       scCommitmentRoot: Array[Byte],
+                                       merklePath: Array[Byte]
+                                     )
+

--- a/sdk/src/main/scala/com/horizen/state/BaseStateReader.scala
+++ b/sdk/src/main/scala/com/horizen/state/BaseStateReader.scala
@@ -11,6 +11,7 @@ import java.math.BigInteger
 trait BaseStateReader {
   def getWithdrawalEpochInfo: WithdrawalEpochInfo
   def getTopQualityCertificate(referencedWithdrawalEpoch: Int): Option[WithdrawalEpochCertificate]
+  def getTopCertificateMainchainHash(referencedWithdrawalEpoch: Int): Option[Array[Byte]] //hash of mainchain block that published the top quality cert of this epoch
   def getFeePaymentsInfo(withdrawalEpoch: Int, blockToAppendFeeInfo: Option[AccountBlockFeeInfo] = None): Seq[AccountPayment]
   def getConsensusEpochNumber: Option[ConsensusEpochNumber]
   def getTransactionReceipt(txHash: Array[Byte]): Option[EthereumReceipt]

--- a/sdk/src/main/scala/com/horizen/state/StateView.scala
+++ b/sdk/src/main/scala/com/horizen/state/StateView.scala
@@ -14,7 +14,7 @@ import java.math.BigInteger
 trait StateView[TX <: Transaction] extends BaseStateReader {
 
   def updateWithdrawalEpochInfo(withdrawalEpochInfo: WithdrawalEpochInfo): Unit
-  def updateTopQualityCertificate(cert: WithdrawalEpochCertificate, blockId: ModifierId): Unit
+  def updateTopQualityCertificate(cert: WithdrawalEpochCertificate, mainChainHash: Array[Byte], blockId: ModifierId): Unit
   def updateFeePaymentInfo(info: AccountBlockFeeInfo): Unit
   def updateConsensusEpochNumber(consensusEpochNum: ConsensusEpochNumber): Unit
   def updateTransactionReceipts(receipts: Seq[EthereumReceipt]): Unit

--- a/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
+++ b/sdk/src/main/scala/com/horizen/storage/SidechainStateStorage.scala
@@ -4,21 +4,24 @@ package com.horizen.storage
 import com.google.common.primitives.{Bytes, Ints}
 import com.horizen.SidechainTypes
 import com.horizen.backup.BoxIterator
-import com.horizen.block.{WithdrawalEpochCertificate, WithdrawalEpochCertificateSerializer}
+import com.horizen.block.{MainchainHeader, WithdrawalEpochCertificate, WithdrawalEpochCertificateSerializer}
 import com.horizen.box.{WithdrawalRequestBox, WithdrawalRequestBoxSerializer}
 import com.horizen.certificatesubmitter.keys._
 import com.horizen.companion.SidechainBoxesCompanion
 import com.horizen.consensus._
 import com.horizen.cryptolibprovider.utils.CircuitTypes
+import com.horizen.cryptolibprovider.CryptoLibProvider
 import com.horizen.forge.{ForgerList, ForgerListSerializer}
 import com.horizen.params.NetworkParams
 import com.horizen.utils.{ByteArrayWrapper, ListSerializer, WithdrawalEpochInfo, WithdrawalEpochInfoSerializer, Pair => JPair, _}
 import scorex.util.{ModifierId, ScorexLogging, bytesToId}
 import java.util.{ArrayList => JArrayList}
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.compat.java8.OptionConverters._
 import scala.util._
+import com.horizen.sc2sc.{CrossChainMessage, CrossChainMessageHash, CrossChainMessageSerializer}
 
 class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: SidechainBoxesCompanion, params: NetworkParams)
   extends ScorexLogging
@@ -33,6 +36,7 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
 
   private[horizen] val withdrawalEpochInformationKey = Utils.calculateKey("withdrawalEpochInformation".getBytes)
   private val withdrawalRequestSerializer = new ListSerializer[WithdrawalRequestBox](WithdrawalRequestBoxSerializer.getSerializer)
+  private val crossChainMessagesSerializer = new ListSerializer[CrossChainMessage](CrossChainMessageSerializer.getSerializer)
 
   private[horizen] val consensusEpochKey = Utils.calculateKey("consensusEpoch".getBytes)
 
@@ -41,12 +45,26 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
   private[horizen] val forgerListIndexKey = Utils.calculateKey("forgerListIndexKey".getBytes)
 
   private val undefinedWithdrawalEpochCounter: Int = -1
+  private val undefinedCrosschainMessagesEpochCounter: Int = -1
+
   private[horizen] def getWithdrawalEpochCounterKey(withdrawalEpoch: Int): ByteArrayWrapper = {
     Utils.calculateKey(Bytes.concat("withdrawalEpochCounter".getBytes, Ints.toByteArray(withdrawalEpoch)))
   }
 
+  private[horizen] def getCrosschainMessagesEpochCounterKey(withdrawalEpoch: Int): ByteArrayWrapper = {
+    Utils.calculateKey(Bytes.concat("ccMessagesEpochCounterKey".getBytes, Ints.toByteArray(withdrawalEpoch)))
+  }
+
   private[horizen] def getWithdrawalRequestsKey(withdrawalEpoch: Int, counter: Int): ByteArrayWrapper = {
     Utils.calculateKey(Bytes.concat("withdrawalRequests".getBytes, Ints.toByteArray(withdrawalEpoch), Ints.toByteArray(counter)))
+  }
+
+  private[horizen] def getCrosschainMessagesKey(withdrawalEpoch: Int, counter: Int): ByteArrayWrapper = {
+    Utils.calculateKey(Bytes.concat("ccMessages".getBytes, Ints.toByteArray(withdrawalEpoch), Ints.toByteArray(counter)))
+  }
+
+  private[horizen] def getCrosschainMessageSingleKey(hash: CrossChainMessageHash): ByteArrayWrapper = {
+    Utils.calculateKey(Bytes.concat("ccMessage".getBytes, hash.bytes))
   }
 
   private[horizen] def getCertifiersStorageKey(withdrawalEpoch: Int): ByteArrayWrapper = {
@@ -59,6 +77,10 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
 
   private[horizen] def getTopQualityCertificateKey(referencedWithdrawalEpoch: Int): ByteArrayWrapper = {
     Utils.calculateKey(Bytes.concat("topQualityCertificate".getBytes, Ints.toByteArray(referencedWithdrawalEpoch)))
+  }
+
+  private[horizen] def getTopQualityCertificateMainchainHeaderKey(referencedWithdrawalEpoch: Int): ByteArrayWrapper = {
+    Utils.calculateKey(Bytes.concat("topQualityCertificateMainchainHeaderKey".getBytes, Ints.toByteArray(referencedWithdrawalEpoch)))
   }
 
   private[horizen] val getLastCertificateEpochNumberKey = Utils.calculateKey("lastCertificateEpochNumber".getBytes)
@@ -78,7 +100,6 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
   private[horizen] def getUtxoMerkleTreeRootKey(withdrawalEpochNumber: Int): ByteArrayWrapper = {
     Utils.calculateKey(Bytes.concat("utxoMerkleTreeRoot".getBytes, Ints.toByteArray(withdrawalEpochNumber)))
   }
-
 
   def getBox(boxId: Array[Byte]): Option[SidechainTypes#SCB] = {
     storage.get(Utils.calculateKey(boxId)) match {
@@ -113,6 +134,16 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
           Ints.fromByteArray(baw.data)
         }.toOption.getOrElse(undefinedWithdrawalEpochCounter)
       case _ => undefinedWithdrawalEpochCounter
+    }
+  }
+
+  def getCrossChainMessagesEpochCounter(epoch: Int): Int = {
+    storage.get(getCrosschainMessagesEpochCounterKey(epoch)).asScala match {
+      case Some(baw) =>
+        Try {
+          Ints.fromByteArray(baw.data)
+        }.toOption.getOrElse(undefinedCrosschainMessagesEpochCounter)
+      case _ => undefinedCrosschainMessagesEpochCounter
     }
   }
 
@@ -162,6 +193,33 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
     withdrawalRequests
   }
 
+  def getCrossChainMessagesPerEpoch(withdrawalEpoch: Int): Seq[CrossChainMessage] = {
+    // Aggregate all crosschainMessages until reaching the counter, where the key is not present in the storage.
+    val crosschainMessages: ListBuffer[CrossChainMessage] = ListBuffer()
+    val lastCounter: Int = getCrossChainMessagesEpochCounter(withdrawalEpoch)
+    for (counter <- 0 to lastCounter) {
+      storage.get(getCrosschainMessagesKey(withdrawalEpoch, counter)).asScala match {
+        case Some(baw) =>
+          crossChainMessagesSerializer.parseBytesTry(baw.data) match {
+            case Success(wr) =>
+              crosschainMessages.appendAll(wr.asScala)
+            case Failure(exception) =>
+              throw new IllegalStateException("Error while crosschainMessages parsing.", exception)
+          }
+        case None =>
+          throw new IllegalStateException("Error while crosschainMessages retrieving: record expected to exist.")
+      }
+    }
+    crosschainMessages
+  }
+
+  def getCrossChainMessageHashEpoch(singleMessageHash: CrossChainMessageHash): Option[Int] = {
+    storage.get(getCrosschainMessageSingleKey(singleMessageHash)).asScala match {
+      case Some(baw) => Option( Ints.fromByteArray(baw.data()))
+      case _ => Option.empty
+    }
+  }
+
   def getCertifiersKeys(withdrawalEpoch: Int): Option[CertifiersKeys] = {
     storage.get(getCertifiersStorageKey(withdrawalEpoch)).asScala match {
       case Some(baw) =>
@@ -199,6 +257,14 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
       case _ => Option.empty
     }
   }
+
+  def getTopQualityCertificateMainchainHeaderHash(referencedWithdrawalEpoch: Int): Option[Array[Byte]] = {
+    storage.get(getTopQualityCertificateMainchainHeaderKey(referencedWithdrawalEpoch)).asScala match {
+      case Some(baw) => Some(baw.data())
+      case _ => Option.empty
+    }
+  }
+
 
   def getLastCertificateReferencedEpoch(): Option[Int] = {
     storage.get(getLastCertificateEpochNumberKey).asScala match {
@@ -276,8 +342,9 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
              boxUpdateList: Set[SidechainTypes#SCB],
              boxIdsRemoveSet: Set[ByteArrayWrapper],
              withdrawalRequestAppendSeq: Seq[WithdrawalRequestBox],
+             crossChainMessagesToAppendSeq: Seq[CrossChainMessage],
              consensusEpoch: ConsensusEpochNumber,
-             topQualityCertificateOpt: Option[WithdrawalEpochCertificate],
+             topQualityCerts: Seq[(WithdrawalEpochCertificate, Array[Byte])],
              blockFeeInfo: BlockFeeInfo,
              utxoMerkleTreeRootOpt: Option[Array[Byte]],
              scHasCeased: Boolean,
@@ -291,8 +358,11 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
     require(!boxUpdateList.contains(null), "Box to add/update must be NOT NULL.")
     require(!boxIdsRemoveSet.contains(null), "BoxId to remove must be NOT NULL.")
     require(withdrawalRequestAppendSeq != null, "Seq of WithdrawalRequests to append must be NOT NULL. Use empty Seq instead.")
+    require(crossChainMessagesToAppendSeq != null, "Seq of CrossChainMessages to append must be NOT NULL. Use empty Seq instead.")
     require(!withdrawalRequestAppendSeq.contains(null), "WithdrawalRequest to append must be NOT NULL.")
     require(blockFeeInfo != null, "BlockFeeInfo must be NOT NULL.")
+
+    val topQualityCertificateOpt : Option[WithdrawalEpochCertificate] = topQualityCerts.lastOption.map(_._1)
 
     val removeList = new JArrayList[ByteArrayWrapper]()
     val updateList = new JArrayList[JPair[ByteArrayWrapper, ByteArrayWrapper]]()
@@ -413,6 +483,37 @@ class SidechainStateStorage(storage: Storage, sidechainBoxesCompanion: Sidechain
       updateList.add(new JPair(getTopQualityCertificateKey(certificate.epochNumber),
         WithdrawalEpochCertificateSerializer.toBytes(certificate)))
     })
+
+    if (params.isNonCeasing) {
+      if (crossChainMessagesToAppendSeq.nonEmpty) {
+        // Calculate the next counter for storing crosschain messages requests without duplication previously stored ones.
+        val nextCrossChainMessageEpochCounter: Int = getCrossChainMessagesEpochCounter(withdrawalEpochInfo.epoch) + 1
+
+        updateList.add(new JPair(getCrosschainMessagesEpochCounterKey(withdrawalEpochInfo.epoch),
+          new ByteArrayWrapper(Ints.toByteArray(nextCrossChainMessageEpochCounter))))
+
+        //collect and store the crosschain messages, grouped by epoch
+        val ccMessages = new JArrayList[CrossChainMessage]()
+        for (b <- crossChainMessagesToAppendSeq) {
+          ccMessages.add(b)
+
+          //store also every  single hash separately with its epoch
+          val singleMessageHash = CryptoLibProvider.sc2scCircuitFunctions.getCrossChainMessageHash(b)
+          updateList.add(new JPair(getCrosschainMessageSingleKey(singleMessageHash),
+            new ByteArrayWrapper(Ints.toByteArray(withdrawalEpochInfo.epoch))))
+        }
+
+        updateList.add(new JPair(getCrosschainMessagesKey(withdrawalEpochInfo.epoch, nextCrossChainMessageEpochCounter),
+          new ByteArrayWrapper(crossChainMessagesSerializer.toBytes(ccMessages))))
+
+      }
+      //for sidechain2Sidehcain we stor also the mainchain hash for each top quality certificate
+      topQualityCerts.foreach(ele =>
+        updateList.add(new JPair(getTopQualityCertificateMainchainHeaderKey(ele._1.epochNumber),
+          new ByteArrayWrapper(ele._2)))
+      )
+    }
+
 
     // Update BlockFeeInfo data
     val nextBlockFeeInfoCounter: Int = getBlockFeeInfoCounter(withdrawalEpochInfo.epoch) + 1

--- a/sdk/src/test/java/com/horizen/backup/BoxIteratorTest.java
+++ b/sdk/src/test/java/com/horizen/backup/BoxIteratorTest.java
@@ -42,7 +42,7 @@ public class BoxIteratorTest extends BoxFixtureClass {
     @Before
     public void setup() {
         customBoxSerializers.put(CustomBox.BOX_TYPE_ID, (BoxSerializer) CustomBoxSerializer.getSerializer());
-        sidechainBoxesCompanion = new SidechainBoxesCompanion(customBoxSerializers);
+        sidechainBoxesCompanion = new SidechainBoxesCompanion(customBoxSerializers, false);
 
         customBoxes = getCustomBoxList(nBoxes);
         for (CustomBox box : customBoxes) {

--- a/sdk/src/test/java/com/horizen/box/CrossChainMessageBoxTest.java
+++ b/sdk/src/test/java/com/horizen/box/CrossChainMessageBoxTest.java
@@ -1,0 +1,67 @@
+package com.horizen.box;
+
+import com.horizen.fixtures.BoxFixtureClass;
+import com.horizen.params.MainNetParams;
+import com.horizen.params.NetworkParams;
+import com.horizen.proposition.MCPublicKeyHashProposition;
+import com.horizen.proposition.PublicKey25519Proposition;
+import com.horizen.sc2sc.CrossChainProtocolVersion;
+import com.horizen.utils.Ed25519;
+import com.horizen.utils.Pair;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CrossChainMessageBoxTest extends BoxFixtureClass {
+
+    PublicKey25519Proposition proposition;
+    CrossChainProtocolVersion protocolVersion;
+    int messageTYpe = 1;
+    long nonce;
+    long value;
+    String payload;
+    byte[] sidechainId;
+    byte[] receivingSidechain;
+
+    @Before
+    public void setUp() {
+        byte[] anotherSeed = "testseed".getBytes();
+        Pair<byte[], byte[]> keyPair = Ed25519.createKeyPair(anotherSeed);
+        proposition = new PublicKey25519Proposition(keyPair.getValue());
+        protocolVersion = CrossChainProtocolVersion.VERSION_1;
+        nonce = 12345;
+        value = 0;
+        payload = "testPayload";
+        sidechainId = new byte[32];
+        new Random().nextBytes(sidechainId);
+        receivingSidechain = new byte[16];
+        new Random().nextBytes(receivingSidechain);
+    }
+    @Test
+    public void creationTest() {
+        CrossChainMessageBox box = getCrossMessageBox(proposition, protocolVersion,
+                messageTYpe, sidechainId, receivingSidechain, payload.getBytes(),  nonce);
+        assertEquals("CrossChainMessageBox creation: proposition is wrong", proposition, box.proposition());
+        assertEquals("CrossChainMessageBox creation: nonce is wrong", box.nonce(), nonce);
+        assertEquals("CrossChainMessageBox creation: value is wrong", box.value(), value);
+    }
+
+    @Test
+    public void serializationTest() {
+        CrossChainMessageBox box = getCrossMessageBox(proposition, protocolVersion,
+                messageTYpe, sidechainId, receivingSidechain, payload.getBytes(),  nonce);
+        byte[] bytes = box.serializer().toBytes(box);
+
+        CrossChainMessageBox box2 = (CrossChainMessageBox)box.serializer().parseBytesTry(bytes).get();
+        assertEquals("Boxes expected to be equal", box, box2);
+
+        assertEquals("CrossChainMessageBox deserialize error: proposition is wrong", proposition, box2.proposition());
+        assertEquals("CrossChainMessageBox deserialize error: nonce is wrong", box2.nonce(), nonce);
+        assertEquals("CrossChainMessageBox deserialize error: value is wrong", box2.value(), value);
+    }
+
+}

--- a/sdk/src/test/java/com/horizen/box/CrossChainMessageBoxTest.java
+++ b/sdk/src/test/java/com/horizen/box/CrossChainMessageBoxTest.java
@@ -13,8 +13,7 @@ import org.junit.Test;
 
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class CrossChainMessageBoxTest extends BoxFixtureClass {
 
@@ -26,7 +25,7 @@ public class CrossChainMessageBoxTest extends BoxFixtureClass {
     String payload;
     byte[] sidechainId;
     byte[] receivingSidechain;
-
+    byte[] receivingSidechain2;
     @Before
     public void setUp() {
         byte[] anotherSeed = "testseed".getBytes();
@@ -40,6 +39,8 @@ public class CrossChainMessageBoxTest extends BoxFixtureClass {
         new Random().nextBytes(sidechainId);
         receivingSidechain = new byte[16];
         new Random().nextBytes(receivingSidechain);
+        receivingSidechain2 = new byte[16];
+        new Random().nextBytes(receivingSidechain2);
     }
     @Test
     public void creationTest() {
@@ -62,6 +63,16 @@ public class CrossChainMessageBoxTest extends BoxFixtureClass {
         assertEquals("CrossChainMessageBox deserialize error: proposition is wrong", proposition, box2.proposition());
         assertEquals("CrossChainMessageBox deserialize error: nonce is wrong", box2.nonce(), nonce);
         assertEquals("CrossChainMessageBox deserialize error: value is wrong", box2.value(), value);
+    }
+
+    @Test
+    public void differentIdTest() {
+        CrossChainMessageBox box = getCrossMessageBox(proposition, protocolVersion,
+                messageTYpe, sidechainId, receivingSidechain, payload.getBytes(),  nonce);
+        CrossChainMessageBox box2 = getCrossMessageBox(proposition, protocolVersion,
+                messageTYpe, sidechainId, receivingSidechain2, payload.getBytes(),  nonce);
+        assertNotEquals("CrossChainMessageBox id should change with different input data", box.id(), box2.id());
+
     }
 
 }

--- a/sdk/src/test/scala/com/horizen/SidechainBackupTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainBackupTest.scala
@@ -30,7 +30,7 @@ class SidechainBackupTest
 
   val customBoxesSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]] = new JHashMap()
   customBoxesSerializers.put(CustomBox.BOX_TYPE_ID, CustomBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers)
+  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers, false)
 
   val boxListFirstModifier = new ListBuffer[SidechainTypes#SCB]()
   val boxListSecondModifier = new ListBuffer[SidechainTypes#SCB]()

--- a/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainStateTest.scala
@@ -1,6 +1,6 @@
 package com.horizen
 
-import com.horizen.block.{MainchainBlockReferenceData, SidechainBlock, WithdrawalEpochCertificate}
+import com.horizen.block.{MainchainBlockReferenceData, MainchainHeader, SidechainBlock, WithdrawalEpochCertificate}
 import com.horizen.box._
 import com.horizen.box.data.{BoxData, ForgerBoxData, WithdrawalRequestBoxData, ZenBoxData}
 import com.horizen.certificatesubmitter.keys.{CertifiersKeys, KeyRotationProof, KeyRotationProofTypes}
@@ -25,8 +25,10 @@ import org.scalatestplus.junit.JUnitSuite
 import org.scalatestplus.mockito.MockitoSugar
 import scorex.util.ModifierId
 import sparkz.core.{bytesToId, bytesToVersion}
-
 import java.util.{ArrayList => JArrayList, List => JList, Optional => JOptional}
+
+import com.horizen.sc2sc.{CrossChainMessage, Sc2ScConfigurator}
+
 import scala.collection.JavaConverters._
 import scala.collection.Seq
 import scala.collection.immutable._
@@ -174,7 +176,7 @@ class SidechainStateTest
     Mockito.when(mockedStateUtxoMerkleTreeProvider.lastVersionId).thenReturn(Some(stateVersion.last))
 
     val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
-      params, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+      params, Sc2ScConfigurator(false, false),  bytesToVersion(stateVersion.last.data), mockedApplicationState)
 
     //Test get
     assertEquals("State must return existing box.",
@@ -330,8 +332,9 @@ class SidechainStateTest
       ArgumentMatchers.any[Set[SidechainTypes#SCB]](),
       ArgumentMatchers.any[Set[ByteArrayWrapper]](),
       ArgumentMatchers.any[Seq[WithdrawalRequestBox]](),
+      ArgumentMatchers.any[Seq[CrossChainMessage]](),
       ArgumentMatchers.any[ConsensusEpochNumber](),
-      ArgumentMatchers.any[Option[WithdrawalEpochCertificate]](),
+      ArgumentMatchers.any[Seq[(WithdrawalEpochCertificate, Array[Byte])]](),
       ArgumentMatchers.any[BlockFeeInfo](),
       ArgumentMatchers.any[Option[Array[Byte]]](),
       ArgumentMatchers.any[Boolean](),
@@ -345,18 +348,18 @@ class SidechainStateTest
         val boxToUpdate = answer.getArgument[Set[SidechainTypes#SCB]](2)
         val boxToRemove = answer.getArgument[Set[ByteArrayWrapper]](3)
         val withdrawalRequestAppendSeq = answer.getArgument[ListBuffer[WithdrawalRequestBox]](4)
-        val consensusEpoch = answer.getArgument[ConsensusEpochNumber](5)
-        val backwardTransferCertificate = answer.getArgument[Option[WithdrawalEpochCertificate]](6)
-        val blockFeeInfo = answer.getArgument[BlockFeeInfo](7)
-        val utxoMerkleTreeRootOpt = answer.getArgument[Option[Array[Byte]]](8)
-        val scHasCeased = answer.getArgument[Boolean](9)
+        val consensusEpoch = answer.getArgument[ConsensusEpochNumber](6)
+        val backwardTransferCertificate = answer.getArgument[Seq[(WithdrawalEpochCertificate, Array[Byte])]](7)
+        val blockFeeInfo = answer.getArgument[BlockFeeInfo](8)
+        val utxoMerkleTreeRootOpt = answer.getArgument[Option[Array[Byte]]](9)
+        val scHasCeased = answer.getArgument[Boolean](10)
 
         // Verify withdrawals
         assertTrue("Withdrawals to append expected to be empty.", withdrawalRequestAppendSeq.isEmpty)
         // Verify consensus epoch number
         assertEquals("Consensus epoch  number should be different.", 2, consensusEpoch)
         // Verify certificate presence
-        assertEquals("Certificate expected to be absent.", None, backwardTransferCertificate)
+        assertEquals("Certificate expected to be absent.", 0, backwardTransferCertificate.size)
         // Verify blockFeeInfo
         assertEquals("blockFeeInfo expected to be different.", modBlockFeeInfo, blockFeeInfo)
         // Verify utxoMerkleTreeRoot
@@ -464,7 +467,7 @@ class SidechainStateTest
       .thenReturn(Success(mockedApplicationState))
 
     val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
-      params, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+      params, Sc2ScConfigurator(false,false), bytesToVersion(stateVersion.last.data), mockedApplicationState)
 
     val applyTry = sidechainState.applyModifier(mockedBlock)
 
@@ -488,7 +491,7 @@ class SidechainStateTest
     Mockito.when(stateUtxoMerkleTreeProvider.lastVersionId).thenReturn(Some(version))
 
     val sidechainState = new SidechainState(stateStorage, stateForgerBoxStorage, stateUtxoMerkleTreeProvider,
-      params, bytesToVersion(version.data), applicationState)
+      params, Sc2ScConfigurator(false,false), bytesToVersion(version.data), applicationState)
 
     // Test 1: No block fee info record in the storage
     Mockito.when(stateStorage.getFeePayments(ArgumentMatchers.any[Int]())).thenReturn(Seq())
@@ -570,7 +573,7 @@ class SidechainStateTest
     Mockito.when(stateUtxoMerkleTreeProvider.lastVersionId).thenReturn(Some(version))
 
     val sidechainState = new SidechainState(stateStorage, stateForgerBoxStorage, stateUtxoMerkleTreeProvider,
-      params, bytesToVersion(version.data), applicationState)
+      params, Sc2ScConfigurator(false,false), bytesToVersion(version.data), applicationState)
 
 
     // Test 1: No utxoMerkleTreeRoot found for given epoch
@@ -611,7 +614,7 @@ class SidechainStateTest
     Mockito.when(stateUtxoMerkleTreeProvider.lastVersionId).thenReturn(Some(version))
 
     val sidechainState = new SidechainState(stateStorage, stateForgerBoxStorage, stateUtxoMerkleTreeProvider,
-      params, bytesToVersion(version.data), applicationState)
+      params, Sc2ScConfigurator(false,false), bytesToVersion(version.data), applicationState)
 
 
     // Test 1: Sidechain is alive
@@ -670,7 +673,7 @@ class SidechainStateTest
     Mockito.when(mockedParams.restrictForgers).thenReturn(false)
 
     val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
-      mockedParams, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+      mockedParams, Sc2ScConfigurator(false,false), bytesToVersion(stateVersion.last.data), mockedApplicationState)
 
     //Test validate(Transaction) with no restrict forgers enabled
     var tryValidate = sidechainState.validate(stakeTransaction)
@@ -762,7 +765,7 @@ class SidechainStateTest
     Mockito.when(mockedParams.restrictForgers).thenReturn(true)
 
     val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
-      mockedParams, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+      mockedParams, Sc2ScConfigurator(false,false), bytesToVersion(stateVersion.last.data), mockedApplicationState)
 
     val forgerList = Seq(
       (secretList(0).publicImage(), vrfList(0)),
@@ -924,7 +927,7 @@ class SidechainStateTest
     Mockito.when(mockedParams.maxWBsAllowed).thenReturn(99)
 
     val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
-      mockedParams, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+      mockedParams, Sc2ScConfigurator(false,false), bytesToVersion(stateVersion.last.data), mockedApplicationState)
 
     //Test validate(Transaction) with a number of WithdrawalBoxes < maxWBsAllowed
     var tryValidate = sidechainState.validate(belowTresholdTransaction)
@@ -1005,7 +1008,7 @@ class SidechainStateTest
       ArgumentMatchers.any[SidechainBlock]())
 
     val sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
-      mockedParams, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+      mockedParams, Sc2ScConfigurator(false,false), bytesToVersion(stateVersion.last.data), mockedApplicationState)
 
     var validateTry = sidechainState.validate(mockedBlock)
     assertFalse("Block validation must fail.",
@@ -1128,7 +1131,7 @@ class SidechainStateTest
     Mockito.when(mockedStateStorage.getWithdrawalEpochInfo).thenReturn(Some(WithdrawalEpochInfo(0,0)))
 
     val sidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
-      params, bytesToVersion(getVersion.data()), mockedApplicationState)
+      params, Sc2ScConfigurator(false,false), bytesToVersion(getVersion.data()), mockedApplicationState)
 
     val consensusEpochNumberFork = 10
 
@@ -1195,7 +1198,7 @@ class SidechainStateTest
     Mockito.when(mockedParams.circuitType).thenReturn(CircuitTypes.NaiveThresholdSignatureCircuit)
 
     var sidechainState: SidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
-      mockedParams, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+      mockedParams, Sc2ScConfigurator(false,false), bytesToVersion(stateVersion.last.data), mockedApplicationState)
 
     var tryValidate = sidechainState.validate(keyRotationTransaction.asInstanceOf[SidechainTypes#SCBT])
     assertFalse("Transaction validation must fail.",
@@ -1208,7 +1211,7 @@ class SidechainStateTest
     Mockito.when(mockedParams.circuitType).thenReturn(CircuitTypes.NaiveThresholdSignatureCircuitWithKeyRotation)
 
     sidechainState = new SidechainState(mockedStateStorage, mockedStateForgerBoxStorage, mockedStateUtxoMerkleTreeProvider,
-      mockedParams, bytesToVersion(stateVersion.last.data), mockedApplicationState)
+      mockedParams, Sc2ScConfigurator(false,false), bytesToVersion(stateVersion.last.data), mockedApplicationState)
 
     tryValidate = sidechainState.validate(keyRotationTransaction.asInstanceOf[SidechainTypes#SCBT])
     assertFalse("Transaction validation must fail.",

--- a/sdk/src/test/scala/com/horizen/SidechainWalletTest.scala
+++ b/sdk/src/test/scala/com/horizen/SidechainWalletTest.scala
@@ -60,7 +60,7 @@ class SidechainWalletTest
 
   var customBoxesSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]] = new JHashMap()
   customBoxesSerializers.put(CustomBox.BOX_TYPE_ID, CustomBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers)
+  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers, false)
 
   val customSecretSerializers: JHashMap[JByte, SecretSerializer[SidechainTypes#SCS]] = new JHashMap()
   customSecretSerializers.put(CustomPrivateKey.SECRET_TYPE_ID, CustomPrivateKeySerializer.getSerializer.asInstanceOf[SecretSerializer[SidechainTypes#SCS]])

--- a/sdk/src/test/scala/com/horizen/WalletBoxSerializerTest.scala
+++ b/sdk/src/test/scala/com/horizen/WalletBoxSerializerTest.scala
@@ -22,7 +22,7 @@ class WalletBoxSerializerTest extends JUnitSuite with BoxFixture {
     val transactionIdBytes = new Array[Byte](32)
     var customBoxesSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]] = new JHashMap()
     customBoxesSerializers.put(CustomBox.BOX_TYPE_ID, CustomBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-    val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers)
+    val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers, false)
 
     var serializer: WalletBoxSerializer = null
     var bytes: Array[Byte] = null

--- a/sdk/src/test/scala/com/horizen/account/fixtures/AccountCrossChainMessageFixture.scala
+++ b/sdk/src/test/scala/com/horizen/account/fixtures/AccountCrossChainMessageFixture.scala
@@ -1,0 +1,25 @@
+package com.horizen.account.fixtures
+
+
+import scala.util.Random
+import com.horizen.account.sc2sc.AccountCrossChainMessage
+import com.horizen.fixtures.SecretFixture
+import com.google.common.primitives.Longs
+
+trait AccountCrossChainMessageFixture extends SecretFixture{
+
+  def getRandomAccountCrossMessage(seed: Long): AccountCrossChainMessage ={
+    val random: Random = new Random(seed)
+    val receiverSidechain = new Array[Byte](32)
+    random.nextBytes(receiverSidechain)
+    val receiverAddress = new Array[Byte](16)
+    random.nextBytes(receiverAddress)
+    AccountCrossChainMessage(
+      1,
+      getPrivateKey25519(Longs.toByteArray(random.nextLong())).publicImage().pubKeyBytes(),
+      receiverSidechain,
+      receiverAddress,
+      "my payload".getBytes
+    )
+  }
+}

--- a/sdk/src/test/scala/com/horizen/account/fixtures/MockedAccountSidechainNodeViewHolderFixture.scala
+++ b/sdk/src/test/scala/com/horizen/account/fixtures/MockedAccountSidechainNodeViewHolderFixture.scala
@@ -26,6 +26,7 @@ class MockedAccountSidechainNodeViewHolder(sidechainSettings: SidechainSettings,
     null,
     null,
     null,
+    null,
     null ) {
 
   override def dumpStorages(): Unit = {}

--- a/sdk/src/test/scala/com/horizen/account/performance/AccountSidechainNodeViewHolderPerfTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/performance/AccountSidechainNodeViewHolderPerfTest.scala
@@ -26,10 +26,12 @@ import org.scalatestplus.junit.JUnitSuite
 import org.scalatestplus.mockito.MockitoSugar.mock
 import sparkz.core.VersionTag
 import sparkz.core.utils.NetworkTimeProvider
-
 import java.io.{BufferedWriter, FileWriter}
 import java.math.BigInteger
 import java.util.Calendar
+
+import com.horizen.sc2sc.Sc2ScConfigurator
+
 import scala.collection.concurrent.TrieMap
 
 /*
@@ -531,6 +533,7 @@ class AccountSidechainNodeViewHolderPerfTest
   class MockedAccountSidechainNodeViewHolder(
       sidechainSettings: SidechainSettings,
       params: NetworkParams,
+      sc2ScConfig: Sc2ScConfigurator,
       timeProvider: NetworkTimeProvider,
       historyStorage: AccountHistoryStorage,
       consensusDataStorage: ConsensusDataStorage,
@@ -542,6 +545,7 @@ class AccountSidechainNodeViewHolderPerfTest
   ) extends AccountSidechainNodeViewHolder(
         sidechainSettings,
         params,
+        sc2ScConfig,
         timeProvider,
         historyStorage,
         consensusDataStorage,
@@ -580,6 +584,7 @@ class AccountSidechainNodeViewHolderPerfTest
     Mockito.when(mockWalletSettings.maxTxFee).thenReturn(100L)
     Mockito.when(sidechainSettings.wallet).thenReturn(mockWalletSettings)
     val params: NetworkParams = mock[NetworkParams]
+    val sc2scConfig : Sc2ScConfigurator = Sc2ScConfigurator(false, false)
     val timeProvider: NetworkTimeProvider = mock[NetworkTimeProvider]
 
     val historyStorage: AccountHistoryStorage = mock[AccountHistoryStorage]
@@ -593,7 +598,7 @@ class AccountSidechainNodeViewHolderPerfTest
 
     val versionTag: VersionTag = VersionTag @@ BytesUtils.toHexString(getVersion.data())
 
-    state = new AccountState(params, timeProvider, versionTag, stateMetadataStorage, stateDbStorage, Seq()) {
+    state = new AccountState(params, Sc2ScConfigurator(false, false), timeProvider, versionTag, stateMetadataStorage, stateDbStorage, Seq()) {
       override def getView: AccountStateView = stateViewMock
     }
 
@@ -604,6 +609,7 @@ class AccountSidechainNodeViewHolderPerfTest
         new MockedAccountSidechainNodeViewHolder(
           sidechainSettings,
           params,
+          sc2scConfig,
           timeProvider,
           historyStorage,
           consensusDataStorage,

--- a/sdk/src/test/scala/com/horizen/account/sc2sc/AbstractCrossChainMessageProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/sc2sc/AbstractCrossChainMessageProcessorTest.scala
@@ -1,0 +1,116 @@
+package com.horizen.account.sc2sc
+
+import java.math.BigInteger
+import java.util
+import com.google.common.primitives.{Bytes, Ints}
+import com.horizen.account.state.{AccountStateView, ExecutionFailedException}
+import com.horizen.params.MainNetParams
+import com.horizen.utils.{ByteArrayWrapper, BytesUtils}
+import org.junit.Assert.{assertArrayEquals, assertFalse, assertTrue}
+import org.junit.Test
+import org.mockito.{ArgumentMatchers, Mockito}
+import org.scalatestplus.junit.JUnitSuite
+import org.scalatestplus.mockito.MockitoSugar
+import scala.util.Random
+
+class AbstractCrossChainMessageProcessorTest extends JUnitSuite with MockitoSugar with CrossChainMessageProcessorFixture {
+
+
+  @Test
+  def testInit(): Unit = {
+    val mockStateView = mock[AccountStateView]
+    Mockito
+      .when(mockStateView.addAccount(ArgumentMatchers.any[Array[Byte]], ArgumentMatchers.any[Array[Byte]]))
+      .thenAnswer(args => {
+        assertArrayEquals("Different address expected.", CrossChainMessageProcessorTestImpl.contractAddress, args.getArgument(0))
+        assertArrayEquals("Different code expected.", CrossChainMessageProcessorTestImpl.contractCode, args.getArgument(1))
+      })
+    getMessageProcessorTestImpl(MainNetParams()).init(mockStateView)
+  }
+
+  @Test
+  def testCanProcess(): Unit = {
+    val msg = listOfCrosschainMessages(1)
+    val mockStateView = mock[AccountStateView]
+    assertTrue(
+      "Message listOfCrosschainMessages cannot be processed",
+      getMessageProcessorTestImpl(MainNetParams()).canProcess(msg, mockStateView)
+    )
+    val wrongAddress = BytesUtils.fromHexString("35fdd51e73221f467b40946c97791a3e19799bea")
+    val msgNotProcessable = getMessage(wrongAddress, BigInteger.ZERO, Array.emptyByteArray)
+    assertFalse(
+      "Message not for WithdrawalMsgProcessor can be processed",
+      getMessageProcessorTestImpl(MainNetParams()).canProcess(msgNotProcessable, mockStateView)
+    )
+  }
+
+  @Test
+  def testProcessWithWrongPArams(): Unit = {
+    val value = BigInteger.valueOf(1000000000L) // 1 zenny and 1 wei
+    val mockStateView = mock[AccountStateView]
+
+    // msgWithWrongFunctionCall processing should result in ExecutionFailed
+    val data = BytesUtils.fromHexString("99")
+    val msgWithWrongFunctionCall = getMessage(CrossChainMessageProcessorTestImpl.contractAddress, value, data)
+    assertThrows[ExecutionFailedException] {
+      withGas(getMessageProcessorTestImpl(MainNetParams()).process(msgWithWrongFunctionCall, mockStateView, _, defaultBlockContext))
+    }
+  }
+
+  @Test
+  def testGetListOfWithdrawalReqs(): Unit = {
+    val mockStateView = mock[AccountStateView]
+    val proc : AbstractCrossChainMessageProcessor  = getMessageProcessorTestImpl(MainNetParams())
+
+    val epochNum = 102
+
+    // No messages
+    val msg = listOfCrosschainMessages(epochNum)
+    val counterKey = getMessageProcessorTestImpl(MainNetParams()).getMessageEpochCounterKey(epochNum)
+    val numOfWithdrawalReqs = Bytes.concat(new Array[Byte](32 - Ints.BYTES), Ints.toByteArray(0))
+
+    Mockito
+      .when(mockStateView.getAccountStorage(CrossChainMessageProcessorTestImpl.contractAddress, counterKey))
+      .thenReturn(numOfWithdrawalReqs)
+
+    var returnData = withGas(proc.process(msg, mockStateView, _, defaultBlockContext))
+    val expectedListOfWR = new util.ArrayList[AccountCrossChainMessage]()
+    assertArrayEquals(CrosschainMessagesListEncoder.encode(expectedListOfWR), returnData)
+
+    // With 3 messages
+    val numOfMessages = 3
+    val numOfMessagesReqsInBytes =
+      Bytes.concat(new Array[Byte](32 - Ints.BYTES), Ints.toByteArray(numOfMessages))
+    Mockito
+      .when(mockStateView.getAccountStorage(CrossChainMessageProcessorTestImpl.contractAddress, counterKey))
+      .thenReturn(numOfMessagesReqsInBytes)
+
+
+    val mockMessageRequestsList = new util.HashMap[ByteArrayWrapper, Array[Byte]](numOfMessages)
+
+    for (index <- 1 to numOfMessages) {
+      val wr = AccountCrossChainMessage(
+          1,
+          Array.fill(20)(Random.nextInt().toByte),
+          Array.fill(20)(Random.nextInt().toByte),
+          Array.fill(20)(Random.nextInt().toByte),
+          Array.fill(20)(Random.nextInt().toByte)
+        )
+      expectedListOfWR.add(wr)
+      val key = proc.getMessageKey(epochNum, index)
+      mockMessageRequestsList.put(new ByteArrayWrapper(key), wr.bytes)
+    }
+
+    Mockito
+      .when(mockStateView.getAccountStorageBytes(ArgumentMatchers.any[Array[Byte]], ArgumentMatchers.any[Array[Byte]]))
+      .thenAnswer(answer => {
+        val key: Array[Byte] = answer.getArgument(1)
+        mockMessageRequestsList.get(new ByteArrayWrapper(key))
+      })
+
+    returnData = withGas(proc.process(msg, mockStateView, _, defaultBlockContext), 10000000)
+    assertArrayEquals(CrosschainMessagesListEncoder.encode(expectedListOfWR), returnData)
+  }
+
+
+}

--- a/sdk/src/test/scala/com/horizen/account/sc2sc/CrossChainMessageProcessorFixture.scala
+++ b/sdk/src/test/scala/com/horizen/account/sc2sc/CrossChainMessageProcessorFixture.scala
@@ -1,0 +1,51 @@
+package com.horizen.account.sc2sc
+
+import java.math.BigInteger
+import com.google.common.primitives.Bytes
+import com.horizen.account.abi.ABIUtil.getFunctionSignature
+import com.horizen.account.state.{AccountStateViewGasTracked,  BaseAccountStateView, BlockContext, ExecutionFailedException, ExecutionRevertedException, GasPool, Message, MessageProcessorFixture, WithdrawalMsgProcessor}
+import com.horizen.params.NetworkParams
+import com.horizen.proposition.MCPublicKeyHashProposition
+import com.horizen.utils.BytesUtils
+import scorex.crypto.hash.Keccak256
+
+trait CrossChainMessageProcessorFixture extends MessageProcessorFixture {
+
+  val mcAddr = new MCPublicKeyHashProposition(randomBytes(20))
+
+  def getMessageProcessorTestImpl(networkParams: NetworkParams) : AbstractCrossChainMessageProcessor = {
+     new CrossChainMessageProcessorTestImpl(networkParams)
+  }
+
+  def listOfCrosschainMessages(epochNun: Int): Message = {
+    val params = GetListOfCrosschainMessagesInputCmd(epochNun).encode()
+    val data = Bytes.concat(BytesUtils.fromHexString(CrossChainMessageProcessorTestImpl.GetListOfCrosschainMessagesCmdSig), params)
+    getMessage(CrossChainMessageProcessorTestImpl.contractAddress, BigInteger.ZERO, data)
+  }
+}
+
+class CrossChainMessageProcessorTestImpl(networkParams: NetworkParams)  extends AbstractCrossChainMessageProcessor(networkParams)  {
+
+  override val contractAddress: Array[Byte] = CrossChainMessageProcessorTestImpl.contractAddress
+  override val contractCode: Array[Byte] =   CrossChainMessageProcessorTestImpl.contractCode
+
+  @throws(classOf[ExecutionFailedException])
+  override def process(msg: Message, view: BaseAccountStateView, gas: GasPool, blockContext: BlockContext): Array[Byte] = {
+    val gasView = new AccountStateViewGasTracked(view, gas)
+    getFunctionSignature(msg.getData) match {
+      case CrossChainMessageProcessorTestImpl.GetListOfCrosschainMessagesCmdSig =>
+        execGetListOfCrosschainMessages(msg, gasView)
+      case functionSig =>
+        throw new ExecutionRevertedException(s"Requested function does not exist. Function signature: $functionSig")
+    }
+  }
+
+
+}
+
+object CrossChainMessageProcessorTestImpl extends CrossChainMessageProcessorConstants {
+  override val contractAddress: Array[Byte] = BytesUtils.fromHexString("0000000000000000000001111111111111111111")
+  override val contractCode: Array[Byte] = Keccak256.hash("CrossChainMessageProcessorTestImplCode")
+}
+
+

--- a/sdk/src/test/scala/com/horizen/account/state/AccountStateTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/AccountStateTest.scala
@@ -15,6 +15,8 @@ import sparkz.core.VersionTag
 import sparkz.core.utils.NetworkTimeProvider
 import java.math.BigInteger
 
+import com.horizen.sc2sc.Sc2ScConfigurator
+
 
 class AccountStateTest
   extends JUnitSuite
@@ -26,6 +28,7 @@ class AccountStateTest
 {
 
   val params: MainNetParams = MainNetParams()
+  val sc2ScConfigurator: Sc2ScConfigurator = Sc2ScConfigurator(false, false)
   var state: AccountState = _
   val metadataStorage: AccountStateMetadataStorage = mock[AccountStateMetadataStorage]
 
@@ -37,7 +40,7 @@ class AccountStateTest
     val versionTag: VersionTag = VersionTag @@ BytesUtils.toHexString(getVersion.data())
     val mockedTimeProvider: NetworkTimeProvider = mock[NetworkTimeProvider]
 
-    state = new AccountState(params, mockedTimeProvider, versionTag, metadataStorage, stateDbStorege, messageProcessors)
+    state = new AccountState(params, sc2ScConfigurator, mockedTimeProvider, versionTag, metadataStorage, stateDbStorege, messageProcessors)
   }
 
   @Test

--- a/sdk/src/test/scala/com/horizen/account/state/AccountStateViewTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/AccountStateViewTest.scala
@@ -1,8 +1,12 @@
 package com.horizen.account.state
 
+import com.horizen.account.fixtures.AccountCrossChainMessageFixture
+import com.horizen.account.sc2sc.{AbstractCrossChainMessageProcessor, AccountCrossChainMessage, CrossChainMessageProvider}
 import com.horizen.account.storage.AccountStateMetadataStorageView
 import com.horizen.account.utils.ZenWeiConverter
+import com.horizen.cryptolibprovider.{CryptoLibProvider}
 import com.horizen.evm.StateDB
+import com.horizen.params.MainNetParams
 import com.horizen.proposition.MCPublicKeyHashProposition
 import com.horizen.utils.WithdrawalEpochUtils.MaxWithdrawalReqsNumPerEpoch
 import org.junit.Assert._
@@ -10,23 +14,29 @@ import org.junit._
 import org.mockito._
 import org.scalatestplus.junit.JUnitSuite
 import org.scalatestplus.mockito._
+import com.horizen.sc2sc.CrossChainMessage
 
 import scala.util.Random
 
-class AccountStateViewTest extends JUnitSuite with MockitoSugar {
+class AccountStateViewTest extends JUnitSuite
+  with MockitoSugar
+  with AccountCrossChainMessageFixture{
 
   var stateView: AccountStateView = _
+  var params = MainNetParams()
 
   @Before
   def setUp(): Unit = {
     val mockWithdrawalReqProvider = mock[WithdrawalRequestProvider]
+    val mocCrossChainReqProvider1 = mock[CrossChainMessageProvider]
+    val mocCrossChainReqProvider2 = mock[CrossChainMessageProvider]
     val messageProcessors: Seq[MessageProcessor] = Seq()
     val metadataStorageView: AccountStateMetadataStorageView =
       mock[AccountStateMetadataStorageView]
     val stateDb: StateDB = mock[StateDB]
     stateView = new AccountStateView(metadataStorageView, stateDb, messageProcessors) {
-      override lazy val withdrawalReqProvider: WithdrawalRequestProvider =
-        mockWithdrawalReqProvider
+      override lazy val withdrawalReqProvider: WithdrawalRequestProvider = mockWithdrawalReqProvider
+      override lazy val crossChainMessageProviders = Seq(mocCrossChainReqProvider1, mocCrossChainReqProvider2)
     }
   }
 
@@ -79,5 +89,52 @@ class AccountStateViewTest extends JUnitSuite with MockitoSugar {
       assertEquals("wrong address", destAddress, wr.proposition)
       assertEquals("wrong amount", index + 1, wr.valueInZennies)
     })
+  }
+
+  @Test
+  def testCrosschainMessages(): Unit = {
+    val epochNum = 102
+
+    // No messages
+    Mockito
+      .when(stateView.crossChainMessageProviders(0).getCrossChainMesssages(epochNum, stateView))
+      .thenReturn(Seq())
+    Mockito
+      .when(stateView.crossChainMessageProviders(1).getCrossChainMesssages(epochNum, stateView))
+      .thenReturn(Seq())
+
+    var res = stateView.getCrossChainMessages(epochNum)
+    assertTrue("The list of crosschain messages is not empty", res.isEmpty)
+
+    // With some cross chain messages from different providers
+    var fakeMessages : List[CrossChainMessage] = List()
+    (0 until 3).foreach(index => {
+      fakeMessages = fakeMessages :+  AbstractCrossChainMessageProcessor.buildCrosschainMessageFromAccount( getRandomAccountCrossMessage(index), params)
+    })
+
+    Mockito
+      .when(stateView.crossChainMessageProviders(0).getCrossChainMesssages(epochNum, stateView))
+      .thenReturn(Seq(fakeMessages(0), fakeMessages(1)))
+    Mockito
+      .when(stateView.crossChainMessageProviders(1).getCrossChainMesssages(epochNum, stateView))
+      .thenReturn(Seq(fakeMessages(2)))
+
+    res = stateView.getCrossChainMessages(epochNum)
+
+    assertEquals("Wrong list of crosschain messages size", 3, res.size)
+    (0 until 3).foreach(index => {
+      val wr : CrossChainMessage = res(index)
+      assertEquals("wrong address", fakeMessages(index).getMessageType, wr.getMessageType)
+      assertEquals("wrong payload", fakeMessages(index).getPayload, wr.getPayload)
+    })
+
+    val messageHash =  CryptoLibProvider.sc2scCircuitFunctions.getCrossChainMessageHash(res(1))
+    Mockito
+      .when(stateView.crossChainMessageProviders(0).getCrossChainMessageHashEpoch(messageHash, stateView))
+      .thenReturn(Some(epochNum))
+
+    assertTrue("Crosschain message hash not found", stateView.getCrossChainMessageHashEpoch(messageHash).isDefined )
+    assertEquals("Crosschain message hash epoch incorrect",  epochNum, stateView.getCrossChainMessageHashEpoch(messageHash).get)
+
   }
 }

--- a/sdk/src/test/scala/com/horizen/account/storage/AccountStateMetadataStorageViewTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/storage/AccountStateMetadataStorageViewTest.scala
@@ -51,6 +51,8 @@ class AccountStateMetadataStorageViewTest
     assertTrue("Block fee info should be empty in view", storageView.getFeePayments(0).isEmpty)
     assertTrue("Block fee info should be empty in storage", stateMetadataStorage.getFeePayments(0).isEmpty)
 
+    assertTrue("Top certificate mainchain hash should be empty in view", storageView.getTopCertificateMainchainHash(0).isEmpty)
+
     assertTrue("Consensus epoch number should be empty in view", storageView.getConsensusEpochNumber.isEmpty)
     assertTrue("Consensus epoch number should be empty in storage", stateMetadataStorage.getConsensusEpochNumber.isEmpty)
 
@@ -75,8 +77,11 @@ class AccountStateMetadataStorageViewTest
     assertEquals("Block fee is present in storage", 0, stateMetadataStorage.getFeePayments(currentEpoch).size)
 
     storageView.updateTopQualityCertificate(generateCertificateWithEpochNumber(currentEpoch))
+    storageView.addTopCertificateMainchainHash(currentEpoch, generateRandomMainchainHash())
     assertFalse("Certificate is not present in view", storageView.getTopQualityCertificate(currentEpoch).isEmpty)
     assertTrue("Certificate is present in storage", stateMetadataStorage.getTopQualityCertificate(currentEpoch).isEmpty)
+    assertFalse("Top certificate mainchain hash is not present in view", storageView.getTopCertificateMainchainHash(currentEpoch).isEmpty)
+    assertTrue("Top certificate mainchain hash is present in storage", stateMetadataStorage.getTopCertificateMainchainHash(currentEpoch).isEmpty)
 
     // Check state root of empty storage and view
     assertArrayEquals("Non-default account state was set in the view", DEFAULT_ACCOUNT_STATE_ROOT, storageView.getAccountStateRoot)
@@ -116,6 +121,8 @@ class AccountStateMetadataStorageViewTest
       stateMetadataStorage.getAccountStateRoot)
     assertEquals("Certificate is different in view and in storage after a commit", storageView.getTopQualityCertificate(currentEpoch).get.epochNumber,
       stateMetadataStorage.getTopQualityCertificate(currentEpoch).get.epochNumber)
+    assertArrayEquals("Top certificate mainchain hash is different in view and in storage after a commit", storageView.getTopCertificateMainchainHash(currentEpoch).get,
+      stateMetadataStorage.getTopCertificateMainchainHash(currentEpoch).get)
 
     assertEquals("Height after commit should be 1 in view", 1, storageView.getHeight)
     assertEquals("Height after commit should be 1 in storage", 1, stateMetadataStorage.getHeight)

--- a/sdk/src/test/scala/com/horizen/api/http/Sc2ScApiRouteTest.scala
+++ b/sdk/src/test/scala/com/horizen/api/http/Sc2ScApiRouteTest.scala
@@ -1,0 +1,130 @@
+package com.horizen.api.http
+
+import akka.actor.ActorRef
+import akka.http.scaladsl.model.{ContentTypes, HttpMethods, StatusCodes}
+import akka.http.scaladsl.server.{MalformedRequestContentRejection, MethodRejection, Route}
+import akka.testkit
+import akka.testkit.{TestActor, TestProbe}
+import com.horizen.account.sc2sc.CrossChainMessageProcessorFixture
+import com.horizen.api.http.Sc2scApiRouteRestScheme.{CrossChainMessageEle, ReqCreateRedeemMessage}
+import com.horizen.sc2sc.Sc2scProver.ReceivableMessages.BuildRedeemMessage
+import com.horizen.sc2sc.{CrossChainMessage, CrossChainMessageImpl, CrossChainProtocolVersion, CrossChainRedeemMessageImpl}
+import com.horizen.serialization.SerializationUtil
+import com.horizen.utils.BytesUtils
+import org.junit.Assert.{assertEquals, assertTrue}
+import sparkz.core.NodeViewHolder.CurrentView
+import scala.collection.JavaConverters.asScalaIteratorConverter
+import scala.util.{Failure, Success}
+import com.horizen.sc2sc.Sc2ScException
+
+
+class Sc2ScApiRouteTest extends SidechainApiRouteTest with CrossChainMessageProcessorFixture{
+  override val basePath = "/sc2sc/"
+  type NodeView = CurrentView[Any, Any, Any, Any]
+  var   mockSc2scProver = getMockSc2ScProver()
+  val sc2scApiRoute: Route = Sc2scApiRoute(mockedRESTSettings, mockedSidechainNodeViewHolder.ref, mockSc2scProver).route
+
+  var simulateEnError = false
+
+  val testCrossChainMessage =    new CrossChainMessageEle(
+    CrossChainProtocolVersion.VERSION_1,
+    1 ,
+    BytesUtils.toHexString(getRandomBytes(14)),
+    BytesUtils.toHexString(getRandomBytes(14)),
+    BytesUtils.toHexString(getRandomBytes(14)),
+    BytesUtils.toHexString(getRandomBytes(14)),
+    BytesUtils.toHexString("testPayload".getBytes))
+
+  "The Api should to" should {
+
+    "reject and reply with http error" in {
+      Get(basePath) ~> sc2scApiRoute ~> check {
+        rejection shouldBe MethodRejection(HttpMethods.POST)
+      }
+      Get(basePath) ~> Route.seal(sc2scApiRoute) ~> check {
+        status.intValue() shouldBe StatusCodes.MethodNotAllowed.intValue
+        responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
+      }
+      Post(basePath + "createRedeemMessage").withEntity("maybe_a_json") ~> sc2scApiRoute ~> check {
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+      }
+    }
+
+    "reply at /createRedeemMessage" in {
+      Post(basePath + "createRedeemMessage").withHeaders(apiTokenHeader)
+        .withEntity(SerializationUtil.serialize(
+          ReqCreateRedeemMessage(testCrossChainMessage)
+          )) ~> sc2scApiRoute ~> check {
+        status.intValue() shouldBe StatusCodes.OK.intValue
+        responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
+        val result = mapper.readTree(entityAs[String]).get("result")
+        if (result == null)
+          fail("Serialization failed for object SidechainApiResponseBody")
+        assertEquals(1, result.elements().asScala.length)
+        assertTrue(result.get("redeemMessage").isObject)
+        assertEquals(6, result.get("redeemMessage").elements().asScala.length)
+        assertTrue(result.get("redeemMessage").get("proof").isTextual)
+        assertTrue(result.get("redeemMessage").get("proof").asText().equals(BytesUtils.toHexString(redeemMesssage.getProof)))
+      }
+    }
+
+    "reply with error at /createRedeemMessage" in {
+      simulateEnError = true
+      Post(basePath + "createRedeemMessage").withHeaders(apiTokenHeader)
+        .withEntity(SerializationUtil.serialize(
+          ReqCreateRedeemMessage(testCrossChainMessage)
+        )) ~> sc2scApiRoute ~> check {
+        status.intValue() shouldBe StatusCodes.OK.intValue
+        responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
+        val result = mapper.readTree(entityAs[String]).get("error")
+        if (result == null)
+          fail("Serialization failed for object SidechainApiResponseBody")
+        assertEquals(3, result.elements().asScala.length)
+        assertTrue(result.get("description").isTextual)
+        assertTrue(result.get("description").asText().equals("Failed to create redeem message"))
+        assertTrue(result.get("detail").isTextual)
+        assertTrue(result.get("detail").asText().equals(anErrorDetail))
+
+      }
+    }
+  }
+
+  def getRandomBytes(num: Int) = {
+    val bytes = new Array[Byte](num)
+    scala.util.Random.nextBytes(bytes)
+    bytes
+  }
+
+  def getMockSc2ScProver() = {
+    val mockProver = TestProbe()
+    mockProver.setAutoPilot(new testkit.TestActor.AutoPilot {
+      override def run(sender: ActorRef, msg: Any): TestActor.AutoPilot = {
+        msg match {
+          case BuildRedeemMessage(message: CrossChainMessage) =>
+            simulateEnError match {
+              case true =>  sender ! Failure(new Sc2ScException(anErrorDetail))
+              case false =>  sender ! Success(redeemMesssage)
+            }
+
+        }
+        TestActor.KeepRunning
+      }
+    })
+    mockProver.ref
+  }
+
+  var anErrorDetail ="Dummy error detail"
+
+  var redeemMesssage = new CrossChainRedeemMessageImpl(
+    new CrossChainMessageImpl(
+      CrossChainProtocolVersion.VERSION_1,
+      1,
+      getRandomBytes(14),
+      getRandomBytes(14),
+      getRandomBytes(14),
+      getRandomBytes(14),
+      getRandomBytes(14)
+    ),
+    getRandomBytes(14), getRandomBytes(14), getRandomBytes(14), getRandomBytes(14), getRandomBytes(14)
+  )
+}

--- a/sdk/src/test/scala/com/horizen/api/http/SidechainApiRouteTest.scala
+++ b/sdk/src/test/scala/com/horizen/api/http/SidechainApiRouteTest.scala
@@ -346,7 +346,7 @@ abstract class SidechainApiRouteTest extends AnyWordSpec with Matchers with Scal
 
   val customBoxesSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]] = new JHashMap()
   customBoxesSerializers.put(CustomBox.BOX_TYPE_ID, CustomBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers)
+  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers, false)
   val mockedStorageIterator: StorageIterator = mock[StorageIterator]
   var boxList: ListBuffer[SidechainTypes#SCB] = new ListBuffer[SidechainTypes#SCB]()
   boxList ++= getCustomBoxList(3).asScala.map(_.asInstanceOf[SidechainTypes#SCB])

--- a/sdk/src/test/scala/com/horizen/block/WithdrawalEpochCertificateFixture.scala
+++ b/sdk/src/test/scala/com/horizen/block/WithdrawalEpochCertificateFixture.scala
@@ -26,4 +26,6 @@ trait WithdrawalEpochCertificateFixture {
       Seq(),
       Seq())
   }
+
+  def generateRandomMainchainHash(): Array[Byte] = getBytes()
 }

--- a/sdk/src/test/scala/com/horizen/certificatesubmitter/CertificateSubmitterTest.scala
+++ b/sdk/src/test/scala/com/horizen/certificatesubmitter/CertificateSubmitterTest.scala
@@ -22,6 +22,7 @@ import com.horizen.fork.{ForkManagerUtil, SimpleForkConfigurator}
 import com.horizen.node.util.MainchainBlockReferenceInfo
 import com.horizen.params.{CommonParams, NetworkParams, RegTestParams}
 import com.horizen.proposition.{Proposition, SchnorrProposition}
+import com.horizen.sc2sc.Sc2ScConfigurator
 import com.horizen.secret.{SchnorrKeyGenerator, SchnorrSecret}
 import com.horizen.storage.SidechainHistoryStorage
 import com.horizen.transaction.MC2SCAggregatedTransaction
@@ -54,6 +55,7 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
   implicit val executionContext: ExecutionContext = actorSystem.dispatchers.lookup("sparkz.executionContext")
   implicit val timeout: Timeout = 100 milliseconds
   private var consensusEpochAtWhichForkIsApplied: Int = _
+  private var sc2scConfig_noSc2sc = Sc2ScConfigurator(false, false)
 
   @Before
   def init(): Unit = {
@@ -106,9 +108,9 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mainchainChannel: MainchainNodeChannel = mock[MainchainNodeChannel]
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc,  mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
     actorSystem.eventStream.subscribe(certificateSubmitterRef, SidechainAppEvents.SidechainApplicationStart.getClass)
 
     actorSystem.eventStream.publish(SidechainAppEvents.SidechainApplicationStart)
@@ -150,9 +152,9 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mainchainChannel: MainchainNodeChannel = mock[MainchainNodeChannel]
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
     actorSystem.eventStream.subscribe(certificateSubmitterRef, SidechainAppEvents.SidechainApplicationStart.getClass)
 
     actorSystem.eventStream.publish(SidechainAppEvents.SidechainApplicationStart)
@@ -192,9 +194,9 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mainchainChannel: MainchainNodeChannel = mock[MainchainNodeChannel]
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
     actorSystem.eventStream.subscribe(certificateSubmitterRef, SidechainAppEvents.SidechainApplicationStart.getClass)
 
     actorSystem.eventStream.publish(SidechainAppEvents.SidechainApplicationStart)
@@ -234,9 +236,9 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mainchainChannel: MainchainNodeChannel = mock[MainchainNodeChannel]
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc,  mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
     actorSystem.eventStream.subscribe(certificateSubmitterRef, SidechainAppEvents.SidechainApplicationStart.getClass)
 
     actorSystem.eventStream.publish(SidechainAppEvents.SidechainApplicationStart)
@@ -277,9 +279,9 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mainchainChannel: MainchainNodeChannel = mock[MainchainNodeChannel]
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
     actorSystem.eventStream.subscribe(certificateSubmitterRef, SidechainAppEvents.SidechainApplicationStart.getClass)
 
     actorSystem.eventStream.publish(SidechainAppEvents.SidechainApplicationStart)
@@ -307,9 +309,9 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mainchainChannel: MainchainNodeChannel = mock[MainchainNodeChannel]
     val params: NetworkParams = mock[NetworkParams]
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], mock[NetworkParams], mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], mock[NetworkParams], mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
 
     val submitter: CertificateSubmitter[CertificateDataWithoutKeyRotation] = certificateSubmitterRef.underlyingActor
 
@@ -341,9 +343,9 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mainchainChannel: MainchainNodeChannel = mock[MainchainNodeChannel]
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
     val params: NetworkParams = mock[NetworkParams]
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], mock[NetworkParams], mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], mock[NetworkParams], mainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
 
     val submitter: CertificateSubmitter[CertificateDataWithoutKeyRotation] = certificateSubmitterRef.underlyingActor
 
@@ -412,10 +414,10 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
 
     // TODO: add cases for NonCeasingStrategy
     val mainchainChannel: MainchainNodeChannel = mock[MainchainNodeChannel]
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val submissionStrategy: CertificateSubmissionStrategy = new CeasingSidechain(mockedMainchainChannel, params)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, submissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mainchainChannel, submissionStrategy, keyRotationStrategy)))
 
     val submitter: CertificateSubmitter[CertificateDataWithoutKeyRotation] = certificateSubmitterRef.underlyingActor
 
@@ -752,11 +754,11 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mockedSettings: SidechainSettings = getMockedSettings(timeout.duration * 100, submitterIsEnabled = true, signerIsEnabled = true)
     val dustThreshold = ZenCoinsUtils.getMinDustThreshold(ZenCoinsUtils.MC_DEFAULT_FEE_RATE)
     val params: NetworkParams = mock[NetworkParams]
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
     val submitter: CertificateSubmitter[CertificateDataWithoutKeyRotation] = TestActorRef(Props(
-      new CertificateSubmitter(mockedSettings, mock[ActorRef], mock[SecureEnclaveApiClient], mock[NetworkParams], mock[MainchainNodeChannel], mockedSubmissionStrategy, keyRotationStrategy)
+      new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mock[ActorRef], mock[SecureEnclaveApiClient], mock[NetworkParams], mock[MainchainNodeChannel], mockedSubmissionStrategy, keyRotationStrategy)
     )).underlyingActor
 
     assertEquals("Before the fork, ftMinAmount should be 0",
@@ -797,11 +799,11 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     })
     val mockedSidechainNodeViewHolderRef: ActorRef = mockedSidechainNodeViewHolder.ref
 
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mockedMainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mockedMainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
 
     val submitter: CertificateSubmitter[CertificateDataWithoutKeyRotation] = certificateSubmitterRef.underlyingActor
 
@@ -930,11 +932,11 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     })
     val mockedSidechainNodeViewHolderRef: ActorRef = mockedSidechainNodeViewHolder.ref
 
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mockedMainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings,  sc2scConfig_noSc2sc, mockedSidechainNodeViewHolderRef, mock[SecureEnclaveApiClient], params, mockedMainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
 
     val submitter: CertificateSubmitter[CertificateDataWithoutKeyRotation] = certificateSubmitterRef.underlyingActor
 
@@ -992,9 +994,9 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mockedSidechainNodeViewHolder = TestProbe()
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolder.ref, mock[SecureEnclaveApiClient], params, mockedMainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mockedSidechainNodeViewHolder.ref, mock[SecureEnclaveApiClient], params, mockedMainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
 
     val submitter: CertificateSubmitter[CertificateDataWithoutKeyRotation] = certificateSubmitterRef.underlyingActor
 
@@ -1036,9 +1038,9 @@ class CertificateSubmitterTest extends JUnitSuite with MockitoSugar {
     val mockedSidechainNodeViewHolder = TestProbe()
     val mockedSubmissionStrategy: CertificateSubmissionStrategy = mock[CertificateSubmissionStrategy]
 
-    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
+    val keyRotationStrategy: CircuitStrategy[SidechainTypes#SCBT, SidechainBlockHeader, SidechainBlock, SidechainHistory, SidechainState, _ <: CertificateData] = new WithoutKeyRotationCircuitStrategy(mockedSettings, sc2scConfig_noSc2sc, params, CryptoLibProvider.sigProofThresholdCircuitFunctions)
     val certificateSubmitterRef: TestActorRef[CertificateSubmitter[CertificateDataWithoutKeyRotation]] = TestActorRef(
-      Props(new CertificateSubmitter(mockedSettings, mockedSidechainNodeViewHolder.ref, mock[SecureEnclaveApiClient], params, mockedMainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
+      Props(new CertificateSubmitter(mockedSettings, sc2scConfig_noSc2sc, mockedSidechainNodeViewHolder.ref, mock[SecureEnclaveApiClient], params, mockedMainchainChannel, mockedSubmissionStrategy, keyRotationStrategy)))
 
     val submitter: CertificateSubmitter[CertificateDataWithoutKeyRotation] = certificateSubmitterRef.underlyingActor
 

--- a/sdk/src/test/scala/com/horizen/companion/SidechainBoxesCompanionTest.scala
+++ b/sdk/src/test/scala/com/horizen/companion/SidechainBoxesCompanionTest.scala
@@ -21,8 +21,8 @@ class SidechainBoxesCompanionTest
   var customBoxesSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]] = new JHashMap()
   customBoxesSerializers.put(CustomBox.BOX_TYPE_ID, CustomBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
 
-  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers)
-  val sidechainBoxesCompanionCore = SidechainBoxesCompanion(new JHashMap())
+  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers, false)
+  val sidechainBoxesCompanionCore = SidechainBoxesCompanion(new JHashMap(), false)
 
   @Test
   def testCore(): Unit = {

--- a/sdk/src/test/scala/com/horizen/fixtures/BoxFixture.scala
+++ b/sdk/src/test/scala/com/horizen/fixtures/BoxFixture.scala
@@ -6,11 +6,13 @@ import com.horizen.box._
 import com.horizen.proposition.{MCPublicKeyHashProposition, Proposition, PublicKey25519Proposition, VrfPublicKey}
 import com.horizen.secret.PrivateKey25519
 import java.util.{ArrayList => JArrayList, List => JList}
-import com.horizen.box.data.{ForgerBoxData, WithdrawalRequestBoxData, ZenBoxData}
+
+import com.horizen.box.data.{CrossChainMessageBoxData, ForgerBoxData, WithdrawalRequestBoxData, ZenBoxData}
 import com.horizen.{SidechainTypes, WalletBox}
 
 import scala.util.Random
 import com.horizen.customtypes._
+import com.horizen.sc2sc.CrossChainProtocolVersion
 import com.horizen.utils.ZenCoinsUtils
 
 import scala.collection.JavaConverters._
@@ -46,6 +48,34 @@ trait BoxFixture
     new ZenBox(new ZenBoxData(proposition, value), nonce)
   }
 
+  def getCrossMessageBox(proposition: PublicKey25519Proposition,
+                         protocolVersion: CrossChainProtocolVersion,
+                         messageType: Integer,
+                         receiverSidechain: Array[Byte],
+                         receiverAddress: Array[Byte],
+                         payload: Array[Byte],
+                         nonce: Long
+                        ): CrossChainMessageBox = {
+    new CrossChainMessageBox(new CrossChainMessageBoxData(proposition, protocolVersion,
+      messageType, receiverSidechain, receiverAddress, payload), nonce)
+  }
+
+  def getRandomCrossMessageBox(seed: Long): CrossChainMessageBox ={
+    val random: Random = new Random(seed)
+    val receiverSidechain = new Array[Byte](32)
+    random.nextBytes(receiverSidechain)
+    val receiverAddress = new Array[Byte](16)
+    random.nextBytes(receiverAddress)
+    getCrossMessageBox(
+      getPrivateKey25519(Longs.toByteArray(random.nextLong())).publicImage(),
+      CrossChainProtocolVersion.VERSION_1,
+      1,
+      receiverSidechain,
+      receiverAddress,
+      "my payload".getBytes,
+      random.nextLong()
+    )
+  }
 
   def getZenBoxList(count: Int): JList[ZenBox] = {
     val boxList: JList[ZenBox] = new JArrayList[ZenBox]()

--- a/sdk/src/test/scala/com/horizen/fixtures/MockedSidechainNodeViewHolderFixture.scala
+++ b/sdk/src/test/scala/com/horizen/fixtures/MockedSidechainNodeViewHolderFixture.scala
@@ -11,7 +11,7 @@ class MockedSidechainNodeViewHolder(sidechainSettings: SidechainSettings,
                                     state: SidechainState,
                                     wallet: SidechainWallet,
                                     mempool: SidechainMemoryPool)
-  extends SidechainNodeViewHolder(sidechainSettings, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null ) {
+  extends SidechainNodeViewHolder(sidechainSettings, null, null, null, null, null, null, null, null, null, null, null, null,  null,null, null, null, null ) {
 
   override def dumpStorages: Unit = {}
 

--- a/sdk/src/test/scala/com/horizen/fixtures/SidechainNodeViewHolderFixture.scala
+++ b/sdk/src/test/scala/com/horizen/fixtures/SidechainNodeViewHolderFixture.scala
@@ -2,6 +2,7 @@ package com.horizen.fixtures
 
 import java.lang.{Byte => JByte}
 import java.util.{HashMap => JHashMap}
+
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler}
 import akka.stream.ActorMaterializer
@@ -15,6 +16,7 @@ import com.horizen.customconfig.CustomAkkaConfiguration
 import com.horizen.customtypes.{DefaultApplicationState, DefaultApplicationWallet}
 import com.horizen.fork.{ForkManagerUtil, SimpleForkConfigurator}
 import com.horizen.params.{MainNetParams, NetworkParams, RegTestParams, TestNetParams}
+import com.horizen.sc2sc.Sc2ScConfigurator
 import com.horizen.secret.{PrivateKey25519Serializer, SecretSerializer}
 import com.horizen.state.ApplicationState
 import com.horizen.storage._
@@ -109,6 +111,7 @@ trait SidechainNodeViewHolderFixture
   val forgingBoxesMerklePathStorage = new ForgingBoxesInfoStorage(getStorage())
   val cswDataProvider: SidechainWalletCswDataProvider = SidechainWalletCswDataProviderCSWEnabled(new SidechainWalletCswDataStorage(getStorage()))
   val backupStorage = new BackupStorage(getStorage(), sidechainBoxesCompanion)
+  val sc2scConfig = Sc2ScConfigurator(false, false)
 
   // Append genesis secrets if we start the node first time
   if(sidechainSecretStorage.isEmpty) {
@@ -130,6 +133,7 @@ trait SidechainNodeViewHolderFixture
     cswDataProvider,
     backupStorage,
     params,
+    sc2scConfig,
     timeProvider,
     defaultApplicationWallet,
     defaultApplicationState,

--- a/sdk/src/test/scala/com/horizen/fixtures/SidechainNodeViewHolderFixture.scala
+++ b/sdk/src/test/scala/com/horizen/fixtures/SidechainNodeViewHolderFixture.scala
@@ -50,7 +50,7 @@ trait SidechainNodeViewHolderFixture
 
   val timeProvider = new NetworkTimeProvider(sidechainSettings.sparkzSettings.ntp)
 
-  val sidechainBoxesCompanion: SidechainBoxesCompanion =  SidechainBoxesCompanion(new JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]]())
+  val sidechainBoxesCompanion: SidechainBoxesCompanion =  SidechainBoxesCompanion(new JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]](), false)
   val sidechainSecretsCompanion: SidechainSecretsCompanion = SidechainSecretsCompanion(new JHashMap[JByte, SecretSerializer[SidechainTypes#SCS]]())
   val sidechainTransactionsCompanion: SidechainTransactionsCompanion = getDefaultTransactionsCompanion
   val defaultApplicationWallet: ApplicationWallet = new DefaultApplicationWallet()

--- a/sdk/src/test/scala/com/horizen/forge/ForgerTest.scala
+++ b/sdk/src/test/scala/com/horizen/forge/ForgerTest.scala
@@ -6,6 +6,7 @@ import com.horizen.block.SidechainBlock
 import com.horizen.companion.SidechainTransactionsCompanion
 import com.horizen.forge.AbstractForger.ReceivableMessages.StartForging
 import com.horizen.params.NetworkParams
+import com.horizen.sc2sc.Sc2ScConfigurator
 import com.horizen.{SidechainSettings, WebSocketSettings}
 import org.junit.Test
 import org.mockito.Mockito.when
@@ -66,7 +67,7 @@ class ForgerTest extends JUnitSuite with Matchers {
     val mainchainSynchronizer = mock[MainchainSynchronizer]
     val companion = mock[SidechainTransactionsCompanion]
 
-    val forgeMessageBuilder: ForgeMessageBuilder = new ForgeMessageBuilder(mainchainSynchronizer, companion, params, settings.websocket.allowNoConnectionInRegtest)
+    val forgeMessageBuilder: ForgeMessageBuilder = new ForgeMessageBuilder(mainchainSynchronizer, companion, Sc2ScConfigurator(false, false), params, settings.websocket.allowNoConnectionInRegtest)
 
     class ForgerUnderTest(settings: SidechainSettings,
                      viewHolderRef: ActorRef,

--- a/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/SidechainStateIntegrationTest.scala
@@ -37,7 +37,7 @@ class SidechainStateIntegrationTest
     with MockitoSugar
     with SidechainTypesTestsExtension
 {
-  val sidechainBoxesCompanion = SidechainBoxesCompanion(new JHashMap())
+  val sidechainBoxesCompanion = SidechainBoxesCompanion(new JHashMap(), false)
   val applicationState = new DefaultApplicationState()
 
   var stateStorage: SidechainStateStorage = _

--- a/sdk/src/test/scala/com/horizen/integration/storage/SidechainStateStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/storage/SidechainStateStorageTest.scala
@@ -59,8 +59,8 @@ class SidechainStateStorageTest
 
     // Test insert operation (empty storage).
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(version1, withdrawalEpochInfo, (bList1 ++ bList2).toSet, Set(), Seq(),
-        consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0).isSuccess)
+      sidechainStateStorage.update(version1, withdrawalEpochInfo, (bList1 ++ bList2).toSet, Set(), Seq(), Seq(),
+        consensusEpoch, Seq(), blockFeeInfo, None, false, new Array[Int](0), 0).isSuccess)
     assertEquals("Version in storage must be - " + version1,
       version1, sidechainStateStorage.lastVersionId.get)
     assertEquals("Storage must contain 1 version.",
@@ -77,7 +77,7 @@ class SidechainStateStorageTest
     val boxIdsToRemoveSet: Set[ByteArrayWrapper] = Set(new ByteArrayWrapper(bList1.head.id()), new ByteArrayWrapper(bList2.head.id()))
     assertTrue("Update(delete) operation must be successful.",
       sidechainStateStorage.update(version2, withdrawalEpochInfo, Set(),
-        boxIdsToRemoveSet, Seq(), consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0).isSuccess)
+        boxIdsToRemoveSet, Seq(), Seq(), consensusEpoch,  Seq(), blockFeeInfo, None, false, new Array[Int](0), 0).isSuccess)
 
     assertEquals("Version in storage must be - " + version2,
       version2, sidechainStateStorage.lastVersionId.get)
@@ -127,8 +127,8 @@ class SidechainStateStorageTest
     val mod1WithdrawalEpochInfo = WithdrawalEpochInfo(firstWithdrawalEpochNumber, 1)
     val mod1mcBlockHashInCertificate = Option(Array.fill(32)(rnd.nextInt().toByte))
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), withdrawalRequestsList,
-        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod1mcBlockHashInCertificate)), blockFeeInfo, None, false, new Array[Int](0), 0
+      sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), withdrawalRequestsList, Seq(),
+        consensusEpoch, Seq((generateWithdrawalEpochCertificate(mod1mcBlockHashInCertificate), generateRandomMainchainHash())), blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -154,8 +154,8 @@ class SidechainStateStorageTest
     val mod2WithdrawalEpochInfo = WithdrawalEpochInfo(firstWithdrawalEpochNumber, 2)
     val mod2mcBlockHashInCertificate = Option(Array.fill(32)(rnd.nextInt().toByte))
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), newWithdrawalRequestsList,
-        consensusEpoch, Option(generateWithdrawalEpochCertificate(mod2mcBlockHashInCertificate)), blockFeeInfo, None, false, new Array[Int](0), 0
+      sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), newWithdrawalRequestsList, Seq(),
+        consensusEpoch, Seq((generateWithdrawalEpochCertificate(mod2mcBlockHashInCertificate), generateRandomMainchainHash())), blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -182,8 +182,8 @@ class SidechainStateStorageTest
     val mod3WithdrawalEpochInfo = WithdrawalEpochInfo(secondWithdrawalEpochNumber, 1)
     val secondEpochWithdrawalRequestsList: List[WithdrawalRequestBox] = getWithdrawalRequestsBoxList(2).asScala.toList
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod3Version, mod3WithdrawalEpochInfo, Set(), Set(), secondEpochWithdrawalRequestsList,
-        consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0
+      sidechainStateStorage.update(mod3Version, mod3WithdrawalEpochInfo, Set(), Set(), secondEpochWithdrawalRequestsList, Seq(),
+        consensusEpoch, Seq(), blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
     // Check that first epoch withdrawals still exist -> no clean-up
@@ -196,8 +196,8 @@ class SidechainStateStorageTest
     val mod4WithdrawalEpochInfo = WithdrawalEpochInfo(thirdWithdrawalEpochNumber, 1)
     val thirdEpochWithdrawalRequestsList: List[WithdrawalRequestBox] = getWithdrawalRequestsBoxList(3).asScala.toList
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod4Version, mod4WithdrawalEpochInfo, Set(), Set(), thirdEpochWithdrawalRequestsList,
-        consensusEpoch, None, blockFeeInfo, None, false, new Array[Int](0), 0
+      sidechainStateStorage.update(mod4Version, mod4WithdrawalEpochInfo, Set(), Set(), thirdEpochWithdrawalRequestsList, Seq(),
+        consensusEpoch, Seq(), blockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
     // Check that first epoch withdrawals were removed.
@@ -237,8 +237,8 @@ class SidechainStateStorageTest
     val mod1BlockFeeInfo = BlockFeeInfo(100, getPrivateKey25519("mod1".getBytes()).publicImage())
 
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod1BlockFeeInfo, None, false, new Array[Int](0), 0
+      sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(), Seq(),
+        consensusEpoch, Seq(), mod1BlockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -258,8 +258,8 @@ class SidechainStateStorageTest
     val mod2BlockFeeInfo = BlockFeeInfo(200, getPrivateKey25519("mod2".getBytes()).publicImage())
 
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod2BlockFeeInfo, None, false, new Array[Int](0), 0
+      sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),Seq(),
+        consensusEpoch, Seq(), mod2BlockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -281,8 +281,8 @@ class SidechainStateStorageTest
     val mod3BlockFeeInfo = BlockFeeInfo(300, getPrivateKey25519("mod3".getBytes()).publicImage())
 
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod3Version, mod3WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod3BlockFeeInfo, None, false, new Array[Int](0), 0
+      sidechainStateStorage.update(mod3Version, mod3WithdrawalEpochInfo, Set(), Set(), Seq(), Seq(),
+        consensusEpoch, Seq(), mod3BlockFeeInfo, None, false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -329,8 +329,8 @@ class SidechainStateStorageTest
     val mod1BlockFeeInfo = BlockFeeInfo(100, getPrivateKey25519("mod1".getBytes()).publicImage())
 
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod1BlockFeeInfo, Some(utxoMerkleRoot1), scHasCeased = false, new Array[Int](0), 0
+      sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(), Seq(),
+        consensusEpoch, Seq(), mod1BlockFeeInfo, Some(utxoMerkleRoot1), scHasCeased = false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -348,8 +348,8 @@ class SidechainStateStorageTest
     val mod2BlockFeeInfo = BlockFeeInfo(100, getPrivateKey25519("mod1".getBytes()).publicImage())
 
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod2BlockFeeInfo, Some(utxoMerkleRoot2), scHasCeased = true, new Array[Int](0), 0
+      sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(), Seq(),
+        consensusEpoch, Seq(), mod2BlockFeeInfo, Some(utxoMerkleRoot2), scHasCeased = true, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -379,8 +379,8 @@ class SidechainStateStorageTest
     val mod1BlockFeeInfo = BlockFeeInfo(100, getPrivateKey25519("mod1".getBytes()).publicImage())
 
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod1BlockFeeInfo, None, scHasCeased = false, new Array[Int](0), 0
+      sidechainStateStorage.update(mod1Version, mod1WithdrawalEpochInfo, Set(), Set(), Seq(), Seq(),
+        consensusEpoch, Seq(), mod1BlockFeeInfo, None, scHasCeased = false, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -394,8 +394,8 @@ class SidechainStateStorageTest
     val mod2BlockFeeInfo = BlockFeeInfo(100, getPrivateKey25519("mod1".getBytes()).publicImage())
 
     assertTrue("Update(insert) must be successful.",
-      sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(),
-        consensusEpoch, None, mod2BlockFeeInfo, None, scHasCeased = true, new Array[Int](0), 0
+      sidechainStateStorage.update(mod2Version, mod2WithdrawalEpochInfo, Set(), Set(), Seq(), Seq(),
+        consensusEpoch, Seq(), mod2BlockFeeInfo, None, scHasCeased = true, new Array[Int](0), 0
       ).isSuccess
     )
 
@@ -417,6 +417,6 @@ class SidechainStateStorageTest
     //Try to remove non-existent item
     assertFalse("Remove operation of non-existent item must not throw exception.",
       sidechainStateStorage.update(version1, withdrawalEpochInfo, Set(), bList1.map(b => new ByteArrayWrapper(b.id())),
-        Seq(), intToConsensusEpochNumber(0), None, blockFeeInfo, None, false, new Array[Int](0), 0).isFailure)
+        Seq(), Seq(), intToConsensusEpochNumber(0), Seq(), blockFeeInfo, None, false, new Array[Int](0), 0).isFailure)
   }
 }

--- a/sdk/src/test/scala/com/horizen/integration/storage/SidechainStateStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/storage/SidechainStateStorageTest.scala
@@ -28,7 +28,7 @@ class SidechainStateStorageTest
 
   val customBoxesSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]] = new JHashMap()
   customBoxesSerializers.put(CustomBox.BOX_TYPE_ID, CustomBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers)
+  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers, false)
 
   val withdrawalEpochInfo: WithdrawalEpochInfo = WithdrawalEpochInfo(0, 0)
   val consensusEpoch: ConsensusEpochNumber = intToConsensusEpochNumber(1)

--- a/sdk/src/test/scala/com/horizen/integration/storage/SidechainWalletBoxStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/integration/storage/SidechainWalletBoxStorageTest.scala
@@ -23,8 +23,8 @@ class SidechainWalletBoxStorageTest
 
   var customBoxesSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]] = new JHashMap()
   customBoxesSerializers.put(CustomBox.BOX_TYPE_ID, CustomBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers)
-  val sidechainBoxesCompanionCore = SidechainBoxesCompanion(new JHashMap())
+  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers, false)
+  val sidechainBoxesCompanionCore = SidechainBoxesCompanion(new JHashMap(), false)
 
   @Test
   def mainWorkflow() : Unit = {

--- a/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/storage/SidechainStateStorageTest.scala
@@ -50,7 +50,7 @@ class SidechainStateStorageTest
 
   val customBoxesSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]] = new JHashMap()
   customBoxesSerializers.put(CustomBox.BOX_TYPE_ID, CustomBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers)
+  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers, false)
 
   val withdrawalEpochInfo = WithdrawalEpochInfo(1, 2)
 

--- a/sdk/src/test/scala/com/horizen/storage/SidechainWalletBoxStorageTest.scala
+++ b/sdk/src/test/scala/com/horizen/storage/SidechainWalletBoxStorageTest.scala
@@ -39,8 +39,8 @@ class SidechainWalletBoxStorageTest
 
   var customBoxesSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]] = new JHashMap()
   customBoxesSerializers.put(CustomBox.BOX_TYPE_ID, CustomBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
-  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers)
-  val sidechainBoxesCompanionCore = SidechainBoxesCompanion(new JHashMap())
+  val sidechainBoxesCompanion = SidechainBoxesCompanion(customBoxesSerializers, false)
+  val sidechainBoxesCompanionCore = SidechainBoxesCompanion(new JHashMap(), false)
 
   @Before
   def setUp() : Unit = {


### PR DESCRIPTION
Sender implementation:
covers most of the sender part implementation, with the following missing parts:
- cryptolib interfaces are still mocked and not tested - and still not used in certificate creation and api endpoints
