### PR TITLE
[SDK-827] StateDbAccountStateView: failed transaction log level fixes

### DIFF
--- a/sdk/src/main/java/io/horizen/account/state/ExecutionRevertedException.java
+++ b/sdk/src/main/java/io/horizen/account/state/ExecutionRevertedException.java
@@ -1,23 +1,25 @@
 package io.horizen.account.state;
 
+import org.web3j.utils.Numeric;
+
 /**
  * Message processing failed, also revert-and-keep-gas-left.
  */
 public class ExecutionRevertedException extends ExecutionFailedException {
-    public final byte[] revertReason;
+    public final byte[] returnData;
 
-    public ExecutionRevertedException(byte[] revertReason) {
-        super("execution reverted");
-        this.revertReason = revertReason;
+    public ExecutionRevertedException(byte[] returnData) {
+        super(String.format("execution reverted with return data \"%s\"", Numeric.toHexString(returnData)));
+        this.returnData = returnData;
     }
 
     public ExecutionRevertedException(String message) {
         super(message);
-        this.revertReason = new byte[0];
+        this.returnData = new byte[0];
     }
 
     public ExecutionRevertedException(String message, Throwable cause) {
         super(message, cause);
-        this.revertReason = new byte[0];
+        this.returnData = new byte[0];
     }
 }

--- a/sdk/src/main/java/io/horizen/account/state/ExecutionRevertedException.java
+++ b/sdk/src/main/java/io/horizen/account/state/ExecutionRevertedException.java
@@ -1,6 +1,7 @@
 package io.horizen.account.state;
 
 import org.web3j.utils.Numeric;
+import scala.Array;
 
 /**
  * Message processing failed, also revert-and-keep-gas-left.
@@ -15,11 +16,11 @@ public class ExecutionRevertedException extends ExecutionFailedException {
 
     public ExecutionRevertedException(String message) {
         super(message);
-        this.returnData = new byte[0];
+        this.returnData = Array.emptyByteArray();
     }
 
     public ExecutionRevertedException(String message, Throwable cause) {
         super(message, cause);
-        this.returnData = new byte[0];
+        this.returnData = Array.emptyByteArray();
     }
 }

--- a/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
@@ -87,7 +87,7 @@ class EthService(
           case err: RpcException => throw err
           case reverted: ExecutionRevertedException =>
             throw new RpcException(
-              new RpcError(RpcCode.ExecutionError.code, reverted.getMessage, Numeric.toHexString(reverted.revertReason))
+              new RpcError(RpcCode.ExecutionError.code, reverted.getMessage, Numeric.toHexString(reverted.returnData))
             )
           case err: ExecutionFailedException =>
             throw new RpcException(new RpcError(RpcCode.ExecutionError.code, err.getMessage, null))
@@ -350,7 +350,7 @@ class EthService(
       val (success, reverted) = check(highBound)
       if (!success) {
         val error = reverted
-          .map(err => RpcError.fromCode(RpcCode.ExecutionReverted, Numeric.toHexString(err.revertReason)))
+          .map(err => RpcError.fromCode(RpcCode.ExecutionReverted, Numeric.toHexString(err.returnData)))
           .getOrElse(RpcError.fromCode(RpcCode.InvalidParams, s"gas required exceeds allowance ($highBound)"))
         throw new RpcException(error)
       }

--- a/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateView.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateView.scala
@@ -208,7 +208,7 @@ class StateDbAccountStateView(
       } catch {
         // any other exception will bubble up and invalidate the block
         case err: ExecutionFailedException =>
-          log.error(s"applying message failed, tx.id=${ethTx.id}", err)
+          log.debug(s"applying message failed, tx id: ${ethTx.id}, reason: ${err.getMessage}")
           ReceiptStatus.FAILED
       } finally {
         // finalize pending changes, clear the journal and reset refund counter


### PR DESCRIPTION
Before:
```
[ERROR] 2023-03-30 19:24:22:674 +0300 [StateDbAccountStateView.scala:211 ] [2-Hop-akka.actor.default-dispatcher-16] io.horizen.account.state.AccountStateView - applying message failed, tx.id=3bc1b2459b8ed7608b2b50ac2db8810dc4e56d46df14a9039510b27b73a995b4
io.horizen.account.state.ExecutionRevertedException: Key Rotation Proof is invalid: Key rotation proof - master signature is invalid: 0
	at io.horizen.account.state.CertificateKeyRotationMsgProcessor.execSubmitKeyRotation(CertificateKeyRotationMsgProcessor.scala:159) ~[sidechains-sdk-0.7.0-SNAPSHOT.jar:0.7.0-SNAPSHOT]
	at io.horizen.account.state.CertificateKeyRotationMsgProcessor.process(CertificateKeyRotationMsgProcessor.scala:44) ~[sidechains-sdk-0.7.0-SNAPSHOT.jar:0.7.0-SNAPSHOT]
	at io.horizen.account.state.StateTransition.transition(StateTransition.scala:54) ~[sidechains-sdk-0.7.0-SNAPSHOT.jar:0.7.0-SNAPSHOT]
	at io.horizen.account.state.StateDbAccountStateView.applyMessage(StateDbAccountStateView.scala:163) ~[sidechains-sdk-0.7.0-SNAPSHOT.jar:0.7.0-SNAPSHOT]
	at io.horizen.account.state.StateDbAccountStateView.$anonfun$applyTransaction$1(StateDbAccountStateView.scala:206) ~[sidechains-sdk-0.7.0-SNAPSHOT.jar:0.7.0-SNAPSHOT]
```

After:
```
[DEBUG] 2023-03-30 19:31:22:503 +0300 [StateDbAccountStateView.scala:211 ] [2-Hop-akka.actor.default-dispatcher-11] io.horizen.account.state.AccountStateView - applying message failed, tx id: 8b78e73788c38a9fbe51c561fa0282b767da38c63b827412651a48b2d6ef8837, reason: Key Rotation Proof is invalid: Key rotation proof - signing signature is invalid: 0
```