### PR TITLE
Updated Bcrypt library

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -168,7 +168,7 @@ HTTP request:
 Config file:
 
         restApi {
-            "apiKeyHash": "$2a$10$6CUHuJzctrPAsxWO5K4Pi.mx3OV0TIb2bSaq4ZBZQsR0MV3SVB6rC"
+            "apiKeyHash": "$2y$12$vga1LEzU1jiLYI766CIeVOi1A9QwFBqYgjbAsD.2t8Z7SFP6ff4Eq"
         }
 
 **Sidechain-related RPC commands in Mainchain**

--- a/examples/README.md
+++ b/examples/README.md
@@ -168,7 +168,7 @@ HTTP request:
 Config file:
 
         restApi {
-            "apiKeyHash": "$2y$12$vga1LEzU1jiLYI766CIeVOi1A9QwFBqYgjbAsD.2t8Z7SFP6ff4Eq"
+            "apiKeyHash": "$2y$08$sB9Zrn4S2/YYfJ8/lhNxXO/Ku7uciazel3hx4bvjMs7nrqcLqMS0y"
         }
 
 **Sidechain-related RPC commands in Mainchain**

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -269,6 +269,11 @@
       <artifactId>evm</artifactId>
       <version>0.6.0-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>at.favre.lib</groupId>
+      <artifactId>bcrypt</artifactId>
+      <version>0.10.2</version>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>io.horizen</groupId>
       <artifactId>sparkz-core_2.12</artifactId>
-      <version>2.0.0-RC10</version>
+      <version>2.0.0-RC11</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/sdk/src/test/scala/com/horizen/fixtures/BasicAuthenticationFixture.scala
+++ b/sdk/src/test/scala/com/horizen/fixtures/BasicAuthenticationFixture.scala
@@ -1,0 +1,17 @@
+package com.horizen.fixtures
+
+import akka.http.javadsl.model.headers.{BasicHttpCredentials, HttpCredentials}
+import at.favre.lib.crypto.bcrypt.BCrypt
+
+
+trait BasicAuthenticationFixture {
+
+  def getBasicAuthCredentials(username: String = "username", password: String = "password"): BasicHttpCredentials = {
+    HttpCredentials.createBasicHttpCredentials(username, password)
+  }
+
+  def getBasicAuthApiKeyHash(password: String, bcryptCostAlgorithm: Int = 8): String = {
+    //Algorithm cost, higher is the number, higher is the round in the algorithm and the time to hash/verify the password
+    BCrypt.`with`(BCrypt.Version.VERSION_2Y).hashToString(bcryptCostAlgorithm, password.toCharArray)
+  }
+}

--- a/sdk/src/test/scala/io/horizen/account/api/http/route/AccountEthRpcRouteMock.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/http/route/AccountEthRpcRouteMock.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit
 import akka.testkit.{TestActor, TestProbe}
+import at.favre.lib.crypto.bcrypt.BCrypt
 import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
 import io.horizen.AbstractSidechainNodeViewHolder.ReceivableMessages.{ApplyBiFunctionOnNodeView, ApplyFunctionOnNodeView, GetDataFromCurrentSidechainNodeView, LocallyGeneratedSecret}
 import io.horizen.account.api.http.AccountNodeViewUtilMocks
@@ -22,7 +23,6 @@ import io.horizen.params.MainNetParams
 import io.horizen.{SidechainSettings, SidechainTypes}
 import io.horizen.evm.LevelDBDatabase
 import org.junit.runner.RunWith
-import org.mindrot.jbcrypt.BCrypt
 import org.mockito.Mockito
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -53,7 +53,7 @@ abstract class AccountEthRpcRouteMock extends AnyWordSpec with Matchers with Sca
 
   val credentials = HttpCredentials.createBasicHttpCredentials("username","password")
   val badCredentials = HttpCredentials.createBasicHttpCredentials("username","wrong_password")
-  val apiKeyHash = BCrypt.hashpw(credentials.password(), BCrypt.gensalt())
+  val apiKeyHash = BCrypt.`with`(BCrypt.Version.VERSION_2Y).hashToString(12, credentials.password().toCharArray)
 
   val memoryPool: java.util.List[EthereumTransaction] = utilMocks.transactionList
   val mockedRESTSettings: RESTApiSettings = mock[RESTApiSettings]

--- a/sdk/src/test/scala/io/horizen/account/api/http/route/AccountEthRpcRouteMock.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/http/route/AccountEthRpcRouteMock.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit
 import akka.testkit.{TestActor, TestProbe}
 import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
+import com.horizen.fixtures.BasicAuthenticationFixture
 import io.horizen.AbstractSidechainNodeViewHolder.ReceivableMessages.{ApplyBiFunctionOnNodeView, ApplyFunctionOnNodeView, GetDataFromCurrentSidechainNodeView, LocallyGeneratedSecret}
 import io.horizen.account.api.http.AccountNodeViewUtilMocks
 import io.horizen.account.companion.SidechainAccountTransactionsCompanion

--- a/sdk/src/test/scala/io/horizen/account/api/http/route/AccountEthRpcRouteMock.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/http/route/AccountEthRpcRouteMock.scala
@@ -1,12 +1,10 @@
 package io.horizen.account.api.http.route
 
 import akka.actor.{ActorRef, ActorSystem}
-import akka.http.javadsl.model.headers.HttpCredentials
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit
 import akka.testkit.{TestActor, TestProbe}
-import at.favre.lib.crypto.bcrypt.BCrypt
 import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
 import io.horizen.AbstractSidechainNodeViewHolder.ReceivableMessages.{ApplyBiFunctionOnNodeView, ApplyFunctionOnNodeView, GetDataFromCurrentSidechainNodeView, LocallyGeneratedSecret}
 import io.horizen.account.api.http.AccountNodeViewUtilMocks
@@ -37,7 +35,7 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
 @RunWith(classOf[JUnitRunner])
-abstract class AccountEthRpcRouteMock extends AnyWordSpec with Matchers with ScalatestRouteTest with MockitoSugar with SidechainBlockFixture with CompanionsFixture with SidechainTypes {
+abstract class AccountEthRpcRouteMock extends AnyWordSpec with Matchers with ScalatestRouteTest with MockitoSugar with SidechainBlockFixture with CompanionsFixture with SidechainTypes with BasicAuthenticationFixture {
   implicit def exceptionHandler: ExceptionHandler = SidechainApiErrorHandler.exceptionHandler
 
   implicit def rejectionHandler: RejectionHandler = SidechainApiRejectionHandler.rejectionHandler
@@ -51,9 +49,9 @@ abstract class AccountEthRpcRouteMock extends AnyWordSpec with Matchers with Sca
 
   val utilMocks = new AccountNodeViewUtilMocks()
 
-  val credentials = HttpCredentials.createBasicHttpCredentials("username","password")
-  val badCredentials = HttpCredentials.createBasicHttpCredentials("username","wrong_password")
-  val apiKeyHash = BCrypt.`with`(BCrypt.Version.VERSION_2Y).hashToString(12, credentials.password().toCharArray)
+  val credentials = getBasicAuthCredentials()
+  val badCredentials = getBasicAuthCredentials(password = "wrong_password")
+  val apiKeyHash = getBasicAuthApiKeyHash(credentials.password())
 
   val memoryPool: java.util.List[EthereumTransaction] = utilMocks.transactionList
   val mockedRESTSettings: RESTApiSettings = mock[RESTApiSettings]

--- a/sdk/src/test/scala/io/horizen/account/api/http/route/AccountSidechainApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/http/route/AccountSidechainApiRouteTest.scala
@@ -1,12 +1,10 @@
 package io.horizen.account.api.http.route
 
 import akka.actor.{ActorRef, ActorSystem}
-import akka.http.javadsl.model.headers.HttpCredentials
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit
 import akka.testkit.{TestActor, TestProbe}
-import at.favre.lib.crypto.bcrypt.BCrypt
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper, SerializationFeature}
 import io.horizen.AbstractSidechainNodeViewHolder.ReceivableMessages._
 import io.horizen.SidechainTypes
@@ -46,7 +44,7 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
 @RunWith(classOf[JUnitRunner])
-abstract class AccountSidechainApiRouteTest extends AnyWordSpec with Matchers with ScalatestRouteTest with MockitoSugar with SidechainBlockFixture with CompanionsFixture with SidechainTypes {
+abstract class AccountSidechainApiRouteTest extends AnyWordSpec with Matchers with ScalatestRouteTest with MockitoSugar with SidechainBlockFixture with CompanionsFixture with SidechainTypes with BasicAuthenticationFixture{
   implicit def exceptionHandler: ExceptionHandler = SidechainApiErrorHandler.exceptionHandler
 
   implicit def rejectionHandler: RejectionHandler = SidechainApiRejectionHandler.rejectionHandler
@@ -66,9 +64,9 @@ abstract class AccountSidechainApiRouteTest extends AnyWordSpec with Matchers wi
 
   val memoryPool: java.util.List[EthereumTransaction] = utilMocks.transactionList
 
-  val credentials = HttpCredentials.createBasicHttpCredentials("username","password")
-  val badCredentials = HttpCredentials.createBasicHttpCredentials("username","wrong_password")
-  val apiKeyHash = BCrypt.`with`(BCrypt.Version.VERSION_2Y).hashToString(12, credentials.password().toCharArray)
+  val credentials = getBasicAuthCredentials()
+  val badCredentials = getBasicAuthCredentials(password = "wrong_password")
+  val apiKeyHash = getBasicAuthApiKeyHash(credentials.password())
 
   val mockedRESTSettings: RESTApiSettings = mock[RESTApiSettings]
   Mockito.when(mockedRESTSettings.timeout).thenAnswer(_ => 1 seconds)

--- a/sdk/src/test/scala/io/horizen/account/api/http/route/AccountSidechainApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/http/route/AccountSidechainApiRouteTest.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit
 import akka.testkit.{TestActor, TestProbe}
+import at.favre.lib.crypto.bcrypt.BCrypt
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper, SerializationFeature}
 import io.horizen.AbstractSidechainNodeViewHolder.ReceivableMessages._
 import io.horizen.SidechainTypes
@@ -27,7 +28,6 @@ import io.horizen.params.MainNetParams
 import io.horizen.secret.SecretSerializer
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.runner.RunWith
-import org.mindrot.jbcrypt.BCrypt
 import org.mockito.Mockito
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -68,7 +68,7 @@ abstract class AccountSidechainApiRouteTest extends AnyWordSpec with Matchers wi
 
   val credentials = HttpCredentials.createBasicHttpCredentials("username","password")
   val badCredentials = HttpCredentials.createBasicHttpCredentials("username","wrong_password")
-  val apiKeyHash = BCrypt.hashpw(credentials.password(), BCrypt.gensalt())
+  val apiKeyHash = BCrypt.`with`(BCrypt.Version.VERSION_2Y).hashToString(12, credentials.password().toCharArray)
 
   val mockedRESTSettings: RESTApiSettings = mock[RESTApiSettings]
   Mockito.when(mockedRESTSettings.timeout).thenAnswer(_ => 1 seconds)

--- a/sdk/src/test/scala/io/horizen/account/api/http/route/AccountSidechainApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/http/route/AccountSidechainApiRouteTest.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit
 import akka.testkit.{TestActor, TestProbe}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper, SerializationFeature}
+import com.horizen.fixtures.BasicAuthenticationFixture
 import io.horizen.AbstractSidechainNodeViewHolder.ReceivableMessages._
 import io.horizen.SidechainTypes
 import io.horizen.account.api.http.AccountNodeViewUtilMocks

--- a/sdk/src/test/scala/io/horizen/api/http/route/SidechainApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/api/http/route/SidechainApiRouteTest.scala
@@ -1,12 +1,10 @@
 package io.horizen.api.http.route
 
 import akka.actor.{ActorRef, ActorSystem}
-import akka.http.javadsl.model.headers.HttpCredentials
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit
 import akka.testkit.{TestActor, TestProbe}
-import at.favre.lib.crypto.bcrypt.BCrypt
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper, SerializationFeature}
 import io.horizen.AbstractSidechainNodeViewHolder.ReceivableMessages._
 import io.horizen.api.http.SidechainBlockActor.ReceivableMessages.{GenerateSidechainBlocks, SubmitSidechainBlock}
@@ -39,7 +37,6 @@ import io.horizen.utxo.transaction.{BoxTransaction, RegularTransaction}
 import io.horizen.{SidechainSettings, SidechainTypes}
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.runner.RunWith
-import org.mindrot.jbcrypt.BCrypt
 import org.mockito.Mockito
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -70,7 +67,7 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
 @RunWith(classOf[JUnitRunner])
-abstract class SidechainApiRouteTest extends AnyWordSpec with Matchers with ScalatestRouteTest with MockitoSugar with SidechainBlockFixture with CompanionsFixture with SidechainTypes {
+abstract class SidechainApiRouteTest extends AnyWordSpec with Matchers with ScalatestRouteTest with MockitoSugar with SidechainBlockFixture with CompanionsFixture with SidechainTypes with BasicAuthenticationFixture{
 
   implicit def exceptionHandler: ExceptionHandler = SidechainApiErrorHandler.exceptionHandler
 
@@ -127,9 +124,9 @@ abstract class SidechainApiRouteTest extends AnyWordSpec with Matchers with Scal
   val mainchainBlockReferenceInfoRef = utilMocks.mainchainBlockReferenceInfoRef
   val keyRotationProof = utilMocks.keyRotationProof
   val certifiersKeys = utilMocks.certifiersKeys
-  val credentials = HttpCredentials.createBasicHttpCredentials("username","password")
-  val badCredentials = HttpCredentials.createBasicHttpCredentials("username","wrong_password")
-  val apiKeyHash = BCrypt.`with`(BCrypt.Version.VERSION_2Y).hashToString(12, credentials.password().toCharArray)
+  val credentials = getBasicAuthCredentials()
+  val badCredentials = getBasicAuthCredentials(password = "wrong_password")
+  val apiKeyHash = getBasicAuthApiKeyHash(credentials.password())
 
   val mockedRESTSettings: RESTApiSettings = mock[RESTApiSettings]
   Mockito.when(mockedRESTSettings.timeout).thenAnswer(_ => 1 seconds)

--- a/sdk/src/test/scala/io/horizen/api/http/route/SidechainApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/api/http/route/SidechainApiRouteTest.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit
 import akka.testkit.{TestActor, TestProbe}
+import at.favre.lib.crypto.bcrypt.BCrypt
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper, SerializationFeature}
 import io.horizen.AbstractSidechainNodeViewHolder.ReceivableMessages._
 import io.horizen.api.http.SidechainBlockActor.ReceivableMessages.{GenerateSidechainBlocks, SubmitSidechainBlock}
@@ -128,7 +129,7 @@ abstract class SidechainApiRouteTest extends AnyWordSpec with Matchers with Scal
   val certifiersKeys = utilMocks.certifiersKeys
   val credentials = HttpCredentials.createBasicHttpCredentials("username","password")
   val badCredentials = HttpCredentials.createBasicHttpCredentials("username","wrong_password")
-  val apiKeyHash = BCrypt.hashpw(credentials.password(), BCrypt.gensalt())
+  val apiKeyHash = BCrypt.`with`(BCrypt.Version.VERSION_2Y).hashToString(12, credentials.password().toCharArray)
 
   val mockedRESTSettings: RESTApiSettings = mock[RESTApiSettings]
   Mockito.when(mockedRESTSettings.timeout).thenAnswer(_ => 1 seconds)

--- a/sdk/src/test/scala/io/horizen/api/http/route/SidechainApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/api/http/route/SidechainApiRouteTest.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit
 import akka.testkit.{TestActor, TestProbe}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper, SerializationFeature}
+import com.horizen.fixtures.BasicAuthenticationFixture
 import io.horizen.AbstractSidechainNodeViewHolder.ReceivableMessages._
 import io.horizen.api.http.SidechainBlockActor.ReceivableMessages.{GenerateSidechainBlocks, SubmitSidechainBlock}
 import io.horizen.api.http.SidechainTransactionActor.ReceivableMessages.BroadcastTransaction

--- a/tools/sctool/pom.xml
+++ b/tools/sctool/pom.xml
@@ -27,9 +27,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.mindrot</groupId>
-			<artifactId>jbcrypt</artifactId>
-			<version>0.4</version>
+			<groupId>at.favre.lib</groupId>
+			<artifactId>bcrypt</artifactId>
+			<version>0.10.2</version>
 		</dependency>
 	</dependencies>
 

--- a/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
+++ b/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
@@ -626,7 +626,7 @@ public class ScBootstrappingToolCommandProcessor extends CommandProcessor {
             return;
         }
         String toEncode = json.get("string").asText();
-        String encoded = BCrypt.with(BCrypt.Version.VERSION_2Y).hashToString(12, toEncode.toCharArray());
+        String encoded = BCrypt.with(BCrypt.Version.VERSION_2Y).hashToString(8, toEncode.toCharArray());
 
         ObjectNode resJson = new ObjectMapper().createObjectNode();
         resJson.put("encodedString", encoded);

--- a/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
+++ b/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
@@ -1,5 +1,6 @@
 package io.horizen;
 
+import at.favre.lib.crypto.bcrypt.BCrypt;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -54,7 +55,6 @@ import io.horizen.vrf.VrfOutput;
 import scala.Enumeration;
 import scala.collection.Seq;
 import scala.collection.mutable.ListBuffer;
-import org.mindrot.jbcrypt.BCrypt;
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -626,7 +626,8 @@ public class ScBootstrappingToolCommandProcessor extends CommandProcessor {
             return;
         }
         String toEncode = json.get("string").asText();
-        String encoded = BCrypt.hashpw(toEncode, BCrypt.gensalt());
+        String encoded = BCrypt.with(BCrypt.Version.VERSION_2Y).hashToString(12, toEncode.toCharArray());
+
         ObjectNode resJson = new ObjectMapper().createObjectNode();
         resJson.put("encodedString", encoded);
 


### PR DESCRIPTION
## Description
Update Bcrypt library.

## Jira Ticket
[756](https://horizenlabs.atlassian.net/jira/software/c/projects/SDK/boards/14?modal=detail&selectedIssue=SDK-756&assignee=615f31c32f6aed0068c67291)

## Changes

- Updated Bcrypt library inside Bootstrapping tool

## Breaking Changes
- No breaking changes, the new library allows to use older version of algorithm

## Checks
- [✔] Project Builds
- [✔] Project passes unit tests
- [✔] Project passes integration tests (Python)
- [✔] Updated documentation accordingly