### PR TITLE
NCC. Height restriction for the Merkel Tree Wrapper.

### DIFF
--- a/sdk/src/main/java/io/horizen/cryptolibprovider/utils/InMemorySparseMerkleTreeWrapper.java
+++ b/sdk/src/main/java/io/horizen/cryptolibprovider/utils/InMemorySparseMerkleTreeWrapper.java
@@ -15,8 +15,13 @@ public class InMemorySparseMerkleTreeWrapper implements AutoCloseable {
     private final InMemorySparseMerkleTree merkleTree;
     private final long leavesNumber;
     private final RangeSet<Long> emptyLeaves;
+    public static final int MAX_TREE_HEIGHT = 22;
 
     public InMemorySparseMerkleTreeWrapper(int height) {
+        if (height < 0 || height > MAX_TREE_HEIGHT) {
+            throw new IllegalArgumentException("Height must be not less than 0 and less or equal to " + MAX_TREE_HEIGHT);
+        }
+
         merkleTree = InMemorySparseMerkleTree.init(height);
         leavesNumber = 1L << height;
         emptyLeaves = TreeRangeSet.create(Arrays.asList(Range.closedOpen(0L, leavesNumber)));

--- a/sdk/src/test/java/io/horizen/cryptolibprovider/InMemorySparseMerkleTreeWrapperTest.java
+++ b/sdk/src/test/java/io/horizen/cryptolibprovider/InMemorySparseMerkleTreeWrapperTest.java
@@ -158,4 +158,37 @@ public class InMemorySparseMerkleTreeWrapperTest {
             merkleTreeWrapper.close();
         } catch (Exception ignored) {}
     }
+
+    @Test
+    public void heightCheck() {
+        boolean illegarArgumentExceptionOccured = false;
+        // Negative height check
+        try {
+            new InMemorySparseMerkleTreeWrapper(-1);
+        } catch (IllegalArgumentException ex) {
+            illegarArgumentExceptionOccured = true;
+        }
+
+        assertTrue("IllegalArgumentException expected to be occured ", illegarArgumentExceptionOccured);
+
+        illegarArgumentExceptionOccured = false;
+        // Too large height check
+        try {
+            new InMemorySparseMerkleTreeWrapper(InMemorySparseMerkleTreeWrapper.MAX_TREE_HEIGHT + 1);
+        } catch (IllegalArgumentException ex) {
+            illegarArgumentExceptionOccured = true;
+        }
+
+        assertTrue("IllegalArgumentException expected to be occured ", illegarArgumentExceptionOccured);
+
+        // Successful case
+        try {
+            new InMemorySparseMerkleTreeWrapper(InMemorySparseMerkleTreeWrapper.MAX_TREE_HEIGHT);
+            illegarArgumentExceptionOccured = false;
+        } catch (IllegalArgumentException ex) {
+            illegarArgumentExceptionOccured = true;
+        }
+
+        assertFalse("IllegalArgumentException not expected to be occured ", illegarArgumentExceptionOccured);
+    }
 }


### PR DESCRIPTION
Added height restriction for the Merkel Tree Wrapper.
Height must be not less than 0 and less or equal to 22.

Added tests to check these restrictions.