### PR TITLE
zendoo-sc-crpytolib version upgraded to 0.6.0

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>io.horizen</groupId>
       <artifactId>zendoo-sc-cryptolib</artifactId>
-      <version>0.6.0-rc1</version>
+      <version>0.6.0</version>
       <scope>compile</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.sparkzfoundation/sparkz-core -->


### PR DESCRIPTION
Regression passed. New version is backward compatible to the 0.6.0-rc1