### PR TITLE
Truncated Trailing Data in Parsing Functions

### DIFF
--- a/sdk/src/main/java/io/horizen/utils/CheckedCompanion.scala
+++ b/sdk/src/main/java/io/horizen/utils/CheckedCompanion.scala
@@ -1,0 +1,28 @@
+package io.horizen.utils
+
+import sparkz.core.serialization.{BytesSerializable, SparkzSerializer}
+import sparkz.util.serialization.VLQByteBufferReader
+import java.nio.ByteBuffer
+
+/**
+ * Extends the DynamicTypedSerializer with the capability of checking that there are no remaining bytes after the
+ * parsing of the input bytes array. *
+ * */
+trait CheckedCompanion[
+  T<: BytesSerializable,
+  S<: SparkzSerializer[T]
+]
+  extends DynamicTypedSerializer[T, S]
+    {
+      override final def parseBytes(bytes: Array[Byte]): T = {
+        val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
+        val parsedObj = parse(reader)
+        val size = reader.remaining
+        if (size > 0) {
+          val trailingBytes = reader.getBytes(size)
+          throw new IllegalArgumentException(
+            s"Spurious bytes found in byte stream after obj parsing: [${BytesUtils.toHexString(trailingBytes)}]...")
+        }
+        parsedObj
+      }
+    }

--- a/sdk/src/main/scala/io/horizen/account/api/http/route/AccountTransactionApiRoute.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/http/route/AccountTransactionApiRoute.scala
@@ -267,16 +267,15 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
         entity(as[ReqSignTransaction]) {
           body => {
             applyOnNodeView { sidechainNodeView =>
-              val unsignedTxObj = Try {
-                companion.parseBytes(BytesUtils.fromHexString(body.transactionBytes)).asInstanceOf[EthereumTransaction]
-              }
+              val unsignedTxObj = companion.parseBytesTry(BytesUtils.fromHexString(body.transactionBytes))
+
               unsignedTxObj match {
                 case Success(unsignedTx) =>
                   val txCost = unsignedTx.maxCost
                   val secret = getFittingSecret(sidechainNodeView, body.from, txCost)
                   secret match {
                     case Some(secret) =>
-                      val signedTx = signTransactionWithSecret(secret, unsignedTx)
+                      val signedTx = signTransactionWithSecret(secret, unsignedTx.asInstanceOf[EthereumTransaction])
                       ApiResponseUtil.toResponse(rawTransactionResponseRepresentation(signedTx))
                     case None =>
                       ApiResponseUtil.toResponse(ErrorInsufficientBalance("ErrorInsufficientBalance", JOptional.empty()))

--- a/sdk/src/main/scala/io/horizen/account/api/http/route/AccountTransactionApiRoute.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/http/route/AccountTransactionApiRoute.scala
@@ -267,9 +267,7 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
         entity(as[ReqSignTransaction]) {
           body => {
             applyOnNodeView { sidechainNodeView =>
-              val unsignedTxObj = companion.parseBytesTry(BytesUtils.fromHexString(body.transactionBytes))
-
-              unsignedTxObj match {
+              companion.parseBytesTry(BytesUtils.fromHexString(body.transactionBytes)) match {
                 case Success(unsignedTx) =>
                   val txCost = unsignedTx.maxCost
                   val secret = getFittingSecret(sidechainNodeView, body.from, txCost)
@@ -282,7 +280,6 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
                   }
                 case Failure(exception) =>
                   ApiResponseUtil.toResponse(ErrorByteTransactionParsing("ErrorByteTransactionParsing", JOptional.of(exception)))
-
               }
             }
           }
@@ -774,14 +771,6 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
 }
 
 object AccountTransactionRestScheme {
-  @JsonView(Array(classOf[Views.Default]))
-   private[horizen] case class ReqAllTransactions(format: Option[Boolean]) extends SuccessResponse
-
-  @JsonView(Array(classOf[Views.Default]))
-   private[horizen] case class RespAllTransactions(transactions: List[SidechainTypes#SCAT]) extends SuccessResponse
-
-  @JsonView(Array(classOf[Views.Default]))
-   private[horizen] case class RespAllTransactionIds(transactionIds: List[String]) extends SuccessResponse
 
   @JsonView(Array(classOf[Views.Default]))
    private[horizen] case class RespAllWithdrawalRequests(listOfWR: List[WithdrawalRequest]) extends SuccessResponse

--- a/sdk/src/main/scala/io/horizen/account/companion/SidechainAccountTransactionsCompanion.scala
+++ b/sdk/src/main/scala/io/horizen/account/companion/SidechainAccountTransactionsCompanion.scala
@@ -4,12 +4,10 @@ import io.horizen.SidechainTypes
 import io.horizen.account.transaction.AccountTransactionsIdsEnum.EthereumTransactionId
 import io.horizen.account.transaction.EthereumTransactionSerializer
 import io.horizen.transaction.TransactionSerializer
-import io.horizen.utils.{BytesUtils, DynamicTypedSerializer}
-import sparkz.util.serialization.VLQByteBufferReader
+import io.horizen.utils.{CheckedCompanion, DynamicTypedSerializer}
 
 import java.util.{HashMap => JHashMap}
 import java.lang.{Byte => JByte}
-import java.nio.ByteBuffer
 
 case class SidechainAccountTransactionsCompanion(customAccountTransactionSerializers: JHashMap[JByte, TransactionSerializer[SidechainTypes#SCAT]])
   extends DynamicTypedSerializer[SidechainTypes#SCAT, TransactionSerializer[SidechainTypes#SCAT]](
@@ -18,17 +16,5 @@ case class SidechainAccountTransactionsCompanion(customAccountTransactionSeriali
         put(EthereumTransactionId.id(), EthereumTransactionSerializer.getSerializer.asInstanceOf[TransactionSerializer[SidechainTypes#SCAT]])
       }
     },
-    customAccountTransactionSerializers)
-    {
-      override def parseBytes(bytes: Array[Byte]): SidechainTypes#SCAT = {
-        val reader = new VLQByteBufferReader(ByteBuffer.wrap(bytes))
-        val parsedTransaction = parse(reader)
-        val size = reader.remaining
-        if (size > 0) {
-          val trailingBytes = reader.getBytes(size)
-          throw new IllegalArgumentException(
-            s"Spurious bytes found in byte stream after obj parsing: [${BytesUtils.toHexString(trailingBytes)}]...")
-        }
-        parsedTransaction
-      }
-    }
+    customAccountTransactionSerializers
+  ) with CheckedCompanion[SidechainTypes#SCAT, TransactionSerializer[SidechainTypes#SCAT]]

--- a/sdk/src/main/scala/io/horizen/api/http/route/BlockBaseApiRoute.scala
+++ b/sdk/src/main/scala/io/horizen/api/http/route/BlockBaseApiRoute.scala
@@ -216,6 +216,8 @@ abstract class BlockBaseApiRoute[
           s"Block was not created: transactionsBytes parameter can be used only in regtest", JOptional.empty()))
       } else {
 
+        // any exception raised by parsing bytes will result in the offending tx being excluded from container
+        // and that is acceptable because forcing a tx is a feature used in testing
         val forcedTx: Iterable[TX] = body.transactionsBytes
           .map(txBytes => companion.parseBytesTry(BytesUtils.fromHexString(txBytes)))
           .flatten(maybeTx => maybeTx.map(Seq(_)).getOrElse(None))

--- a/sdk/src/main/scala/io/horizen/api/http/route/WalletBaseApiRoute.scala
+++ b/sdk/src/main/scala/io/horizen/api/http/route/WalletBaseApiRoute.scala
@@ -19,7 +19,6 @@ import io.horizen.proposition.{Proposition, VrfPublicKey}
 import io.horizen.secret._
 import io.horizen.transaction.Transaction
 import io.horizen.utils.BytesUtils
-import io.horizen.utxo.api.http.route.ImportSecretsDetail
 import io.horizen.{SidechainNodeViewBase, SidechainTypes}
 import sparkz.core.settings.RESTApiSettings
 
@@ -328,5 +327,18 @@ object WalletBaseErrorResponse {
 
   case class ErrorFailedToParseSecret(description: String, exception: JOptional[Throwable]) extends ErrorResponse {
     override val code: String = "0305"
+  }
+}
+
+
+@JsonView(Array(classOf[Views.Default]))
+case class ImportSecretsDetail private (lineNumber: Int,
+                                        description: String) {
+  def getLineNumber: Int = {
+    lineNumber
+  }
+
+  def getDescription: String = {
+    description
   }
 }

--- a/sdk/src/main/scala/io/horizen/companion/SidechainSecretsCompanion.scala
+++ b/sdk/src/main/scala/io/horizen/companion/SidechainSecretsCompanion.scala
@@ -6,8 +6,7 @@ import io.horizen.SidechainTypes
 import io.horizen.account.secret.PrivateKeySecp256k1Serializer
 import io.horizen.secret.SecretsIdsEnum.{PrivateKey25519SecretId, SchnorrSecretKeyId, VrfPrivateKeySecretId, PrivateKeySecp256k1SecretId}
 import io.horizen.secret.{PrivateKey25519Serializer, SchnorrSecretSerializer, SecretSerializer, VrfSecretKeySerializer}
-import io.horizen.utils.DynamicTypedSerializer
-
+import io.horizen.utils.{CheckedCompanion, DynamicTypedSerializer}
 
 case class SidechainSecretsCompanion(customSecretSerializers: JHashMap[JByte, SecretSerializer[SidechainTypes#SCS]])
   extends DynamicTypedSerializer[SidechainTypes#SCS, SecretSerializer[SidechainTypes#SCS]](
@@ -17,4 +16,5 @@ case class SidechainSecretsCompanion(customSecretSerializers: JHashMap[JByte, Se
       put(SchnorrSecretKeyId.id, SchnorrSecretSerializer.getSerializer.asInstanceOf[SecretSerializer[SidechainTypes#SCS]])
       put(PrivateKeySecp256k1SecretId.id, PrivateKeySecp256k1Serializer.getSerializer.asInstanceOf[SecretSerializer[SidechainTypes#SCS]])
     }},
-    customSecretSerializers)
+    customSecretSerializers
+  ) with CheckedCompanion[SidechainTypes#SCS, SecretSerializer[SidechainTypes#SCS]]

--- a/sdk/src/main/scala/io/horizen/utxo/api/http/route/SidechainWalletApiRoute.scala
+++ b/sdk/src/main/scala/io/horizen/utxo/api/http/route/SidechainWalletApiRoute.scala
@@ -112,7 +112,6 @@ case class SidechainWalletApiRoute(override val settings: RESTApiSettings,
     }
   }
 
-
   def getClassByBoxClassName(className: String): Try[java.lang.Class[_ <: SidechainTypes#SCB]] = {
     Try(Class.forName(className).asSubclass(classOf[SidechainTypes#SCB])) orElse
       Try(Class.forName("io.horizen.utxo.box." + className).asSubclass(classOf[SidechainTypes#SCB]))
@@ -135,14 +134,3 @@ object SidechainWalletRestScheme {
 
 }
 
-@JsonView(Array(classOf[Views.Default]))
-case class ImportSecretsDetail private (lineNumber: Int,
-                                        description: String) {
-  def getLineNumber: Int = {
-    lineNumber
-  }
-
-  def getDescription: String = {
-    description
-  }
-}

--- a/sdk/src/main/scala/io/horizen/utxo/companion/SidechainBoxesCompanion.scala
+++ b/sdk/src/main/scala/io/horizen/utxo/companion/SidechainBoxesCompanion.scala
@@ -5,8 +5,7 @@ import java.lang.{Byte => JByte}
 import io.horizen.utxo.box.CoreBoxesIdsEnum._
 import io.horizen.SidechainTypes
 import io.horizen.utxo.box._
-import io.horizen.utils.DynamicTypedSerializer
-
+import io.horizen.utils.{CheckedCompanion, DynamicTypedSerializer}
 
 case class SidechainBoxesCompanion(customBoxSerializers: JHashMap[JByte, BoxSerializer[SidechainTypes#SCB]])
   extends DynamicTypedSerializer[SidechainTypes#SCB, BoxSerializer[SidechainTypes#SCB]](
@@ -15,5 +14,6 @@ case class SidechainBoxesCompanion(customBoxSerializers: JHashMap[JByte, BoxSeri
         put(WithdrawalRequestBoxId.id(), WithdrawalRequestBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
         put(ForgerBoxId.id(), ForgerBoxSerializer.getSerializer.asInstanceOf[BoxSerializer[SidechainTypes#SCB]])
     }},
-    customBoxSerializers)
+    customBoxSerializers
+  ) with CheckedCompanion[SidechainTypes#SCB, BoxSerializer[SidechainTypes#SCB]]
 

--- a/sdk/src/test/scala/io/horizen/utxo/api/http/route/SidechainTransactionApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/api/http/route/SidechainTransactionApiRouteTest.scala
@@ -4,10 +4,11 @@ import akka.http.scaladsl.model.{ContentTypes, HttpMethods, StatusCodes}
 import akka.http.scaladsl.server.{MalformedRequestContentRejection, MethodRejection, Route}
 import com.google.common.primitives.Bytes
 import io.horizen.api.http.route.SidechainApiRouteTest
+import io.horizen.api.http.route.TransactionBaseErrorResponse._
+import io.horizen.api.http.route.TransactionBaseRestScheme.{ReqAllTransactions, ReqDecodeTransactionBytes}
 import io.horizen.json.SerializationUtil
 import io.horizen.proposition.PublicKey25519Proposition
 import io.horizen.utils.BytesUtils
-import io.horizen.utxo.api.http.route.SidechainTransactionErrorResponse.{ErrorByteTransactionParsing, ErrorNotFoundTransactionId, ErrorNotFoundTransactionInput, GenericTransactionError}
 import io.horizen.utxo.api.http.route.SidechainTransactionRestScheme._
 import io.horizen.utxo.transaction.RegularTransactionSerializer
 import org.junit.Assert._
@@ -32,7 +33,7 @@ class SidechainTransactionApiRouteTest extends SidechainApiRouteTest {
       }
 
       Post(basePath + "allTransactions").withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "allTransactions").withEntity("maybe_a_json") ~> Route.seal(sidechainTransactionApiRoute) ~> check {
         status.intValue() shouldBe StatusCodes.BadRequest.intValue
@@ -40,7 +41,7 @@ class SidechainTransactionApiRouteTest extends SidechainApiRouteTest {
       }
 
       Post(basePath + "findById").withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "findById").withEntity("maybe_a_json") ~> Route.seal(sidechainTransactionApiRoute) ~> check {
         status.intValue() shouldBe StatusCodes.BadRequest.intValue
@@ -48,7 +49,7 @@ class SidechainTransactionApiRouteTest extends SidechainApiRouteTest {
       }
 
       Post(basePath + "decodeTransactionBytes").withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "decodeTransactionBytes").withEntity("maybe_a_json") ~> Route.seal(sidechainTransactionApiRoute) ~> check {
         status.intValue() shouldBe StatusCodes.BadRequest.intValue
@@ -56,68 +57,68 @@ class SidechainTransactionApiRouteTest extends SidechainApiRouteTest {
       }
 
       Post(basePath + "createCoreTransaction").addCredentials(credentials) ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "createCoreTransaction").addCredentials(credentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "createCoreTransaction").addCredentials(credentials) ~> Route.seal(sidechainTransactionApiRoute) ~> check {
         status.intValue() shouldBe StatusCodes.BadRequest.intValue
         responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
       }
       Post(basePath + "createCoreTransaction").addCredentials(badCredentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
 
       Post(basePath + "createCoreTransactionSimplified").addCredentials(credentials) ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "createCoreTransactionSimplified").addCredentials(credentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "createCoreTransactionSimplified").addCredentials(credentials) ~> Route.seal(sidechainTransactionApiRoute) ~> check {
         status.intValue() shouldBe StatusCodes.BadRequest.intValue
         responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
       }
       Post(basePath + "createCoreTransactionSimplified").addCredentials(badCredentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
 
       Post(basePath + "sendCoinsToAddress").addCredentials(credentials) ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "sendCoinsToAddress").addCredentials(credentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "sendCoinsToAddress").addCredentials(credentials) ~> Route.seal(sidechainTransactionApiRoute) ~> check {
         status.intValue() shouldBe StatusCodes.BadRequest.intValue
         responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
       }
       Post(basePath + "sendCoinsToAddress").addCredentials(badCredentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
 
       Post(basePath + "sendTransaction").addCredentials(credentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
       Post(basePath + "sendTransaction").addCredentials(credentials).withEntity("maybe_a_json") ~> Route.seal(sidechainTransactionApiRoute) ~> check {
         status.intValue() shouldBe StatusCodes.BadRequest.intValue
         responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
       }
       Post(basePath + "sendTransaction").addCredentials(badCredentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
 
       Post(basePath + "spendForgingStake").addCredentials(badCredentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
 
       Post(basePath + "makeForgerStake").addCredentials(badCredentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
 
       Post(basePath + "withdrawCoins").addCredentials(badCredentials).withEntity("maybe_a_json") ~> sidechainTransactionApiRoute ~> check {
-        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName.toString)
+        rejection.getClass.getCanonicalName.contains(MalformedRequestContentRejection.getClass.getCanonicalName)
       }
 
     }
@@ -136,7 +137,7 @@ class SidechainTransactionApiRouteTest extends SidechainApiRouteTest {
         assertTrue(result.get("transactions").isArray)
         assertEquals(memoryPool.size(), result.get("transactions").elements().asScala.length)
         val transactionJsonNode = result.get("transactions").elements().asScala.toList
-        for (i <- 0 to transactionJsonNode.size - 1)
+        for (i <- transactionJsonNode.indices)
           jsonChecker.assertsOnTransactionJson(transactionJsonNode(i), memoryPool.get(i))
       }
       // parameter 'format' = false
@@ -152,7 +153,7 @@ class SidechainTransactionApiRouteTest extends SidechainApiRouteTest {
         assertTrue(result.get("transactionIds").isArray)
         assertEquals(memoryPool.size(), result.get("transactionIds").elements().asScala.length)
         val transactionIdsJsonNode = result.get("transactionIds").elements().asScala.toList
-        for (i <- 0 to transactionIdsJsonNode.size - 1)
+        for (i <- transactionIdsJsonNode.indices)
           assertEquals(memoryPool.get(i).id, transactionIdsJsonNode(i).asText())
       }
     }
@@ -466,6 +467,19 @@ class SidechainTransactionApiRouteTest extends SidechainApiRouteTest {
         } catch {
           case _: Throwable => fail()
         }
+      }
+      // add trailing bytes after payload, it should fail
+      Post(basePath + "sendTransaction")
+        .addCredentials(credentials).withEntity(SerializationUtil.serialize(ReqSendTransactionPost(
+        BytesUtils.toHexString(transactionBytes) + "abcd"
+      ))) ~> sidechainTransactionApiRoute ~> check {
+        status.intValue() shouldBe StatusCodes.OK.intValue
+        responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
+        // assert we got an error of the expected type
+        assertsOnSidechainErrorResponseSchema(entityAs[String], ErrorByteTransactionParsing("", JOptional.empty()).code)
+        // assert we have the expected specific error of that type
+        val errMsg = mapper.readTree(entityAs[String]).get("error").get("detail").asText()
+        assertTrue(errMsg.contains("Spurious bytes found"))
       }
       // BytesUtils.fromHexString(body.transactionBytes) -> ERROR
       Post(basePath + "sendTransaction")

--- a/sdk/src/test/scala/io/horizen/utxo/api/http/route/SidechainWalletApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/api/http/route/SidechainWalletApiRouteTest.scala
@@ -3,10 +3,11 @@ package io.horizen.utxo.api.http.route
 import akka.http.scaladsl.model.{ContentTypes, HttpMethods, StatusCodes}
 import akka.http.scaladsl.server.{MalformedRequestContentRejection, MethodRejection, Route}
 import io.horizen.api.http.route.SidechainApiRouteTest
-import io.horizen.api.http.route.WalletBaseErrorResponse.{ErrorPropositionNotFound, ErrorSecretAlreadyPresent, ErrorSecretNotAdded}
+import io.horizen.api.http.route.WalletBaseErrorResponse.{ErrorFailedToParseSecret, ErrorPropositionNotFound, ErrorSecretAlreadyPresent, ErrorSecretNotAdded}
 import io.horizen.api.http.route.WalletBaseRestScheme.{ReqAllPropositions, ReqDumpSecrets, ReqExportSecret, ReqImportSecret}
 import io.horizen.json.SerializationUtil
 import io.horizen.utils.BytesUtils
+import io.horizen.utxo.api.http.route.SidechainTransactionErrorResponse.ErrorByteTransactionParsing
 import io.horizen.utxo.api.http.route.SidechainWalletRestScheme._
 import org.junit.Assert._
 
@@ -282,6 +283,24 @@ class SidechainWalletApiRouteTest extends SidechainApiRouteTest {
     }
 
     "reply at /importSecret" in {
+      //private25519 secret is not added since there are spurious bytes after end of data
+      sidechainApiMockConfiguration.setShould_nodeViewHolder_LocallyGeneratedSecret_reply(false)
+      Post(basePath + "importSecret")
+        .addCredentials(credentials)
+        .withEntity(
+          SerializationUtil.serialize(ReqImportSecret(
+            "00" + // companion type
+              "2b64a179846da0b13ed5b4354dbdeb85a500c60ccb12c01a0fded2bd5d8b58e5" + // 32 bytes
+              "8bb8302e2b46763c830099c6fd862da0774a7b8f1323db5bbd96d3652176e485" + // 32 bytes
+              "ff" // spurious byte
+          ))) ~> sidechainWalletApiRoute ~> check {
+        status.intValue() shouldBe StatusCodes.OK.intValue
+        responseEntity.getContentType() shouldEqual ContentTypes.`application/json`
+        assertsOnSidechainErrorResponseSchema(entityAs[String], ErrorFailedToParseSecret("", JOptional.empty()).code)
+        // assert we have the expected specific error of that type
+        val errMsg = mapper.readTree(entityAs[String]).get("error").get("detail").asText()
+        assertTrue(errMsg.contains("Spurious bytes found"))
+      }
       // private25519 secret is added
       sidechainApiMockConfiguration.setShould_nodeViewHolder_LocallyGeneratedSecret_reply(true)
       Post(basePath + "importSecret")

--- a/sdk/src/test/scala/io/horizen/utxo/api/http/route/SidechainWalletApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/api/http/route/SidechainWalletApiRouteTest.scala
@@ -7,7 +7,6 @@ import io.horizen.api.http.route.WalletBaseErrorResponse.{ErrorFailedToParseSecr
 import io.horizen.api.http.route.WalletBaseRestScheme.{ReqAllPropositions, ReqDumpSecrets, ReqExportSecret, ReqImportSecret}
 import io.horizen.json.SerializationUtil
 import io.horizen.utils.BytesUtils
-import io.horizen.utxo.api.http.route.SidechainTransactionErrorResponse.ErrorByteTransactionParsing
 import io.horizen.utxo.api.http.route.SidechainWalletRestScheme._
 import org.junit.Assert._
 

--- a/sdk/src/test/scala/io/horizen/utxo/companion/SidechainBoxesCompanionTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/companion/SidechainBoxesCompanionTest.scala
@@ -1,5 +1,6 @@
 package io.horizen.utxo.companion
 
+import com.google.common.primitives.Bytes
 import io.horizen.SidechainTypes
 import io.horizen.customtypes._
 import io.horizen.utxo.box.BoxSerializer
@@ -11,6 +12,7 @@ import org.scalatestplus.junit.JUnitSuite
 
 import java.lang.{Byte => JByte}
 import java.util.{HashMap => JHashMap}
+import scala.util.{Failure, Success}
 
 class SidechainBoxesCompanionTest
   extends JUnitSuite
@@ -90,5 +92,39 @@ class SidechainBoxesCompanionTest
     }
 
     assertTrue("Exception must be thrown for unregistered box type.", exceptionThrown)
+  }
+
+
+  @Test
+  def testSpuriousBytes(): Unit = {
+    // Test 1: ZenBox deserialization
+    val zenBox = getZenBox
+    val zenBoxBytes = Bytes.concat(sidechainBoxesCompanion.toBytes(zenBox), new Array[Byte](1))
+
+    assertEquals("Type of serialized box must be ZenBox.", zenBox.boxTypeId(), zenBoxBytes(0))
+    val exception1 = intercept[IllegalArgumentException](
+     sidechainBoxesCompanion.parseBytesTry(zenBoxBytes).get
+    )
+    assertTrue(exception1.getMessage.contains("Spurious bytes found"))
+
+    // Test 2: WithdrawalRequestBox serialization/deserialization
+    val withdrawalRequestBox = getWithdrawalRequestBox
+    val withdrawalRequestBoxBytes = Bytes.concat(sidechainBoxesCompanion.toBytes(withdrawalRequestBox), new Array[Byte](1))
+
+    assertEquals("Type of serialized box must be WithdrawalRequestBox.", withdrawalRequestBox.boxTypeId(), withdrawalRequestBoxBytes(0))
+    val exception2 = intercept[IllegalArgumentException](
+      sidechainBoxesCompanion.parseBytesTry(withdrawalRequestBoxBytes).get
+    )
+    assertTrue(exception2.getMessage.contains("Spurious bytes found"))
+
+    // Test 3: ForgerBox serialization/deserialization
+    val forgerBox = getForgerBox
+    val forgerBoxBytes = Bytes.concat(sidechainBoxesCompanion.toBytes(forgerBox), new Array[Byte](1))
+
+    assertEquals("Type of serialized box must be ForgerBox.", forgerBox.boxTypeId(), forgerBoxBytes(0))
+    val exception3 = intercept[IllegalArgumentException](
+      sidechainBoxesCompanion.parseBytesTry(forgerBoxBytes).get
+    )
+    assertTrue(exception3.getMessage.contains("Spurious bytes found"))
   }
 }

--- a/tools/signingtool/src/main/java/io/horizen/SigningToolCommandProcessor.java
+++ b/tools/signingtool/src/main/java/io/horizen/SigningToolCommandProcessor.java
@@ -278,7 +278,7 @@ public class SigningToolCommandProcessor extends CommandProcessor {
             case SCHNORR:
                 Secret secret;
                 try {
-                    secret = SECRETS_COMPANION.parseBytes(BytesUtils.fromHexString(privateKey));
+                    secret = (Secret)SECRETS_COMPANION.parseBytes(BytesUtils.fromHexString(privateKey));
                 } catch (IllegalArgumentException e) {
                     throw new IllegalArgumentException("Unable to parse privateKey bytes: " + e.getMessage());
                 }
@@ -300,7 +300,7 @@ public class SigningToolCommandProcessor extends CommandProcessor {
     private void signMessageSchnorr(String privateKey, byte[] message) {
         Secret secret;
         try {
-            secret = SECRETS_COMPANION.parseBytes(BytesUtils.fromHexString(privateKey));
+            secret = (Secret)SECRETS_COMPANION.parseBytes(BytesUtils.fromHexString(privateKey));
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Unable to parse privateKey bytes: " + e.getMessage());
         }


### PR DESCRIPTION
Added a trait to be used by companion objects if necessary, in order to have a checked (no trailing data) byte array after the parsing.

https://horizenlabs.atlassian.net/browse/SDK-712