### PR TITLE
SDK-912 - EIP-1898

### DIFF
--- a/qa/SidechainTestFramework/account/ac_utils.py
+++ b/qa/SidechainTestFramework/account/ac_utils.py
@@ -3,11 +3,9 @@ import logging
 import os
 import random
 import subprocess
-from enum import Enum
-
-from eth_utils import to_checksum_address
-
 from SidechainTestFramework.scutil import assert_equal, generate_next_block
+from enum import Enum
+from eth_utils import to_checksum_address
 
 cwd = None
 nodeModulesInstalled = False
@@ -202,10 +200,10 @@ def eoa_transfer(node, sender, receiver, amount, call_method: CallMethod = CallM
 
 
 def contract_function_static_call(node, smart_contract_type, smart_contract_address, from_address, method, *args,
-                                  tag='latest'):
+                                  tag = 'latest', eip1898 = False, isBlockHash = False):
     logging.info("Calling {}: using static call function".format(method))
     res = smart_contract_type.static_call(node, method, *args, fromAddress=from_address,
-                                          toAddress=smart_contract_address, tag=tag)
+                                          toAddress=smart_contract_address, tag=tag, eip1898=eip1898, isBlockHash=isBlockHash)
     return res
 
 

--- a/qa/run_sc_tests.sh
+++ b/qa/run_sc_tests.sh
@@ -112,6 +112,7 @@ testScriptsEvm=(
     'sc_evm_mempool_timeout.py'
     'sc_evm_sync_status.py'
     'sc_evm_txpool.py'
+    'sc_evm_eip_1898.py'
     'account_websocket_server.py'
     'account_websocket_server_sync.py'
     'account_websocket_server_rpc.py'

--- a/qa/sc_evm_eip_1898.py
+++ b/qa/sc_evm_eip_1898.py
@@ -118,7 +118,6 @@ class SCEvmEIP1898(AccountChainSetup):
         assert_response(sc_node.rpc_eth_getStorageAt(self.evm_address, eip1898_invalidInput_blockNumber), expect_error=True)
         assert_response(sc_node.rpc_eth_getStorageAt(self.evm_address, eip1898_invalidInput_blockHash), expect_error=True)
         assert_response(sc_node.rpc_eth_getStorageAt(self.evm_address, eip1898_invalidInput_bothFields), expect_error=True)
-        print(storage)
 
         # eth_getTransactionCount
         check_nonce = int(sc_node.rpc_eth_getTransactionCount(self.evm_address)['result'], 16)
@@ -157,7 +156,6 @@ class SCEvmEIP1898(AccountChainSetup):
         assert_equal(check_proof, proof)
         proof = sc_node.rpc_eth_getProof(smart_contract_address, [storage], eip1898_blockHash)['result']
         assert_equal(check_proof, proof)
-        print(sc_node.rpc_eth_getProof(self.evm_address, [storage], eip1898_invalidInput_blockHash))
         assert_response(sc_node.rpc_eth_getProof(self.evm_address, [storage], eip1898_invalidInput_blockHash), expect_error=True)
         assert_response(sc_node.rpc_eth_getProof(self.evm_address, [storage], eip1898_invalidInput_bothFields), expect_error=True)
 

--- a/qa/sc_evm_eip_1898.py
+++ b/qa/sc_evm_eip_1898.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+import logging
+from eth_utils import add_0x_prefix
+
+from SidechainTestFramework.account.ac_chain_setup import AccountChainSetup
+from SidechainTestFramework.account.ac_use_smart_contract import SmartContract
+from SidechainTestFramework.account.ac_utils import deploy_smart_contract, \
+    contract_function_static_call
+from test_framework.util import assert_equal, assert_false, assert_true
+
+"""
+Check that we corretly manage the EIP-1898 inputs for the following rpc methods:
+    - eth_getBalance
+    - eth_getStorageAt
+    - eth_getTransactionCount
+    - eth_getCode
+    - eth_call
+    - eth_getProof
+EIP-1898 details at: https://eips.ethereum.org/EIPS/eip-1898
+
+Configuration: bootstrap 1 SC node and start it with genesis info extracted from a mainchain node.
+    - Mine some blocks to reach hard fork
+    - Create 1 SC node
+    - Extract genesis info
+    - Start SC node with that genesis info
+    - Deploy an ERC20 contract 
+    - Test the previous rpc methods with EIP-1898 inputs
+
+"""
+
+def assert_response(response, expected=None, expect_error=False):
+    if expect_error:
+        assert_true("error" in response)
+    else:
+        assert_false("error" in response)
+        assert_equal(expected, response["result"], "unexpected response")
+
+class SCEvmEIP1898(AccountChainSetup):
+    def __init__(self):
+        super().__init__(withdrawalEpochLength=20)
+
+    def run_test(self):
+        sc_node = self.sc_nodes[0]
+
+        self.sc_ac_setup()
+
+        # -----------------------------------------------------------------------------
+        # Deploy Smart Contract
+        smart_contract_type = 'TestERC20'
+        logging.info("Creating smart contract utilities for {}".format(smart_contract_type))
+        smart_contract = SmartContract(smart_contract_type)
+        logging.info(smart_contract)
+
+        initial_balance = 100
+        smart_contract_address = deploy_smart_contract(sc_node, smart_contract, self.evm_address)
+
+        # eth_call
+        # call smart contract method with tag latest
+        method = 'totalSupply()'
+        res = contract_function_static_call(sc_node, smart_contract, smart_contract_address, self.evm_address, method, tag='latest')
+        assert_equal(initial_balance, res[0])
+        # call smart contract method with tag block number
+        block_number = sc_node.block_best()["result"]["height"]
+        hex_block_number = add_0x_prefix(hex(block_number))
+        res = contract_function_static_call(sc_node, smart_contract, smart_contract_address, self.evm_address, method, tag=hex_block_number)
+        assert_equal(initial_balance, res[0])
+
+        # call smart contract method with EIP-1898 input (block number)
+        res = contract_function_static_call(sc_node, smart_contract, smart_contract_address, self.evm_address, method, tag=hex_block_number, eip1898=True)
+        assert_equal(initial_balance, res[0])
+        # call smart contract method with EIP-1898 input (block hash)
+        block_hash = sc_node.rpc_eth_getBlockByNumber(hex_block_number, False)['result']['hash']
+        res = contract_function_static_call(sc_node, smart_contract, smart_contract_address, self.evm_address, method, tag=block_hash, eip1898=True, isBlockHash=True)
+        assert_equal(initial_balance, res[0])
+
+        # EIP-1898 inputs
+        eip1898_blockNumber = {
+            "blockNumber": hex_block_number
+        }
+        eip1898_blockHash = {
+            "blockHash": block_hash
+        }
+        eip1898_invalidInput_blockNumber = {
+            "blockNumber": "0xffff",
+        }
+        eip1898_invalidInput_blockHash = {
+            "blockHash": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        }
+        eip1898_invalidInput_bothFields = {
+            "blockNumber": hex_block_number,
+            "blockHash": block_hash
+        }
+
+        # eth_getBalance
+        check_balance = int(sc_node.rpc_eth_getBalance(self.evm_address)['result'], 16)
+        balance = int(sc_node.rpc_eth_getBalance(self.evm_address, 'latest')['result'], 16)
+        assert_equal(check_balance, balance)
+        balance = int(sc_node.rpc_eth_getBalance(self.evm_address, hex_block_number)['result'], 16)
+        assert_equal(check_balance, balance)
+        balance = int(sc_node.rpc_eth_getBalance(self.evm_address, eip1898_blockNumber)['result'], 16)
+        assert_equal(check_balance, balance)
+        balance = int(sc_node.rpc_eth_getBalance(self.evm_address, eip1898_blockHash)['result'], 16)
+        assert_equal(check_balance, balance)
+        assert_response(sc_node.rpc_eth_getBalance(self.evm_address, eip1898_invalidInput_blockNumber), expect_error=True)
+        assert_response(sc_node.rpc_eth_getBalance(self.evm_address, eip1898_invalidInput_blockHash), expect_error=True)
+        assert_response(sc_node.rpc_eth_getBalance(self.evm_address, eip1898_invalidInput_bothFields), expect_error=True)
+
+        # eth_getStorageAt
+        check_storage = sc_node.rpc_eth_getStorageAt(smart_contract_address, 1)['result']
+        storage = sc_node.rpc_eth_getStorageAt(smart_contract_address, 1, 'latest')['result']
+        assert_equal(check_storage, storage)
+        storage = sc_node.rpc_eth_getStorageAt(smart_contract_address, 1, hex_block_number)['result']
+        assert_equal(check_storage, storage)
+        storage = sc_node.rpc_eth_getStorageAt(smart_contract_address, 1, eip1898_blockNumber)['result']
+        assert_equal(check_storage, storage)
+        storage = sc_node.rpc_eth_getStorageAt(smart_contract_address, 1, eip1898_blockHash)['result']
+        assert_equal(check_storage, storage)
+        assert_response(sc_node.rpc_eth_getStorageAt(self.evm_address, eip1898_invalidInput_blockNumber), expect_error=True)
+        assert_response(sc_node.rpc_eth_getStorageAt(self.evm_address, eip1898_invalidInput_blockHash), expect_error=True)
+        assert_response(sc_node.rpc_eth_getStorageAt(self.evm_address, eip1898_invalidInput_bothFields), expect_error=True)
+        print(storage)
+
+        # eth_getTransactionCount
+        check_nonce = int(sc_node.rpc_eth_getTransactionCount(self.evm_address)['result'], 16)
+        nonce = int(sc_node.rpc_eth_getTransactionCount(self.evm_address, 'latest')['result'], 16)
+        assert_equal(check_nonce, nonce)
+        nonce = int(sc_node.rpc_eth_getTransactionCount(self.evm_address, hex_block_number)['result'], 16)
+        assert_equal(check_nonce, nonce)
+        nonce = int(sc_node.rpc_eth_getTransactionCount(self.evm_address, eip1898_blockNumber)['result'], 16)
+        assert_equal(check_nonce, nonce)
+        nonce = int(sc_node.rpc_eth_getTransactionCount(self.evm_address, eip1898_blockHash)['result'], 16)
+        assert_equal(check_nonce, nonce)
+        assert_response(sc_node.rpc_eth_getTransactionCount(self.evm_address, eip1898_invalidInput_blockNumber), expect_error=True)
+        assert_response(sc_node.rpc_eth_getTransactionCount(self.evm_address, eip1898_invalidInput_blockHash), expect_error=True)
+        assert_response(sc_node.rpc_eth_getTransactionCount(self.evm_address, eip1898_invalidInput_bothFields), expect_error=True)
+
+        # eth_getCode
+        check_code = sc_node.rpc_eth_getCode(smart_contract_address)['result']
+        code = sc_node.rpc_eth_getCode(smart_contract_address, 'latest')['result']
+        assert_equal(check_code, code)
+        code = sc_node.rpc_eth_getCode(smart_contract_address, hex_block_number)['result']
+        assert_equal(check_code, code)
+        code = sc_node.rpc_eth_getCode(smart_contract_address, eip1898_blockNumber)['result']
+        assert_equal(check_code, code)
+        code = sc_node.rpc_eth_getCode(smart_contract_address, eip1898_blockHash)['result']
+        assert_equal(check_code, code)
+        assert_response(sc_node.rpc_eth_getCode(self.evm_address, eip1898_invalidInput_blockNumber), expect_error=True)
+        assert_response(sc_node.rpc_eth_getCode(self.evm_address, eip1898_invalidInput_blockHash), expect_error=True)
+        assert_response(sc_node.rpc_eth_getCode(self.evm_address, eip1898_invalidInput_bothFields), expect_error=True)
+
+        check_proof = sc_node.rpc_eth_getProof(smart_contract_address, [storage])['result']
+        proof = sc_node.rpc_eth_getProof(smart_contract_address, [storage], 'latest')['result']
+        assert_equal(check_proof, proof)
+        proof = sc_node.rpc_eth_getProof(smart_contract_address, [storage], hex_block_number)['result']
+        assert_equal(check_proof, proof)
+        proof = sc_node.rpc_eth_getProof(smart_contract_address, [storage], eip1898_blockNumber)['result']
+        assert_equal(check_proof, proof)
+        proof = sc_node.rpc_eth_getProof(smart_contract_address, [storage], eip1898_blockHash)['result']
+        assert_equal(check_proof, proof)
+        print(sc_node.rpc_eth_getProof(self.evm_address, [storage], eip1898_invalidInput_blockHash))
+        assert_response(sc_node.rpc_eth_getProof(self.evm_address, [storage], eip1898_invalidInput_blockHash), expect_error=True)
+        assert_response(sc_node.rpc_eth_getProof(self.evm_address, [storage], eip1898_invalidInput_bothFields), expect_error=True)
+
+
+if __name__ == "__main__":
+    SCEvmEIP1898().main()

--- a/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
@@ -907,15 +907,48 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
     // tag: empty string is not valid
     ("0x1234567890123456789012345678901234567890", ""),
     // tag: block with number 0x1337 does not exist
-    ("0x1234567891011121314151617181920212223242", "0x1337")
+    ("0x1234567891011121314151617181920212223242", "0x1337"),
+    // EIP-1898 input object - tag: block with number 0x1337 does not exist
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x1337")),
+    // EIP-1898 input object - tag: empty string is not valid
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "")),
+    // EIP-1898 input object - tag: block with hash 0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253 does not exist
+    ("0x1234567891011121314151617181920212223242", Map("blockHash" -> "0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253")),
+    // EIP-1898 input object both blockNumber and blockHash can't be passed as input parameter
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> null, "blockHash" -> null)),
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "", "blockHash" -> "")),
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x1", "blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"))
+  )
+
+  private val invalidCasesAddressAndTagEIP1898 = Table(
+    ("Address", "Tag"),
+    // EIP-1898 input object - tag: block with number 0x1337 does not exist
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x1337")),
+    // EIP-1898 input object - tag: empty string is not valid
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "")),
+    // EIP-1898 input object - tag: block with hash 0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253 does not exist
+    ("0x1234567891011121314151617181920212223242", Map("blockHash" -> "0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253")),
+    // EIP-1898 input object both blockNumber and blockHash can't be passed as input parameter
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> null, "blockHash" -> null)),
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "", "blockHash" -> "")),
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x1", "blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253")),
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x1", "blockHash" -> "")),
+    ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "", "blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"))
   )
 
   @Test
   def eth_getBalance(): Unit = {
     val validCases = Table(
       ("Address", "tag", "Expected output"),
+      ("0x1234567891011121314151617181920212223242", "0x2", "\"0x7b\""),
       ("0x1234567891011121314151617181920212223242", "latest", "\"0x7b\""),
-      ("0x1234567891011121314151617181920212223241", "latest", "\"0x16345785d89ffff\"")
+      ("0x1234567891011121314151617181920212223242", null, "\"0x7b\""),
+      ("0x1234567891011121314151617181920212223241", "latest", "\"0x16345785d89ffff\""),
+      // EIP-1898 cases
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x2"), "\"0x7b\""),
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> null), "\"0x7b\""),
+      ("0x1234567891011121314151617181920212223242", Map("blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"), "\"0x7b\""),
+      ("0x1234567891011121314151617181920212223242", Map("blockHash" -> null), "\"0x7b\"")
     )
 
     forAll(validCases) { (address, tag, expectedOutput) =>
@@ -924,17 +957,26 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
 
     forAll(invalidCasesAddressAndTag) { (address, tag) =>
       assertThrows[RpcException] {
-        rpc("eth_getBalance", address, tag)
-      }
-    }
+        rpc("eth_getBalance", address, tag)}}
+
+    forAll(invalidCasesAddressAndTagEIP1898) { (address, tag) =>
+      assertThrows[RpcException] {
+        rpc("eth_getBalance", address, tag)}}
   }
 
   @Test
   def eth_getCode(): Unit = {
     val validCases = Table(
       ("Address", "Tag", "Expected output"),
+      ("0x1234567891011121314151617181920212223242", "0x2", "\"0x1234\""),
       ("0x1234567891011121314151617181920212223242", "latest", "\"0x1234\""),
-      ("0x1234567890123456789012345678901234567890", "latest", "\"0x\"")
+      ("0x1234567891011121314151617181920212223242", null, "\"0x1234\""),
+      ("0x1234567890123456789012345678901234567890", "latest", "\"0x\""),
+      // EIP-1898 cases
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x2"), "\"0x1234\""),
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> null), "\"0x1234\""),
+      ("0x1234567891011121314151617181920212223242", Map("blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"), "\"0x1234\""),
+      ("0x1234567891011121314151617181920212223242", Map("blockHash" -> null), "\"0x1234\""),
     )
 
     forAll(validCases) { (address, tag, expectedOutput) =>
@@ -943,17 +985,27 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
 
     forAll(invalidCasesAddressAndTag) { (address, tag) =>
       assertThrows[RpcException] {
-        rpc("eth_getCode", address, tag)
-      }
-    }
+        rpc("eth_getCode", address, tag)}}
+
+    forAll(invalidCasesAddressAndTagEIP1898) { (address, tag) =>
+      assertThrows[RpcException] {
+        rpc("eth_getCode", address, tag)}}
   }
 
   @Test
   def eth_getTransactionCount(): Unit = {
+
     val validCases = Table(
       ("Address", "Tag", "Expected output"),
+      ("0x1234567891011121314151617181920212223242", "0x2", "\"0x1\""),
       ("0x1234567891011121314151617181920212223242", "latest", "\"0x1\""),
-      ("0x1234567890123456789012345678901234567890", "latest", "\"0x0\"")
+      ("0x1234567891011121314151617181920212223242", null, "\"0x1\""),
+      ("0x1234567890123456789012345678901234567890", "0x2", "\"0x0\""),
+      // EIP-1898 cases
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x2"), "\"0x1\""),
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> null), "\"0x1\""),
+      ("0x1234567891011121314151617181920212223242", Map("blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"), "\"0x1\""),
+      ("0x1234567891011121314151617181920212223242", Map("blockHash" -> null), "\"0x1\"")
     )
 
     forAll(validCases) { (address, tag, expectedOutput) =>
@@ -962,38 +1014,53 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
 
     forAll(invalidCasesAddressAndTag) { (address, tag) =>
       assertThrows[RpcException] {
-        rpc("eth_getTransactionCount", address, tag)
-      }
-    }
+        rpc("eth_getTransactionCount", address, tag)}}
+
+    forAll(invalidCasesAddressAndTagEIP1898) { (address, tag) =>
+      assertThrows[RpcException] {
+        rpc("eth_getTransactionCount", address, tag)}}
   }
 
   @Test
   def eth_getStorageAt(): Unit = {
+
+    val expectedOutputAddr1 = "\"0x1511111111111111111111111111111111111111111111111111111111111111\""
+    val expectedOutputAddr2 = "\"0x1411111111111111111111111111111111111111111111111111111111111111\""
     val validCases = Table(
       ("Address", "Key", "Tag", "Expected output"),
-      (
-        "0x1234567891011121314151617181920212223242",
-        "0x0",
-        "latest",
-        "\"0x1511111111111111111111111111111111111111111111111111111111111111\""
-      ),
-      (
-        "0x1234567890123456789012345678901234567890",
-        "0x0",
-        "latest",
-        "\"0x1411111111111111111111111111111111111111111111111111111111111111\""
-      )
-    )
-
-    val invalidCases = Table(
-      ("Address", "Key", "Tag"),
-      ("0x12", "0x12", "latest"),
-      ("0x1234567890123456789012345678901234567890", "0x12", "")
+      ("0x1234567891011121314151617181920212223242", "0x0", "0x2", expectedOutputAddr1),
+      ("0x1234567891011121314151617181920212223242", "0x0", "latest", expectedOutputAddr1),
+      ("0x1234567891011121314151617181920212223242", "0x0", null, expectedOutputAddr1),
+      ("0x1234567890123456789012345678901234567890", "0x0", "latest", expectedOutputAddr2),
+      // EIP-1898 cases
+      ("0x1234567891011121314151617181920212223242", "0x0", Map("blockNumber" -> "0x2"), expectedOutputAddr1),
+      ("0x1234567891011121314151617181920212223242", "0x0", Map("blockNumber" -> null), expectedOutputAddr1),
+      ("0x1234567891011121314151617181920212223242", "0x0", Map("blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"), expectedOutputAddr1),
+      ("0x1234567891011121314151617181920212223242", "0x0", Map("blockHash" -> null), expectedOutputAddr1)
     )
 
     forAll(validCases) { (address, key, tag, expectedOutput) =>
       assertJsonEquals(expectedOutput, rpc("eth_getStorageAt", address, key, tag))
     }
+
+    val invalidCases = Table(
+      ("Address", "Key", "Tag"),
+      ("0x12", "0x12", "latest"),
+      ("0x1234567890123456789012345678901234567890", "0x12", ""),
+      // EIP-1898 invalid cases
+      // block with number 0x1337 does not exist
+      ("0x1234567890123456789012345678901234567890", "0x12", Map("blockNumber" -> "0x1337")),
+      // empty string is not valid
+      ("0x1234567890123456789012345678901234567890", "0x12", Map("blockNumber" -> "")),
+      // block with hash 0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253 does not exist
+      ("0x1234567890123456789012345678901234567890", "0x12", Map("blockHash" -> "0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253")),
+      // both blockNumber and blockHash can't be passed as input parameter
+      ("0x1234567890123456789012345678901234567890", "0x12", Map("blockNumber" -> null, "blockHash" -> null)),
+      ("0x1234567890123456789012345678901234567890", "0x12", Map("blockNumber" -> "", "blockHash" -> "")),
+      ("0x1234567890123456789012345678901234567890", "0x12", Map("blockNumber" -> "0x2", "blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253")),
+      ("0x1234567890123456789012345678901234567890", "0x12", Map("blockNumber" -> "0x2", "blockHash" -> "")),
+      ("0x1234567890123456789012345678901234567890", "0x12", Map("blockNumber" -> "", "blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"))
+    )
 
     forAll(invalidCases) { (address, key, tag) =>
       assertThrows[RpcException] {
@@ -1004,33 +1071,44 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
 
   @Test
   def eth_getProof(): Unit = {
+
     def proofMockData(address: String) =
       s"""{"address":"$address","accountProof":["123"],"balance":"0x7b","codeHash":null,"nonce":"0x1","storageHash":null,"storageProof":[]}"""
     val validCases = Table(
       ("Address", "Tag", "Expected output"),
-      (
-        "0x1234567891011121314151617181920212223242",
-        "latest",
-        proofMockData("0x1234567891011121314151617181920212223242"),
-      ),
-      (
-        "0x1234567890123456789012345678901234567890",
-        "latest",
-        proofMockData("0x1234567890123456789012345678901234567890"),
-      )
+      ("0x1234567891011121314151617181920212223242", "0x2", proofMockData("0x1234567891011121314151617181920212223242")),
+      ("0x1234567891011121314151617181920212223242", "latest", proofMockData("0x1234567891011121314151617181920212223242")),
+      ("0x1234567891011121314151617181920212223242", null, proofMockData("0x1234567891011121314151617181920212223242")),
+      ("0x1234567890123456789012345678901234567890", "latest", proofMockData("0x1234567890123456789012345678901234567890")),
+      // EIP-1898 cases
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x2"), proofMockData("0x1234567891011121314151617181920212223242")),
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> null), proofMockData("0x1234567891011121314151617181920212223242")),
+      ("0x1234567891011121314151617181920212223242", Map("blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"), proofMockData("0x1234567891011121314151617181920212223242")),
+      ("0x1234567891011121314151617181920212223242", Map("blockHash" -> null), proofMockData("0x1234567891011121314151617181920212223242"))
     )
+
+    forAll(validCases) { (address, tag, expectedOutput) =>
+      assertJsonEquals(expectedOutput, rpc("eth_getProof", address, Array("0x1", "0x2"), tag))
+    }
 
     val invalidCases = Table(
       ("Address", "Tag"),
       // invalid address
       ("0x12", "latest"),
       // invalid tag parameter: empty string is not allowed
-      ("0x1234567890123456789012345678901234567890", "")
+      ("0x1234567891011121314151617181920212223242", ""),
+      // EIP-1898 invalid cases
+      // empty string is not valid
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "")),
+      // block with hash 0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253 does not exist
+      ("0x1234567891011121314151617181920212223242", Map("blockHash" -> "0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253")),
+      // both blockNumber and blockHash can't be passed as input parameter
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> null, "blockHash" -> null)),
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "", "blockHash" -> "")),
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x2", "blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253")),
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "0x2", "blockHash" -> "")),
+      ("0x1234567891011121314151617181920212223242", Map("blockNumber" -> "", "blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"))
     )
-
-    forAll(validCases) { (address, tag, expectedOutput) =>
-      assertJsonEquals(expectedOutput, rpc("eth_getProof", address, Array("0x1", "0x2"), tag))
-    }
 
     forAll(invalidCases) { (address, tag) =>
       assertThrows[RpcException] {
@@ -1158,59 +1236,77 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
 
   @Test
   def eth_call(): Unit = {
-    val validCases = Table(
-      ("Transaction args", "Expected output"),
-      (
-        Map(
-          "from" -> senderWithSecret,
-          "to" -> "0x0000000000000000000022222222222222222222",
-          "value" -> "0xE8D4A51000",
-          "data" -> "0x",
-          "gasPrice" -> "0x4B9ACA00",
-          "nonce" -> "0x1",
-        ),
-        "\"0x\""
-      ),
-      (
-        Map(
-          "from" -> senderWithSecret,
-          "to" -> "0x0000000000000000000011111111111111111111",
-          "value" -> "0xE8D4A51000",
-          "data" -> "0x4267ec5edbcbaf2b14a48cfc24941ef5acfdac0a8c590255000000000000000000000000",
-          "gasPrice" -> "0x4B9ACA00",
-          "nonce" -> "0x1",
-        ),
-        "\"0x\""
+
+    val transactionArgsMap1 = Map(
+        "from" -> senderWithSecret,
+        "to" -> "0x0000000000000000000022222222222222222222",
+        "value" -> "0xE8D4A51000",
+        "data" -> "0x",
+        "gasPrice" -> "0x4B9ACA00",
+        "nonce" -> "0x1",
       )
+    val transactionArgsMap2 = Map(
+        "from" -> senderWithSecret,
+        "to" -> "0x0000000000000000000011111111111111111111",
+        "value" -> "0xE8D4A51000",
+        "data" -> "0x4267ec5edbcbaf2b14a48cfc24941ef5acfdac0a8c590255000000000000000000000000",
+        "gasPrice" -> "0x4B9ACA00",
+        "nonce" -> "0x1",
+      )
+
+    val validCases = Table(
+      ("Transaction args", "tag", "Expected output"),
+      (transactionArgsMap1, "0x2", "\"0x\""),
+      (transactionArgsMap1, "latest", "\"0x\""),
+      (transactionArgsMap1, null, "\"0x\""),
+      (transactionArgsMap2, "latest", "\"0x\""),
+      // EIP-1898 cases
+      (transactionArgsMap1, Map("blockNumber" -> "0x2"), "\"0x\""),
+      (transactionArgsMap1, Map("blockNumber" -> null), "\"0x\""),
+      (transactionArgsMap1, Map("blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"), "\"0x\""),
+      (transactionArgsMap1, Map("blockHash" -> null), "\"0x\"")
     )
 
-    forAll(validCases) { (transactionArgs, expectedOutput) =>
-      assertJsonEquals(expectedOutput, rpc("eth_call", transactionArgs))
+    forAll(validCases) { (transactionArgs, tag, expectedOutput) =>
+      assertJsonEquals(expectedOutput, rpc("eth_call", transactionArgs, tag))
     }
 
     val invalidCases = Table(
-      "Transaction args",
-      Map(
+      ("Transaction args", "tag"),
+      (Map(
         "from" -> senderWithSecret,
         "to" -> "0x0000000000000000000022222222222222222222",
         "value" -> "0x999999999900000000000000000",
         "data" -> "0x5ca748ff1122334455669988112233445566778811223344556677881122334455667788aabbddddeeff0099aabbccddeeff0099aabbccddeeff0099aabbccddeeff00123400000000000000000000000000000000000000000000000000000000000000000000000000000000000000bbdf1daf64ed9d6e30f80b93f647b8bc6ea13191",
         "gasPrice" -> "0x4B9ACA00",
         "nonce" -> "0x1",
-      ),
-      Map(
+      ), "0x2"),
+      (Map(
         "from" -> senderWithSecret,
         "to" -> "0x0000000000000000000022222222222222222222",
         "value" -> "0x0",
         "data" -> "5ca748ff1122334455669988112233445566778811223344556677881122334455667788aabbddddeeff0099aabbccddeeff0099aabbccddeeff0099aabbccddeeff00123400000000000000000000000000000000000000000000000000000000000000000000000000000000000000bbdf1daf64ed9d6e30f80b93f647b8bc6ea13191",
         "gasPrice" -> "0x4B9ACA00",
         "nonce" -> "0x1",
-      )
+      ), "0x2"),
+      // EIP-1898 invalid cases
+      // block with number 0x1337 does not exist
+      (transactionArgsMap1, Map("blockNumber" -> "0x1337")),
+      // empty string is not valid
+      (transactionArgsMap1, Map("blockNumber" -> "")),
+      // block with hash 0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253 does not exist
+      (transactionArgsMap1, Map("blockHash" -> "0xxxx1db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253")),
+      // both blockNumber and blockHash can't be passed as input parameter
+      (transactionArgsMap1, Map("blockNumber" -> null, "blockHash" -> null)),
+      (transactionArgsMap1, Map("blockNumber" -> "", "blockHash" -> "")),
+      (transactionArgsMap1, Map("blockNumber" -> "0x1", "blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253")),
+      (transactionArgsMap1, Map("blockNumber" -> "0x1", "blockHash" -> "")),
+      (transactionArgsMap1, Map("blockNumber" -> "", "blockHash" -> "0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253"))
     )
 
-    forAll(invalidCases) { transactionArgs =>
+    forAll(invalidCases) { (transactionArgs, tag) =>
       assertThrows[RpcException] {
-        rpc("eth_call", transactionArgs)
+        rpc("eth_call", transactionArgs, tag)
       }
     }
   }

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountMockDataHelper.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountMockDataHelper.scala
@@ -31,8 +31,8 @@ import io.horizen.transaction.MC2SCAggregatedTransaction
 import io.horizen.transaction.mainchain.{ForwardTransfer, SidechainCreation, SidechainRelatedMainchainOutput}
 import io.horizen.utils.{ByteArrayWrapper, BytesUtils, MerkleTree, Pair, WithdrawalEpochInfo}
 import io.horizen.utxo.box.Box
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito
+import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatestplus.junit.JUnitSuite
 import org.scalatestplus.mockito.MockitoSugar.mock
 import org.web3j.utils.Numeric
@@ -275,8 +275,9 @@ case class AccountMockDataHelper(genesis: Boolean)
       Mockito.when(history.getStorageBlockById(parentId)).thenReturn(Some(parentBlock.get))
       Mockito.when(history.blockInfoById(any())).thenReturn(blockInfo)
     }
-
     Mockito.when(history.getBlockHeightById(any())).thenReturn(Optional.of[Integer](1))
+    Mockito.when(history.getBlockHeightById(ArgumentMatchers.isNull[String])).thenReturn(Optional.empty[Integer]())
+    Mockito.when(history.getBlockHeightById(ArgumentMatchers.matches("^xxx"))).thenReturn(Optional.empty[Integer]())
     history
   }
 


### PR DESCRIPTION
This pull request contains the manage of the EIP-1898 input for the following RPC methods:
- `eth_getBalance`
- `eth_getStorageAt`
- `eth_getTransactionCount`
- `eth_getCode`
- `eth_call`
- `eth_getProof`

The input is managed using the `EthService.getBlockTagByEip1898` method that is able to manage both String-String map or simple String (like the old implementation). 
In case the EIP-1898 input contains the `blockHash` the method reported above will retrieve and return its related block number, afterwards the block hash is retrieved again inside the RPC method logic. This process is obviously not efficient but I decide to proceed this way to not impact the current implementation for the others RPC methods of the `EthService` that are based on methods that expect the block number or the block tag as input.
I propose to do a refactor operation of the `EthService` methods in a separate task/PR


