### PR TITLE
Fix RPC parameter types

### DIFF
--- a/sdk/src/main/java/io/horizen/account/api/rpc/handler/RpcException.java
+++ b/sdk/src/main/java/io/horizen/account/api/rpc/handler/RpcException.java
@@ -3,7 +3,7 @@ package io.horizen.account.api.rpc.handler;
 import io.horizen.account.api.rpc.utils.RpcError;
 
 public class RpcException extends Exception {
-    public RpcError error;
+    public final RpcError error;
 
     public RpcException(RpcError error) {
         super(error.toString());

--- a/sdk/src/main/java/io/horizen/account/api/rpc/service/RpcService.java
+++ b/sdk/src/main/java/io/horizen/account/api/rpc/service/RpcService.java
@@ -49,6 +49,14 @@ public class RpcService {
             return convertedArgs;
         } catch (IllegalArgumentException err) {
             LogManager.getLogger().trace("RPC call with invalid params: " + method, err);
+            // look for an RpcException in the root cause
+            var cause = err.getCause();
+            while (cause != null) {
+                if (cause instanceof RpcException) {
+                    throw (RpcException) cause;
+                }
+                cause = cause.getCause();
+            }
             throw new RpcException(RpcError.fromCode(RpcCode.InvalidParams, err.getMessage()));
         }
     }

--- a/sdk/src/main/java/io/horizen/account/api/rpc/types/TransactionArgs.java
+++ b/sdk/src/main/java/io/horizen/account/api/rpc/types/TransactionArgs.java
@@ -1,6 +1,7 @@
 package io.horizen.account.api.rpc.types;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.horizen.account.api.rpc.handler.RpcException;
 import io.horizen.account.api.rpc.utils.RpcCode;
 import io.horizen.account.api.rpc.utils.RpcError;
@@ -8,48 +9,100 @@ import io.horizen.account.proposition.AddressProposition;
 import io.horizen.account.state.Message;
 import io.horizen.account.transaction.EthereumTransaction;
 import io.horizen.account.utils.BigIntegerUtil;
-import io.horizen.account.utils.EthereumTransactionUtils;
 import io.horizen.evm.Address;
 import io.horizen.params.NetworkParams;
 import org.web3j.utils.Numeric;
 
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TransactionArgs {
-    public BigInteger type;
-    public Address from;
-    public Address to;
+    public final BigInteger type;
+    public final Address from;
+    public final Address to;
+    // currently, gas cannot be final because the estimateGas algorithm needs to modify it
     public BigInteger gas;
-    public BigInteger gasPrice;
-    public BigInteger maxFeePerGas;
-    public BigInteger maxPriorityFeePerGas;
-    public BigInteger value;
-    public BigInteger nonce;
+    public final BigInteger gasPrice;
+    public final BigInteger maxFeePerGas;
+    public final BigInteger maxPriorityFeePerGas;
+    public final BigInteger value;
+    public final BigInteger nonce;
 
     // We accept "data" and "input" for backwards-compatibility reasons.
     // "input" is the newer name and should be preferred by clients.
     // Issue detail: https://github.com/ethereum/go-ethereum/issues/15628
-    public String data;
-    public String input;
+    private final byte[] data;
 
     // Introduced by AccessListTxType transaction.
-//    public AccessList[] accessList;
-    public BigInteger chainId;
+//    public final AccessList[] accessList;
+    private final BigInteger chainId;
+
+    public TransactionArgs(
+        @JsonProperty("type") BigInteger type,
+        @JsonProperty("from") Address from,
+        @JsonProperty("to") Address to,
+        @JsonProperty("gas") BigInteger gas,
+        @JsonProperty("gasPrice") BigInteger gasPrice,
+        @JsonProperty("maxFeePerGas") BigInteger maxFeePerGas,
+        @JsonProperty("maxPriorityFeePerGas") BigInteger maxPriorityFeePerGas,
+        @JsonProperty("value") BigInteger value,
+        @JsonProperty("nonce") BigInteger nonce,
+        @JsonProperty("data") byte[] data,
+        @JsonProperty("input") byte[] input,
+        @JsonProperty("chainId") BigInteger chainId
+    ) throws RpcException {
+        if (gasPrice != null && (maxFeePerGas != null || maxPriorityFeePerGas != null)) {
+            throw new RpcException(RpcError.fromCode(
+                RpcCode.InvalidParams,
+                "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified"
+            ));
+        }
+        // Sanity check the EIP-1559 fee parameters if present.
+        if (gasPrice == null && maxFeePerGas != null && maxPriorityFeePerGas != null) {
+            if (maxFeePerGas.compareTo(maxPriorityFeePerGas) < 0) {
+                throw new RpcException(RpcError.fromCode(
+                    RpcCode.InvalidParams,
+                    String.format("maxFeePerGas (%s) < maxPriorityFeePerGas (%s)", maxFeePerGas, maxPriorityFeePerGas)
+                ));
+            }
+        }
+        if (data != null && input != null && !Arrays.equals(data, input)) {
+            throw new RpcException(RpcError.fromCode(
+                RpcCode.InvalidParams,
+                "both \"data\" and \"input\" are set and not equal. Please use \"input\" to pass transaction call data"
+            ));
+        }
+        this.type = type;
+        this.from = from;
+        this.to = to;
+        this.gas = gas;
+        this.gasPrice = gasPrice;
+        this.maxFeePerGas = maxFeePerGas;
+        this.maxPriorityFeePerGas = maxPriorityFeePerGas;
+        this.value = Objects.requireNonNullElse(value, BigInteger.ZERO);
+        this.nonce = nonce;
+        this.data = Objects.requireNonNullElse(input != null ? input : data, new byte[0]);
+        this.chainId = chainId;
+        // sanity check for contract creation
+        if (this.to == null && this.data.length == 0) {
+            throw new RpcException(
+                RpcError.fromCode(RpcCode.InvalidParams, "contract creation without any data provided"));
+        }
+    }
 
     public byte[] getData() {
-        var hex = getDataString();
-        if (hex == null) return null;
-        return Numeric.hexStringToByteArray(hex);
+        return data;
     }
 
     public String getDataString() {
-        return input != null ? input : data;
+        return Numeric.toHexString(data);
     }
 
     /**
-     * Set sender address or use zero address if none specified.
+     * Get sender address or use zero address if none specified.
      */
     public Address getFrom() {
         return from == null ? Address.ZERO : from;
@@ -64,51 +117,26 @@ public class TransactionArgs {
             ));
         }
         var saneType = type == null ? 0 : type.intValueExact();
-
         var optionalToAddress = Optional.ofNullable(to == null ? null : new AddressProposition(to));
-        var dataBytes = EthereumTransactionUtils.getDataFromString(this.getDataString());
 
         switch (saneType) {
             case 0: // LEGACY type
                 if (chainId != null) {
                     // eip155
-                    return new EthereumTransaction(
-                        saneChainId, optionalToAddress,
-                        nonce, gasPrice, gas, value, dataBytes, null
+                    return new EthereumTransaction(saneChainId, optionalToAddress, nonce, gasPrice, gas, value,
+                        data, null
                     );
                 } else {
-                    return new EthereumTransaction(
-                        optionalToAddress,
-                        nonce, gasPrice, gas, value, dataBytes, null
-                    );
+                    return new EthereumTransaction(optionalToAddress, nonce, gasPrice, gas, value, data, null);
                 }
             case 2: // EIP-1559
-                return new EthereumTransaction(
-                    saneChainId, optionalToAddress,
-                    nonce, gas, maxPriorityFeePerGas, maxFeePerGas, value, dataBytes, null
+                return new EthereumTransaction(saneChainId, optionalToAddress, nonce, gas, maxPriorityFeePerGas,
+                    maxFeePerGas, value, data, null
                 );
             default:
                 // unsupported type
                 return null;
         }
-    }
-
-    @Override
-    public String toString() {
-        return "TransactionArgs{" +
-            "type=" + (type != null ? type.toString() : "empty") +
-            ", from=" + (from != null ? from.toString() : "empty") +
-            ", to=" + (to != null ? to.toString() : "empty") +
-            ", gas=" + (gas != null ? gas.toString() : "empty") +
-            ", gasPrice=" + (gasPrice != null ? gasPrice.toString() : "empty") +
-            ", maxFeePerGas=" + (maxFeePerGas != null ? maxFeePerGas.toString() : "empty") +
-            ", maxPriorityFeePerGas=" + (maxPriorityFeePerGas != null ? maxPriorityFeePerGas.toString() : "empty") +
-            ", value=" + (value != null ? value.toString() : "empty") +
-            ", nonce=" + (nonce != null ? nonce.toString() : "empty") +
-            ", data='" + (data != null ? data : "empty") + '\'' +
-            ", input='" + (input != null ? input : "empty") + '\'' +
-            ", chainId=" + (chainId != null ? chainId.toString() : "empty") +
-            '}';
     }
 
     /**
@@ -123,12 +151,6 @@ public class TransactionArgs {
             throw new IllegalArgumentException("baseFee must be not null.");
         }
 
-        if (gasPrice != null && (maxFeePerGas != null || maxPriorityFeePerGas != null)) {
-            throw new RpcException(RpcError.fromCode(
-                RpcCode.InvalidParams,
-                "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified"
-            ));
-        }
         // global RPC gas cap
         var gasLimit = rpcGasCap;
         // cap gas limit given by the caller
@@ -161,17 +183,25 @@ public class TransactionArgs {
                 effectiveGasPrice = baseFee.add(gasTipCap).min(gasFeeCap);
             }
         }
-        return new Message(
-            getFrom(),
-            to == null ? Optional.empty() : Optional.of(to),
-            effectiveGasPrice,
-            gasFeeCap,
-            gasTipCap,
-            gasLimit,
-            value == null ? BigInteger.ZERO : value,
-            nonce,
-            getData(),
-            true
+        return new Message(getFrom(), to == null ? Optional.empty() : Optional.of(to), effectiveGasPrice, gasFeeCap,
+            gasTipCap, gasLimit, value, nonce, getData(), true
         );
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionArgs{" +
+            "type=" + (type != null ? type.toString() : "empty") +
+            ", from=" + (from != null ? from.toString() : "empty") +
+            ", to=" + (to != null ? to.toString() : "empty") +
+            ", gas=" + (gas != null ? gas.toString() : "empty") +
+            ", gasPrice=" + (gasPrice != null ? gasPrice.toString() : "empty") +
+            ", maxFeePerGas=" + (maxFeePerGas != null ? maxFeePerGas.toString() : "empty") +
+            ", maxPriorityFeePerGas=" + (maxPriorityFeePerGas != null ? maxPriorityFeePerGas.toString() : "empty") +
+            ", value=" + value.toString() +
+            ", nonce=" + (nonce != null ? nonce.toString() : "empty") +
+            ", data='" + getDataString() + "'" +
+            ", chainId=" + (chainId != null ? chainId.toString() : "empty") +
+            '}';
     }
 }

--- a/sdk/src/main/java/io/horizen/account/api/rpc/types/TransactionArgs.java
+++ b/sdk/src/main/java/io/horizen/account/api/rpc/types/TransactionArgs.java
@@ -34,11 +34,11 @@ public class TransactionArgs {
     // We accept "data" and "input" for backwards-compatibility reasons.
     // "input" is the newer name and should be preferred by clients.
     // Issue detail: https://github.com/ethereum/go-ethereum/issues/15628
-    private final byte[] data;
+    public final byte[] data;
 
     // Introduced by AccessListTxType transaction.
 //    public final AccessList[] accessList;
-    private final BigInteger chainId;
+    public final BigInteger chainId;
 
     public TransactionArgs(
         @JsonProperty("type") BigInteger type,
@@ -93,14 +93,6 @@ public class TransactionArgs {
         }
     }
 
-    public byte[] getData() {
-        return data;
-    }
-
-    public String getDataString() {
-        return Numeric.toHexString(data);
-    }
-
     /**
      * Get sender address or use zero address if none specified.
      */
@@ -125,7 +117,7 @@ public class TransactionArgs {
             throw new RpcException(RpcError.fromCode(RpcCode.InvalidParams, "missing gas limit"));
         }
         var saneType = type == null ? 0 : type.intValueExact();
-        var optionalToAddress = Optional.ofNullable(to == null ? null : new AddressProposition(to));
+        var optionalToAddress = Optional.ofNullable(to).map(AddressProposition::new);
 
         switch (saneType) {
             case 0: // LEGACY type
@@ -199,8 +191,9 @@ public class TransactionArgs {
                 effectiveGasPrice = baseFee.add(gasTipCap).min(gasFeeCap);
             }
         }
-        return new Message(getFrom(), to == null ? Optional.empty() : Optional.of(to), effectiveGasPrice, gasFeeCap,
-            gasTipCap, gasLimit, value, nonce, getData(), true
+        return new Message(
+            getFrom(), Optional.ofNullable(to), effectiveGasPrice, gasFeeCap, gasTipCap, gasLimit, value, nonce, data,
+            true
         );
     }
 
@@ -216,7 +209,7 @@ public class TransactionArgs {
             ", maxPriorityFeePerGas=" + (maxPriorityFeePerGas != null ? maxPriorityFeePerGas.toString() : "empty") +
             ", value=" + value.toString() +
             ", nonce=" + (nonce != null ? nonce.toString() : "empty") +
-            ", data='" + getDataString() + "'" +
+            ", data='" + Numeric.toHexString(data) + "'" +
             ", chainId=" + (chainId != null ? chainId.toString() : "empty") +
             '}';
     }

--- a/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
@@ -285,16 +285,12 @@ class EthService(
           highBound = blockContext.blockGasLimit
         }
         // Normalize the max fee per gas the call is willing to spend.
-        var feeCap = BigInteger.ZERO
-        if (params.gasPrice != null && (params.maxFeePerGas != null || params.maxPriorityFeePerGas != null)) {
-          throw new RpcException(
-            RpcError
-              .fromCode(RpcCode.InvalidParams, "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
-          )
-        } else if (params.gasPrice != null) {
-          feeCap = params.gasPrice
+        val feeCap = if (params.gasPrice != null) {
+          params.gasPrice
         } else if (params.maxFeePerGas != null) {
-          feeCap = params.maxFeePerGas
+          params.maxFeePerGas
+        } else {
+          BigInteger.ZERO
         }
         // Recap the highest gas limit with account's available balance.
         if (feeCap.bitLength() > 0) {


### PR DESCRIPTION
- refactored `TransactionArgs` and `FilterQuery` to be immutable as much as possible
- added more validation to both types
- this also fixes a `NullPointerException` caused by optional arguments being omitted, e.g. omitting `value` from an RPC call to `eth_sendTransaction`