### PR TITLE
EVM-737 allow calling precompiled contracts

### DIFF
--- a/evm/src/main/java/com/horizen/evm/LibEvmCallback.java
+++ b/evm/src/main/java/com/horizen/evm/LibEvmCallback.java
@@ -50,7 +50,6 @@ abstract class LibEvmCallback implements AutoCloseable {
             logger.warn("received callback with invalid handle: {}", handle);
             return null;
         }
-        logger.trace("received callback with handle {}", handle);
         return callbacks.get(handle).invoke(args);
     }
 

--- a/evm/src/main/java/com/horizen/evm/StateDB.java
+++ b/evm/src/main/java/com/horizen/evm/StateDB.java
@@ -79,13 +79,14 @@ public class StateDB extends ResourceHandle {
      * <ol>
      * <li>account doesn't exist in the StateDB (first time it receives coins);</li>
      * <li>account has no code (code hash is a keccak256 hash of empty array).</li>
+     * <li>account address does not match any of the precompiled native contracts.</li>
      * </ol>
      *
      * @param address account address
      * @return true if account is EOA, otherwise false
      */
     public boolean isEoaAccount(Address address) {
-        return isEmpty(address) || EMPTY_CODE_HASH.equals(getCodeHash(address));
+        return LibEvm.invoke("StateIsEoa", new AccountParams(handle, address), boolean.class);
     }
 
     /**

--- a/evm/src/test/java/com/horizen/evm/StateDBTest.java
+++ b/evm/src/test/java/com/horizen/evm/StateDBTest.java
@@ -248,7 +248,7 @@ public class StateDBTest extends LibEvmTestBase {
     }
 
     @Test
-    public void TestAccountTypes() throws Exception {
+    public void testAccountTypes() throws Exception {
         final var code = bytes("aa87aee0394326416058ef46b907882903f3646ef2a6d0d20f9e705b87c58c77");
         final var addr1 = new Address("0x1234561234561234561234561234561234561230");
 

--- a/libevm/lib/state.go
+++ b/libevm/lib/state.go
@@ -122,7 +122,7 @@ func (s *Service) StateIsEoa(params AccountParams) (error, bool) {
 	}
 	// test for code in the account
 	// note: for empty accounts the code hash will be zero,
-	// for existing accounts without code the hash will the empty-hash
+	// for existing accounts without code the hash will be the empty-hash,
 	// if neither is true it must be a smart contract account
 	if codeHash := statedb.GetCodeHash(params.Address); codeHash != emptyCodeHash && codeHash != (common.Hash{}) {
 		return nil, false


### PR DESCRIPTION
- update "isEoa" logic to include a check for the addresses of precompiled native contract