### PR TITLE
Sdk-658 mempool size issues

### DIFF
--- a/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
@@ -234,7 +234,9 @@ abstract class AbstractSidechainNodeViewHolder[
     val txToMempool = rolledBackTxs.filter(tx =>
       !appliedTxs.exists(t => t.id == tx.id))
 
-    memPool.putWithoutCheck(txToMempool).filter(tx =>
+    val filteredMempool = memPool.filter(tx => !appliedTxs.exists(t => t.id == tx.id))
+
+    filteredMempool.putWithoutCheck(txToMempool).filter(tx =>
       {
         state match {
           case v: TransactionValidation[TX@unchecked] => v.validate(tx).isSuccess

--- a/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
@@ -15,6 +15,7 @@ import sparkz.core.NodeViewHolder.ReceivableMessages.LocallyGeneratedTransaction
 import sparkz.core.consensus.History.ProgressInfo
 import sparkz.core.network.NodeViewSynchronizer.ReceivableMessages._
 import sparkz.core.settings.SparkzSettings
+import sparkz.core.transaction.state.TransactionValidation
 import sparkz.core.utils.NetworkTimeProvider
 import sparkz.core.{DefaultModifiersCache, ModifiersCache, idToVersion}
 
@@ -225,6 +226,22 @@ abstract class AbstractSidechainNodeViewHolder[
       applyLocallyGeneratedTransactions(newTxs.txs)
   }
 
+  override protected def updateMemPool(blocksRemoved: Seq[PMOD], blocksApplied: Seq[PMOD], memPool: MP, state: MS): MP = {
+    val rolledBackTxs = blocksRemoved.flatMap(extractTransactions)
+
+    val appliedTxs = blocksApplied.flatMap(extractTransactions)
+
+    val txToMempool = rolledBackTxs.filter(tx =>
+      !appliedTxs.exists(t => t.id == tx.id))
+
+    memPool.putWithoutCheck(txToMempool).filter(tx =>
+      {
+        state match {
+          case v: TransactionValidation[TX@unchecked] => v.validate(tx).isSuccess
+          case _ => true
+        }
+      })
+  }
 
   // This method is actually a copy-paste of parent NodeViewHolder.pmodModify method.
   // The difference is that modifiers are applied to the State and Wallet simultaneously.

--- a/sdk/src/test/scala/io/horizen/fixtures/MockedSidechainNodeViewHolderFixture.scala
+++ b/sdk/src/test/scala/io/horizen/fixtures/MockedSidechainNodeViewHolderFixture.scala
@@ -7,6 +7,8 @@ import io.horizen.utxo.mempool.SidechainMemoryPool
 import io.horizen.utxo.state.SidechainState
 import io.horizen.utxo.SidechainNodeViewHolder
 import io.horizen.utxo.wallet.SidechainWallet
+import io.horizen.utxo.block.SidechainBlock
+import akka.testkit.TestActorRef
 import org.mockito.Mockito
 import org.scalatestplus.mockito.MockitoSugar
 import sparkz.core.settings.{NetworkSettings, SparkzSettings}
@@ -15,13 +17,17 @@ class MockedSidechainNodeViewHolder(sidechainSettings: SidechainSettings,
                                     history: SidechainHistory,
                                     state: SidechainState,
                                     wallet: SidechainWallet,
-                                    mempool: SidechainMemoryPool)
+                                    var mempool: SidechainMemoryPool)
   extends SidechainNodeViewHolder(sidechainSettings, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null ) {
 
   override def dumpStorages: Unit = {}
 
   override def restoreState(): Option[(HIS, MS, VL, MP)] = {
     Some(history, state, wallet, mempool)
+  }
+
+  def updateMempool(blocksRemoved: Seq[SidechainBlock], blocksApplied: Seq[SidechainBlock], state: SidechainState): Unit = {
+     this.mempool = this.updateMemPool(blocksRemoved, blocksApplied, this.mempool, state)
   }
 }
 
@@ -56,5 +62,34 @@ trait MockedSidechainNodeViewHolderFixture extends MockitoSugar {
         10000000L
       })
     actorSystem.actorOf(Props(new MockedSidechainNodeViewHolder(sidechainSettings, history, state, wallet, mempool)))
+  }
+
+  def getMockedSidechainNodeViewHolderTestRef(history: SidechainHistory, state: SidechainState, wallet: SidechainWallet, mempool: SidechainMemoryPool)
+                                         (implicit actorSystem: ActorSystem): TestActorRef[MockedSidechainNodeViewHolder] = {
+    val sidechainSettings = mock[SidechainSettings]
+    val sparkzSettings = mock[SparkzSettings]
+    val networkSettings = mock[NetworkSettings]
+    val walletSettings = mock[WalletSettings]
+    Mockito.when(sidechainSettings.sparkzSettings)
+      .thenAnswer(answer => {
+        sparkzSettings
+      })
+    Mockito.when(sparkzSettings.network)
+      .thenAnswer(answer => {
+        networkSettings
+      })
+    Mockito.when(networkSettings.maxModifiersCacheSize)
+      .thenAnswer(answer => {
+        maxModifiersCacheSize
+      })
+    Mockito.when(sidechainSettings.wallet)
+      .thenAnswer(answer => {
+        walletSettings
+      })
+    Mockito.when(sidechainSettings.wallet.maxTxFee)
+      .thenAnswer(answer => {
+        10000000L
+      })
+    TestActorRef(Props(new MockedSidechainNodeViewHolder(sidechainSettings, history, state, wallet, mempool)))
   }
 }

--- a/sdk/src/test/scala/io/horizen/fixtures/SidechainBlockFixture.scala
+++ b/sdk/src/test/scala/io/horizen/fixtures/SidechainBlockFixture.scala
@@ -202,12 +202,13 @@ trait SidechainBlockFixture extends MainchainBlockReferenceFixture with Sidechai
                                  companion: SidechainTransactionsCompanion,
                                  params: NetworkParams,
                                  basicSeed: Long = 123177L,
-                                 timestampDelta: Long = blockGenerationDelta): SidechainBlock = {
+                                 timestampDelta: Long = blockGenerationDelta,
+                                 sidechainTransactions: Seq[SidechainTransaction[Proposition, Box[Proposition]]] = Seq()): SidechainBlock = {
     SidechainBlockFixture.copy(sidechainBlock,
       parentId = sidechainBlock.id,
       timestamp = sidechainBlock.timestamp + blockGenerationDelta,
       mainchainBlocksReferencesData = Seq(),
-      sidechainTransactions = Seq(),
+      sidechainTransactions = sidechainTransactions,
       mainchainHeaders = Seq(),
       companion = companion,
       params = params,

--- a/sdk/src/test/scala/io/horizen/fixtures/TransactionFixture.scala
+++ b/sdk/src/test/scala/io/horizen/fixtures/TransactionFixture.scala
@@ -116,6 +116,20 @@ trait TransactionFixture extends BoxFixture {
     RegularTransaction.create(from, to, 5L)
   }
 
+  def getCompatibleTransaction(fee: Long, numberoOfOutputs: Int): RegularTransaction = {
+    val from: JList[JPair[ZenBox, PrivateKey25519]] = new JArrayList[JPair[ZenBox, PrivateKey25519]]()
+    val to: JList[BoxData[_ <: Proposition, _ <: Box[_ <: Proposition]]] = new JArrayList()
+
+    from.add(new JPair(getZenBox(pk3.publicImage(), 1, 10), pk3))
+    from.add(new JPair(getZenBox(pk4.publicImage(), 1, 10), pk4))
+
+    for (i <- 1 to numberoOfOutputs) {
+      to.add(new ZenBoxData(pk7.publicImage(), 15L))
+    }
+
+    RegularTransaction.create(from, to, fee)
+  }
+
   def getIncompatibleTransaction: RegularTransaction = {
     val from: JList[JPair[ZenBox,PrivateKey25519]] = new JArrayList[JPair[ZenBox,PrivateKey25519]]()
     val to: JList[BoxData[_ <: Proposition, _ <: Box[_ <: Proposition]]] = new JArrayList()
@@ -128,6 +142,19 @@ trait TransactionFixture extends BoxFixture {
     RegularTransaction.create(from, to, 5L)
   }
 
+  def getIncompatibleTransaction(fee: Long, numberoOfOutputs: Int): RegularTransaction = {
+    val from: JList[JPair[ZenBox, PrivateKey25519]] = new JArrayList[JPair[ZenBox, PrivateKey25519]]()
+    val to: JList[BoxData[_ <: Proposition, _ <: Box[_ <: Proposition]]] = new JArrayList()
+
+    from.add(new JPair(getZenBox(pk3.publicImage(), 1, 10), pk5))
+    from.add(new JPair(getZenBox(pk6.publicImage(), 1, 10), pk6))
+
+    for (i <- 1 to numberoOfOutputs) {
+      to.add(new ZenBoxData(pk7.publicImage(), 20L))
+    }
+
+    RegularTransaction.create(from, to, fee)
+  }
 
   def getRegularTransactionList(count: Int): JList[RegularTransaction] = {
     val transactionList : JList[RegularTransaction] = new JArrayList[RegularTransaction]()

--- a/sdk/src/test/scala/io/horizen/utxo/SidechainNodeViewHolderTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/SidechainNodeViewHolderTest.scala
@@ -648,6 +648,7 @@ class SidechainNodeViewHolderTest extends JUnitSuite
     val secondLowestFeeTx = getRegularRandomTransaction(20, 580)
     val compatibleTransactin = getCompatibleTransaction(30, 580)
     val incompatibleTransactin = getIncompatibleTransaction(30, 580)
+    val incompatibleTransactin2 = getIncompatibleTransaction(30, 580)
     val highFeeTransaction = getRegularRandomTransaction(40, 580)
     list += lowestFeeTx
     list += secondLowestFeeTx
@@ -680,6 +681,7 @@ class SidechainNodeViewHolderTest extends JUnitSuite
     Mockito.when(state.validate(ArgumentMatchers.any[SidechainTypes#SCBT])).thenReturn(Try{})
 
     // Test blocks
+    // Try to add andremove transaction from mempool
     val removedBlock1 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq(commontransaction))
     val appliedBlock1 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq(commontransaction))
     val appliedBlock2 = generateNextSidechainBlock(appliedBlock1, sidechainTransactionsCompanion, params, sidechainTransactions = Seq())
@@ -689,6 +691,7 @@ class SidechainNodeViewHolderTest extends JUnitSuite
     assertEquals("Common transaction must not be present ", false, nodeViewHolder.mempool.getTransactionById(commontransaction.id()).isPresent)
     assertEquals("Lowest fee transaction must be present ", true, nodeViewHolder.mempool.getTransactionById(lowestFeeTx.id()).isPresent)
 
+    // Try to add incompatible transaction
     val removedBlock2 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq(incompatibleTransactin))
     val appliedBlock3 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq())
 
@@ -698,7 +701,8 @@ class SidechainNodeViewHolderTest extends JUnitSuite
     assertEquals("IncompatibleTransactin transaction must not be present ", false, nodeViewHolder.mempool.getTransactionById(incompatibleTransactin.id()).isPresent)
     assertEquals("Lowest fee transaction must be present ", true, nodeViewHolder.mempool.getTransactionById(lowestFeeTx.id()).isPresent)
 
-    val removedBlock3 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq(highFeeTransaction))
+    // Try to replace transaction with lowest fee
+    val removedBlock3 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq(highFeeTransaction, incompatibleTransactin, incompatibleTransactin2))
     val appliedBlock4 = generateNextSidechainBlock(appliedBlock1, sidechainTransactionsCompanion, params, sidechainTransactions = Seq())
 
     nodeViewHolder.mempool.maxPoolSizeBytes = totalTxSize

--- a/sdk/src/test/scala/io/horizen/utxo/SidechainNodeViewHolderTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/SidechainNodeViewHolderTest.scala
@@ -1,13 +1,14 @@
 package io.horizen.utxo
 
 import akka.actor.{ActorRef, ActorSystem}
-import akka.testkit.TestProbe
+import akka.testkit.{TestActorRef, TestProbe}
 import akka.util.Timeout
 import io.horizen.MempoolSettings
 import io.horizen.utxo.companion.SidechainTransactionsCompanion
 import io.horizen.consensus.{ConsensusEpochInfo, FullConsensusEpochInfo, intToConsensusEpochNumber}
 import io.horizen.fixtures._
 import io.horizen.params.{NetworkParams, RegTestParams}
+import io.horizen.SidechainTypes
 import io.horizen.utils.{CountDownLatchController, MerkleTree, WithdrawalEpochInfo}
 import io.horizen.utxo.block.SidechainBlock
 import io.horizen.utxo.box.ZenBox
@@ -15,6 +16,7 @@ import io.horizen.utxo.chain.SidechainFeePaymentsInfo
 import io.horizen.utxo.history.SidechainHistory
 import io.horizen.utxo.mempool.SidechainMemoryPool
 import io.horizen.utxo.state.{SidechainState, UtxoMerkleTreeView}
+import io.horizen.utxo.transaction.RegularTransaction
 import io.horizen.utxo.utils.BlockFeeInfo
 import io.horizen.utxo.wallet.SidechainWallet
 import org.junit.Assert.{assertEquals, assertTrue}
@@ -33,12 +35,14 @@ import java.nio.charset.StandardCharsets
 import java.util
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success, Try}
+import scala.collection.mutable
 
 class SidechainNodeViewHolderTest extends JUnitSuite
   with MockedSidechainNodeViewHolderFixture
   with SidechainBlockFixture
   with CompanionsFixture
   with SparkzEncoding
+  with TransactionFixture
 {
   var history: SidechainHistory = _
   var state: SidechainState = _
@@ -635,4 +639,64 @@ class SidechainNodeViewHolderTest extends JUnitSuite
         }
     }
   }
+
+  @Test
+  def applyWithFullMempool(): Unit = {
+    // Filling mempool
+    val list = mutable.MutableList[RegularTransaction]()
+    val lowestFeeTx = getRegularRandomTransaction(10, 10)
+    val secondLowestFeeTx = getRegularRandomTransaction(20, 10)
+    val compatibleTransactin = getCompatibleTransaction(30, 10)
+    val incompatibleTransactin = getIncompatibleTransaction(30, 10)
+    val highFeeTransaction = getRegularRandomTransaction(40, 9)
+    list += lowestFeeTx
+    list += secondLowestFeeTx
+    list += compatibleTransactin
+    val totalTxSize = lowestFeeTx.size() + secondLowestFeeTx.size() + compatibleTransactin.size()
+    mempool = SidechainMemoryPool.createEmptyMempool(getMockedMempoolSettings(1))
+    mempool.maxPoolSizeBytes = totalTxSize
+
+    val mockedNodeViewHolderTestRef: TestActorRef[MockedSidechainNodeViewHolder] = getMockedSidechainNodeViewHolderTestRef(history, state, wallet, mempool)
+    val nodeViewHolder:MockedSidechainNodeViewHolder = mockedNodeViewHolderTestRef.underlyingActor
+
+    //put all transaction
+    for (i <- 0 to (list.size - 1)) {
+      assertEquals("Put tx operation must be success.", true, mempool.put(list.apply(i)).isSuccess)
+    }
+    assertEquals("MemoryPool must have correct size ", list.size, mempool.size)
+    assertEquals("Lowest fee transaction must be present ", true, mempool.getTransactionById(lowestFeeTx.id()).isPresent)
+
+    val commontransaction = getRegularRandomTransaction(15, 10)
+
+    Mockito.when(state.validate(ArgumentMatchers.any[SidechainTypes#SCBT])).thenReturn(Try{})
+
+    // Test blocks
+    val removedBlock1 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq(commontransaction))
+    val appliedBlock1 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq(commontransaction))
+    val appliedBlock2 = generateNextSidechainBlock(appliedBlock1, sidechainTransactionsCompanion, params, sidechainTransactions = Seq())
+
+    nodeViewHolder.updateMempool(Seq(removedBlock1), Seq(appliedBlock1, appliedBlock2), state)
+    assertEquals("MemoryPool must have correct size ", list.size, nodeViewHolder.mempool.size)
+    assertEquals("Common transaction must not be present ", false, nodeViewHolder.mempool.getTransactionById(commontransaction.id()).isPresent)
+    assertEquals("Lowest fee transaction must be present ", true, nodeViewHolder.mempool.getTransactionById(lowestFeeTx.id()).isPresent)
+
+    val removedBlock2 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq(incompatibleTransactin))
+    val appliedBlock3 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq())
+
+    nodeViewHolder.mempool.maxPoolSizeBytes = totalTxSize
+    nodeViewHolder.updateMempool(Seq(removedBlock2), Seq(appliedBlock3), state)
+    assertEquals("MemoryPool must have correct size ", list.size, nodeViewHolder.mempool.size)
+    assertEquals("IncompatibleTransactin transaction must not be present ", false, nodeViewHolder.mempool.getTransactionById(incompatibleTransactin.id()).isPresent)
+    assertEquals("Lowest fee transaction must be present ", true, nodeViewHolder.mempool.getTransactionById(lowestFeeTx.id()).isPresent)
+
+    val removedBlock3 = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, sidechainTransactions = Seq(highFeeTransaction))
+    val appliedBlock4 = generateNextSidechainBlock(appliedBlock1, sidechainTransactionsCompanion, params, sidechainTransactions = Seq())
+
+    nodeViewHolder.mempool.maxPoolSizeBytes = totalTxSize
+    nodeViewHolder.updateMempool(Seq(removedBlock3), Seq(appliedBlock4), state)
+    assertEquals("MemoryPool must have correct size ", list.size, nodeViewHolder.mempool.size)
+    assertEquals("HighFeeTransaction transaction must be present ", true, nodeViewHolder.mempool.getTransactionById(highFeeTransaction.id()).isPresent)
+    assertEquals("Lowest fee transaction must not be present ", false, nodeViewHolder.mempool.getTransactionById(lowestFeeTx.id()).isPresent)
+  }
+
 }


### PR DESCRIPTION
 - Fixed issue of adding transaction to the full mempool. Adding transaction cause removing transaction with the lowest fee rate  but it may happen that finally this transaction won't be added. addWithSizeCheck removes transaction from mempool only after checking that new transaction can be applied.
 - Overrided UpdateMempool AbstractSidechainNodeViewHolder. Earlier it added all transactions from removed blocks to the mempool and only after that filtering them with transaction from applied blocks. It also may cause removing low fee rate transaction from the full mempool.
 - Added unit test for before mention cases.