### PR TITLE
fix gas tests

### DIFF
--- a/sdk/src/main/scala/com/horizen/account/api/http/AccountTransactionApiRoute.scala
+++ b/sdk/src/main/scala/com/horizen/account/api/http/AccountTransactionApiRoute.scala
@@ -26,14 +26,13 @@ import com.horizen.certificatesubmitter.keys.{KeyRotationProof, KeyRotationProof
 import com.horizen.cryptolibprovider.utils.CircuitTypes.{CircuitTypes, NaiveThresholdSignatureCircuit, NaiveThresholdSignatureCircuitWithKeyRotation}
 import com.horizen.node.NodeWalletBase
 import com.horizen.params.NetworkParams
-import com.horizen.proof.Signature25519
-import com.horizen.proposition.{MCPublicKeyHashPropositionSerializer, PublicKey25519Proposition, VrfPublicKey}
-import com.horizen.proof.SchnorrSignatureSerializer
-import com.horizen.proposition.SchnorrPropositionSerializer
+import com.horizen.proof.{SchnorrSignatureSerializer, Signature25519}
+import com.horizen.proposition.{MCPublicKeyHashPropositionSerializer, PublicKey25519Proposition, SchnorrPropositionSerializer, VrfPublicKey}
+import com.horizen.secret.PrivateKey25519
 import com.horizen.serialization.Views
 import com.horizen.utils.BytesUtils
 import sparkz.core.settings.RESTApiSettings
-import com.horizen.secret.PrivateKey25519
+
 import java.math.BigInteger
 import java.util.{Optional => JOptional}
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
@@ -295,7 +294,7 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
             val baseFee = sidechainNodeView.getNodeState.getNextBaseFee
             var maxPriorityFeePerGas = BigInteger.valueOf(120)
             var maxFeePerGas = BigInteger.TWO.multiply(baseFee).add(maxPriorityFeePerGas)
-            var gasLimit = BigInteger.TWO.multiply(GasUtil.TxGas)
+            var gasLimit = BigInteger.valueOf(500000)
 
             if (body.gasInfo.isDefined) {
               maxFeePerGas = body.gasInfo.get.maxFeePerGas
@@ -382,7 +381,7 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
           val baseFee = sidechainNodeView.getNodeState.getNextBaseFee
           var maxPriorityFeePerGas = BigInteger.valueOf(120)
           var maxFeePerGas = BigInteger.TWO.multiply(baseFee).add(maxPriorityFeePerGas)
-          var gasLimit = BigInteger.TWO.multiply(GasUtil.TxGas)
+          var gasLimit = BigInteger.valueOf(500000)
 
           if (body.gasInfo.isDefined) {
             maxFeePerGas = body.gasInfo.get.maxFeePerGas
@@ -431,7 +430,7 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
           val baseFee = sidechainNodeView.getNodeState.getNextBaseFee
           var maxPriorityFeePerGas = BigInteger.valueOf(120)
           var maxFeePerGas = BigInteger.TWO.multiply(baseFee).add(maxPriorityFeePerGas)
-          var gasLimit = BigInteger.TWO.multiply(GasUtil.TxGas)
+          var gasLimit = BigInteger.valueOf(500000)
 
           if (body.gasInfo.isDefined) {
             maxFeePerGas = body.gasInfo.get.maxFeePerGas
@@ -548,7 +547,7 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
           val baseFee = sidechainNodeView.getNodeState.getNextBaseFee
           var maxPriorityFeePerGas = BigInteger.valueOf(120)
           var maxFeePerGas = BigInteger.TWO.multiply(baseFee).add(maxPriorityFeePerGas)
-          var gasLimit = BigInteger.TWO.multiply(GasUtil.TxGas)
+          var gasLimit = BigInteger.valueOf(500000)
 
           if (gasInfo.isDefined) {
             maxFeePerGas = gasInfo.get.maxFeePerGas
@@ -603,7 +602,7 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
           val baseFee = sidechainNodeView.getNodeState.getNextBaseFee
           var maxPriorityFeePerGas = GasUtil.TxGasContractCreation
           var maxFeePerGas = BigInteger.TWO.multiply(baseFee).add(maxPriorityFeePerGas)
-          var gasLimit = BigInteger.TWO.multiply(GasUtil.TxGas)
+          var gasLimit = BigInteger.valueOf(500000)
 
           if (body.gasInfo.isDefined) {
             maxFeePerGas = body.gasInfo.get.maxFeePerGas
@@ -615,7 +614,7 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
           val secret = getFittingSecret(sidechainNodeView, None, txCost)
           secret match {
             case Some(secret) =>
-              val to = null
+              val to: String = null
               val nonce = body.nonce.getOrElse(sidechainNodeView.getNodeState.getNonce(secret.publicImage.address))
               val data = body.contractCode
               val tmpTx: EthereumTransaction = new EthereumTransaction(

--- a/sdk/src/main/scala/com/horizen/account/state/StateDbAccountStateView.scala
+++ b/sdk/src/main/scala/com/horizen/account/state/StateDbAccountStateView.scala
@@ -271,7 +271,7 @@ class StateDbAccountStateView(stateDb: StateDB, messageProcessors: Seq[MessagePr
     stateDb.setStorage(address, key, value)
 
   final override def removeAccountStorage(address: Array[Byte], key: Array[Byte]): Unit =
-    updateAccountStorage(address, key, null)
+    updateAccountStorage(address, key, Array.fill(Hash.LENGTH)(0))
 
   // random data used to salt chunk keys in the storage trie when accessed via get/updateAccountStorageBytes
   private val chunkKeySalt =

--- a/sdk/src/test/scala/com/horizen/account/state/EoaMessageProcessorIntegrationTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/EoaMessageProcessorIntegrationTest.scala
@@ -54,7 +54,8 @@ class EoaMessageProcessorIntegrationTest
 
     usingView(EoaMessageProcessor) { view =>
       view.addBalance(sender, initialBalance)
-      val returnData = assertGas(GasUtil.TxGas)(view.applyMessage(msg, _, defaultBlockContext))
+      // EOA transactions only consume intrinsic gas, the processor itself therefore must not use any gas
+      val returnData = assertGas(0, msg, view, EoaMessageProcessor, defaultBlockContext)
       assertArrayEquals("Different return data found", Array.emptyByteArray, returnData)
       assertEquals("Different from account value found", initialBalance.subtract(value), view.getBalance(sender))
       assertEquals("Different to account value found", value, view.getBalance(msg.getToAddressBytes))

--- a/sdk/src/test/scala/com/horizen/account/state/EoaMessageProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/EoaMessageProcessorTest.scala
@@ -89,7 +89,7 @@ class EoaMessageProcessorTest extends JUnitSuite with MockitoSugar with SecretFi
         assertEquals("Different amount found", msg.getValue, args.getArgument(1))
       })
 
-    val returnData = assertGas(BigInteger.ZERO)(EoaMessageProcessor.process(msg, mockStateView, _, defaultBlockContext))
+    val returnData = assertGas(0, msg, mockStateView, EoaMessageProcessor, defaultBlockContext)
     assertArrayEquals("Different return data found", Array.emptyByteArray, returnData)
 
     // Test 2: Failure during subBalance

--- a/sdk/src/test/scala/com/horizen/account/state/EvmMessageProcessorIntegrationTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/EvmMessageProcessorIntegrationTest.scala
@@ -40,8 +40,9 @@ class EvmMessageProcessorIntegrationTest extends MessageProcessorFixture with Ev
   def testProcess(): Unit = {
 
     val initialBalance = new BigInteger("2000000000000")
+    val evmMessageProcessor = new EvmMessageProcessor()
 
-    usingView(new EvmMessageProcessor) { stateView =>
+    usingView(evmMessageProcessor) { stateView =>
       stateView.addBalance(originAddress.address(), initialBalance)
 
       // smart contract constructor has one argument (256-bit uint)
@@ -49,7 +50,7 @@ class EvmMessageProcessorIntegrationTest extends MessageProcessorFixture with Ev
       initialValue(initialValue.length - 1) = 42
       // add constructor arguments to the end of the deployment code
       val msg = getMessage(null, deployCode ++ initialValue)
-      val result = assertGas(138826)(stateView.applyMessage(msg, _, defaultBlockContext))
+      val result = assertGas(76990, msg, stateView, evmMessageProcessor, defaultBlockContext)
       assertNotNull("result should not be null", result)
     }
   }

--- a/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/ForgerStakeMsgProcessorTest.scala
@@ -3,8 +3,8 @@ package com.horizen.account.state
 import com.google.common.primitives.Bytes
 import com.horizen.account.events.{DelegateForgerStake, OpenForgerList, WithdrawForgerStake}
 import com.horizen.account.proposition.AddressProposition
-import com.horizen.account.state.ForgerStakeMsgProcessor.{AddNewStakeCmd, GetListOfForgersCmd, OpenStakeForgerListCmd, RemoveStakeCmd}
 import com.horizen.account.secret.{PrivateKeySecp256k1, PrivateKeySecp256k1Creator}
+import com.horizen.account.state.ForgerStakeMsgProcessor.{AddNewStakeCmd, GetListOfForgersCmd, OpenStakeForgerListCmd, RemoveStakeCmd}
 import com.horizen.account.utils.ZenWeiConverter
 import com.horizen.evm.interop.EvmLog
 import com.horizen.fixtures.StoreFixture
@@ -19,12 +19,12 @@ import org.scalatestplus.junit.JUnitSuite
 import org.scalatestplus.mockito._
 import org.web3j.abi.datatypes.Type
 import org.web3j.abi.{FunctionReturnDecoder, TypeReference}
-import sparkz.core.bytesToVersion
 import scorex.crypto.hash.Keccak256
+import sparkz.core.bytesToVersion
+
 import java.math.BigInteger
 import java.util
-import java.util.Random
-import java.util.Optional
+import java.util.{Optional, Random}
 import scala.collection.JavaConverters.seqAsJavaListConverter
 
 class ForgerStakeMsgProcessorTest
@@ -183,7 +183,6 @@ class ForgerStakeMsgProcessorTest
   @Test
   def testOpenStakeForgerList(): Unit = {
 
-
     val randomGenerator = new Random(1L)
     val byteSeed = new Array[Byte](32)
     randomGenerator.nextBytes(byteSeed)
@@ -239,15 +238,8 @@ class ForgerStakeMsgProcessorTest
       var msg = getMessage(
         contractAddress, 0, BytesUtils.fromHexString(OpenStakeForgerListCmd) ++ cmdInput.encode(), nonce, ownerAddressProposition.address())
 
-      var returnData = assertGas(45937) {
-        forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext)
-      }
-
-      assertNotNull(returnData)
-      assertEquals(returnData.length, 3)
-      assertEquals(returnData(0), 1)
-      assertEquals(returnData(1), 0)
-      assertEquals(returnData(2), 0)
+      var returnData = assertGas(45937, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
+      assertArrayEquals(Array[Byte](1, 0, 0), returnData)
 
       // Checking log
       val listOfLogs = view.getLogs(txHash1.asInstanceOf[Array[Byte]])
@@ -273,10 +265,8 @@ class ForgerStakeMsgProcessorTest
         contractAddress, 0, BytesUtils.fromHexString(OpenStakeForgerListCmd) ++ cmdInput.encode(), nonce, ownerAddressProposition.address())
 
       // should fail because index is out of bound
-      assertGas(0) { gas =>
-        assertThrows[ExecutionRevertedException] {
-          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
-        }
+      assertThrows[ExecutionRevertedException] {
+        assertGas(0, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
       }
 
       // negative test: use a wrong index (negative value)
@@ -303,10 +293,8 @@ class ForgerStakeMsgProcessorTest
         contractAddress, 0, BytesUtils.fromHexString(OpenStakeForgerListCmd) ++ cmdInput.encode(), nonce, ownerAddressProposition.address())
 
       // should fail because signature is wrong
-      assertGas(0) { gas =>
-        assertThrows[ExecutionRevertedException] {
-          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
-        }
+      assertThrows[ExecutionRevertedException] {
+        assertGas(0, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
       }
 
       // now sign correctly
@@ -318,15 +306,8 @@ class ForgerStakeMsgProcessorTest
       msg = getMessage(
         contractAddress, 0, BytesUtils.fromHexString(OpenStakeForgerListCmd) ++ cmdInput.encode(), nonce, ownerAddressProposition.address())
 
-      returnData = assertGas(2237) {
-        forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext)
-      }
-
-      assertNotNull(returnData)
-      assertEquals(returnData.length, 3)
-      assertEquals(returnData(0), 1)
-      assertEquals(returnData(1), 1)
-      assertEquals(returnData(2), 0)
+      returnData = assertGas(6237, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
+      assertArrayEquals(Array[Byte](1, 1, 0), returnData)
 
       // assert we have open the forger list
       isOpen = forgerStakeMessageProcessor.isForgerListOpen(view)
@@ -347,10 +328,8 @@ class ForgerStakeMsgProcessorTest
         contractAddress, 0, BytesUtils.fromHexString(OpenStakeForgerListCmd) ++ cmdInput.encode(), nonce, ownerAddressProposition.address())
 
       // should fail because the list now is open
-      assertGas(300) { gas =>
-        assertThrows[ExecutionRevertedException] {
-          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
-        }
+      assertThrows[ExecutionRevertedException] {
+        assertGas(4300, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
       }
 
       // assert we have open the forger list
@@ -395,10 +374,8 @@ class ForgerStakeMsgProcessorTest
         contractAddress, 0, BytesUtils.fromHexString(OpenStakeForgerListCmd) ++ cmdInput.encode(), nonce, ownerAddressProposition.address())
 
       // should fail because forger list is not restricted
-      assertGas(0) { gas =>
-        assertThrows[ExecutionRevertedException] {
-          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
-        }
+      assertThrows[ExecutionRevertedException] {
+        assertGas(0, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
       }
 
       // assert we have open the forger list
@@ -420,7 +397,7 @@ class ForgerStakeMsgProcessorTest
       forgerStakeMessageProcessor.init(view)
 
       // create sender account with some fund in it
-      val initialAmount = BigInteger.valueOf(10).multiply(validWeiAmount)
+      val initialAmount = BigInteger.valueOf(100).multiply(validWeiAmount)
       createSenderAccount(view, initialAmount)
 
       Mockito.when(mockNetworkParams.restrictForgers).thenReturn(true)
@@ -439,9 +416,7 @@ class ForgerStakeMsgProcessorTest
       val msg = getMessage(contractAddress, validWeiAmount, BytesUtils.fromHexString(AddNewStakeCmd) ++ data, randomNonce)
 
       // positive case, verify we can add the stake to view
-      val returnData = assertGas(188612) {
-        forgerStakeMessageProcessor.process(msg, view, _, defaultBlockContext)
-      }
+      val returnData = assertGas(186112, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
       assertNotNull(returnData)
       println("This is the returned value: " + BytesUtils.toHexString(returnData))
 
@@ -476,9 +451,7 @@ class ForgerStakeMsgProcessorTest
         ForgerStakeData(ForgerPublicKeys(blockSignerProposition, vrfPublicKey),
           ownerAddressProposition, validWeiAmount))
 
-      val returnData2 = assertGas(180512) {
-        forgerStakeMessageProcessor.process(msg2, view, _, defaultBlockContext)
-      }
+      val returnData2 = assertGas(195012, msg2, view, forgerStakeMessageProcessor, defaultBlockContext)
       assertNotNull(returnData2)
       println("This is the returned value: " + BytesUtils.toHexString(returnData2))
 
@@ -508,9 +481,7 @@ class ForgerStakeMsgProcessorTest
       view.setupTxContext(txHash4, 10)
 
       // try processing the removal of stake, should succeed
-      val returnData3 = assertGas(4281) {
-        forgerStakeMessageProcessor.process(msg3, view, _, defaultBlockContext)
-      }
+      val returnData3 = assertGas(30781, msg3, view, forgerStakeMessageProcessor, defaultBlockContext)
       assertNotNull(returnData3)
       println("This is the returned value: " + BytesUtils.toHexString(returnData3))
 
@@ -525,10 +496,8 @@ class ForgerStakeMsgProcessorTest
       val expectedRemoveStakeEvent = WithdrawForgerStake(ownerAddressProposition, stakeId)
       checkRemoveForgerStakeEvent(expectedRemoveStakeEvent, listOfLogs(0))
 
-      val msg4 = getDefaultMessage(BytesUtils.fromHexString(GetListOfForgersCmd), Array.emptyByteArray, randomNonce, BigInteger.ZERO)
-      val returnData4 = assertGas(900) {
-        forgerStakeMessageProcessor.process(msg4, view, _, defaultBlockContext)
-      }
+      val msg4 = getMessage(contractAddress, 0, BytesUtils.fromHexString(GetListOfForgersCmd), randomNonce)
+      val returnData4 = assertGas(18900, msg4, view, forgerStakeMessageProcessor, defaultBlockContext)
       assertNotNull(returnData4)
       val listOfExpectedForgerStakes = new util.ArrayList[AccountForgingStakeInfo]
       listOfExpectedForgerStakes.add(expectedLastStake)
@@ -572,10 +541,8 @@ class ForgerStakeMsgProcessorTest
         data, randomNonce, validWeiAmount)
 
       // should fail because forger is not in the allowed list
-      assertGas(7300) { gas =>
-        assertThrows[ExecutionFailedException] {
-          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
-        }
+      assertThrows[ExecutionFailedException] {
+        assertGas(4800, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
       }
 
       view.commit(bytesToVersion(getVersion.data()))
@@ -590,11 +557,9 @@ class ForgerStakeMsgProcessorTest
       val msg = getDefaultMessage(BytesUtils.fromHexString("03"), data, randomNonce)
 
       // should fail because op code is invalid
-      assertGas(0)(gas =>
-        assertThrows[ExecutionFailedException] {
-          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
-        }
-      )
+      assertThrows[ExecutionFailedException] {
+        assertGas(0, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
+      }
       view.commit(bytesToVersion(getVersion.data()))
     }
   }
@@ -633,10 +598,8 @@ class ForgerStakeMsgProcessorTest
         data, randomNonce, invalidWeiAmount)
 
       // should fail because staked amount is not a zat amount
-      assertGas(0) { gas =>
-        assertThrows[ExecutionFailedException] {
-          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
-        }
+      assertThrows[ExecutionFailedException] {
+        assertGas(0, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
       }
 
       view.commit(bytesToVersion(getVersion.data()))
@@ -679,10 +642,8 @@ class ForgerStakeMsgProcessorTest
         data, randomNonce, validWeiAmount)
 
        // should fail because recipient is a smart contract
-       assertGas(5200) { gas =>
-        assertThrows[ExecutionRevertedException] {
-          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
-        }
+      assertThrows[ExecutionRevertedException] {
+        assertGas(200, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
       }
       view.commit(bytesToVersion(getVersion.data()))
     }
@@ -713,10 +674,8 @@ class ForgerStakeMsgProcessorTest
         BytesUtils.fromHexString(GetListOfForgersCmd),
         data, randomNonce)
 
-      assertGas(0) { gas =>
-        assertThrows[ExecutionFailedException] {
-          forgerStakeMessageProcessor.process(msg, view, gas, defaultBlockContext)
-        }
+      assertThrows[ExecutionFailedException] {
+        assertGas(0, msg, view, forgerStakeMessageProcessor, defaultBlockContext)
       }
 
       view.commit(bytesToVersion(getVersion.data()))

--- a/sdk/src/test/scala/com/horizen/account/state/StateDbAccountStateViewGasTrackedTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/StateDbAccountStateViewGasTrackedTest.scala
@@ -116,7 +116,15 @@ class StateDbAccountStateViewGasTrackedTest
       (2300, Seq(_.getAccountStorage(origin, slot1), _.getAccountStorage(origin, slot1), _.getNonce(origin))),
       // account storage modification
       (24800, Seq(_.increaseNonce(origin), _.updateAccountStorage(origin, slot1, randomHash))),
-      (24800, Seq(_.increaseNonce(origin), _.removeAccountStorage(origin, slot1)))
+      (4900, Seq(_.increaseNonce(origin), _.removeAccountStorage(origin, slot1))),
+      (
+        24900,
+        Seq(
+          _.increaseNonce(origin),
+          _.updateAccountStorage(origin, slot1, randomHash),
+          _.removeAccountStorage(origin, slot1)
+        )
+      ),
     )
 
     forAll(testCases) { (expectedGas, sequence) =>

--- a/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorIntegrationTest.scala
+++ b/sdk/src/test/scala/com/horizen/account/state/WithdrawalMsgProcessorIntegrationTest.scala
@@ -1,8 +1,7 @@
 package com.horizen.account.state
 
-import com.horizen.account.utils.FeeUtils
 import com.horizen.account.events.AddWithdrawalRequest
-import com.horizen.account.utils.ZenWeiConverter
+import com.horizen.account.utils.{FeeUtils, ZenWeiConverter}
 import com.horizen.evm.interop.EvmLog
 import com.horizen.utils.{BytesUtils, ClosableResourceHandler}
 import org.junit.Assert._
@@ -12,6 +11,7 @@ import org.scalatestplus.mockito._
 import org.web3j.abi.datatypes.Type
 import org.web3j.abi.{FunctionReturnDecoder, TypeReference}
 import scorex.crypto.hash.Keccak256
+
 import java.math.BigInteger
 import java.util
 
@@ -49,7 +49,7 @@ class WithdrawalMsgProcessorIntegrationTest
 
       // GetListOfWithdrawalRequest without withdrawal requests yet
       val msgForListOfWR = listWithdrawalRequestsMessage(withdrawalEpoch)
-      var wrListInBytes = withGas(WithdrawalMsgProcessor.process(msgForListOfWR, view, _, blockContext))
+      var wrListInBytes = assertGas(2100, msgForListOfWR, view, WithdrawalMsgProcessor, blockContext)
       val expectedListOfWR = new util.ArrayList[WithdrawalRequest]()
       assertArrayEquals(WithdrawalRequestsListEncoder.encode(expectedListOfWR), wrListInBytes)
 
@@ -58,7 +58,9 @@ class WithdrawalMsgProcessorIntegrationTest
       val withdrawalAmount = ZenWeiConverter.convertZenniesToWei(10)
       val msgBalance = addWithdrawalRequestMessage(withdrawalAmount)
       // Withdrawal request with insufficient balance should result in ExecutionFailed
-      assertThrows[ExecutionFailedException](withGas(WithdrawalMsgProcessor.process(msgBalance, view, _, blockContext)))
+      assertThrows[ExecutionFailedException] {
+        assertGas(0, msgBalance, view, WithdrawalMsgProcessor, blockContext)
+      }
 
       // Creating the first Withdrawal request
       val withdrawalAmount1 = ZenWeiConverter.convertZenniesToWei(123)
@@ -71,7 +73,7 @@ class WithdrawalMsgProcessorIntegrationTest
       val txHash1 = Keccak256.hash("first tx")
       view.setupTxContext(txHash1, 10)
 
-      val wrInBytes = withGas(WithdrawalMsgProcessor.process(msg, view, _, blockContext))
+      val wrInBytes = assertGas(68412, msg, view, WithdrawalMsgProcessor, blockContext)
       assertArrayEquals(newExpectedWR.encode(), wrInBytes)
       val newBalance = view.getBalance(msg.getFromAddressBytes)
       assertEquals("Wrong value in account balance", 1177, ZenWeiConverter.convertWeiToZennies(newBalance))
@@ -86,7 +88,7 @@ class WithdrawalMsgProcessorIntegrationTest
       view.setupTxContext(txHash2, 10)
 
       // GetListOfWithdrawalRequest after first withdrawal request creation
-      wrListInBytes = withGas(WithdrawalMsgProcessor.process(msgForListOfWR, view, _, blockContext))
+      wrListInBytes = assertGas(6300, msgForListOfWR, view, WithdrawalMsgProcessor, blockContext)
       assertArrayEquals(WithdrawalRequestsListEncoder.encode(expectedListOfWR), wrListInBytes)
 
       // Checking that log didn't change
@@ -102,7 +104,7 @@ class WithdrawalMsgProcessorIntegrationTest
       val txHash3 = Keccak256.hash("third tx")
       view.setupTxContext(txHash3, 10)
 
-      val wrInBytes2 = withGas(WithdrawalMsgProcessor.process(msg, view, _, blockContext))
+      val wrInBytes2 = assertGas(48512, msg, view, WithdrawalMsgProcessor, blockContext)
       assertArrayEquals(newExpectedWR.encode(), wrInBytes2)
 
       val newBalanceAfterSecondWR = view.getBalance(msg.getFromAddressBytes)
@@ -116,7 +118,7 @@ class WithdrawalMsgProcessorIntegrationTest
       checkEvent(expectedEvent, listOfLogs(0))
 
       // GetListOfWithdrawalRequest after second withdrawal request creation
-      wrListInBytes = withGas(WithdrawalMsgProcessor.process(msgForListOfWR, view, _, blockContext))
+      wrListInBytes = assertGas(10500, msgForListOfWR, view, WithdrawalMsgProcessor, blockContext)
       assertArrayEquals(WithdrawalRequestsListEncoder.encode(expectedListOfWR), wrListInBytes)
     }
   }


### PR DESCRIPTION
- fixed `sc_evm_closed_forger.py` by increasing default gas limits in the http api
- fixed `NullPointerException` in  `StateDbAccountStateViewGasTracked.removeAccountStorage`
- updated gas usage in `ForgerStakeMsgProcessorTest`
- added gas usage verification to `WithdrawalMsgProcessorTest`
- updated EOA and EVM message processor tests to not use `applyMessage` but the processors `process` method directly

Tests of gas usage for the ForgerStakesMsgProcessor were using wrong numbers, because they did not reset the access list between multiple calls ("warm" account access uses less gas, etc.).