### PR TITLE
SDK-394 - chainAfter and chainSince methods

### DIFF
--- a/sdk/src/main/scala/io/horizen/chain/ActiveChain.scala
+++ b/sdk/src/main/scala/io/horizen/chain/ActiveChain.scala
@@ -24,6 +24,8 @@ final class ActiveChain private(sidechainCache: ElementsChain[ModifierId, Sidech
 
   def contains(id: ModifierId): Boolean = sidechainCache.contains(id)
 
+  def chainSince(id: ModifierId, limit: Option[Int]): Seq[ModifierId] = sidechainCache.chainSince(id, limit)
+
   def chainAfter(id: ModifierId, limit: Option[Int]): Seq[ModifierId] = sidechainCache.chainAfter(id, limit)
 
   def blockInfoById(id: ModifierId): Option[SidechainBlockInfo] = sidechainCache.heightById(id).flatMap(sidechainCache.dataByHeight)

--- a/sdk/src/main/scala/io/horizen/chain/ElementsChain.scala
+++ b/sdk/src/main/scala/io/horizen/chain/ElementsChain.scala
@@ -71,7 +71,7 @@ class ElementsChain[ID, DATA <: LinkedElement[ID]](private var lastId: Option[ID
     lastId = Some(newId)
   }
 
-  def chainAfter(id: ID, limit: Option[Int]): Seq[ID] = {
+  def chainSince(id: ID, limit: Option[Int], getChainAfter: Boolean=false): Seq[ID] = {
     if (contains(id) && height > 0) {
       var res: Seq[ID] = Seq()
       val startHeight = heightById(id).get
@@ -82,6 +82,8 @@ class ElementsChain[ID, DATA <: LinkedElement[ID]](private var lastId: Option[ID
         case None =>
           height
       }
+      if(getChainAfter) // if getChainAfter is true skip a position to return the chain after the input id
+        currentHeight += 1
       while (currentHeight < height && res.size < blockLimit) {
         currentHeight += 1
         res = res :+ dataByHeight(currentHeight).get.getParentId
@@ -94,6 +96,10 @@ class ElementsChain[ID, DATA <: LinkedElement[ID]](private var lastId: Option[ID
     else {
       Seq()
     }
+  }
+
+  def chainAfter(id: ID, limit: Option[Int]): Seq[ID] = {
+    chainSince(id, limit, true)
   }
 
   def clear(): Unit = {

--- a/sdk/src/main/scala/io/horizen/history/AbstractHistory.scala
+++ b/sdk/src/main/scala/io/horizen/history/AbstractHistory.scala
@@ -5,13 +5,13 @@ import io.horizen.account.state.HistoryBlockHashProvider
 import io.horizen.block.{MainchainBlockReference, MainchainHeader, SidechainBlockBase, SidechainBlockHeaderBase}
 import io.horizen.chain._
 import io.horizen.consensus.{ConsensusDataProvider, ConsensusDataStorage, FullConsensusEpochInfo, blockIdToEpochId}
+import io.horizen.history.validation.{HistoryBlockValidator, SemanticBlockValidator}
 import io.horizen.node.NodeHistoryBase
 import io.horizen.params.{NetworkParams, NetworkParamsUtils}
 import io.horizen.storage.AbstractHistoryStorage
 import io.horizen.storage.leveldb.Algos.encoder
 import io.horizen.transaction.Transaction
 import io.horizen.utils.{BytesUtils, WithdrawalEpochInfo, WithdrawalEpochUtils}
-import io.horizen.history.validation.{HistoryBlockValidator, SemanticBlockValidator}
 import sparkz.core.NodeViewModifier
 import sparkz.core.consensus.History._
 import sparkz.core.consensus.{History, ModifierSemanticValidity}
@@ -199,7 +199,7 @@ abstract class AbstractHistory[
         // fork length is more than params.maxHistoryRewritingLength
           (Seq[ModifierId](), Seq[ModifierId]())
         else
-          (newBestChain, storage.activeChainAfter(newBestChain.head, None))
+          (newBestChain, storage.activeChainSince(newBestChain.head, None))
 
       case None => (Seq[ModifierId](), Seq[ModifierId]())
     }
@@ -293,7 +293,7 @@ abstract class AbstractHistory[
       throw new IllegalArgumentException("Can't ask for a number of blocks = Int.MaxInt!")
     info.knownBlockIds.find(id => storage.isInActiveChain(id)) match {
       case Some(commonBlockId) =>
-        storage.activeChainAfter(commonBlockId, Some(size + 1)).tail.map(id => (SidechainBlockBase.ModifierTypeId, id))      case None =>
+        storage.activeChainAfter(commonBlockId, Some(size)).map(id => (SidechainBlockBase.ModifierTypeId, id))      case None =>
         //log.warn("Found chain without common block ids from remote")
         Seq()
     }

--- a/sdk/src/main/scala/io/horizen/storage/AbstractHistoryStorage.scala
+++ b/sdk/src/main/scala/io/horizen/storage/AbstractHistoryStorage.scala
@@ -145,6 +145,8 @@ abstract class AbstractHistoryStorage[
 
   def activeChainBlockId(height: Int): Option[ModifierId] = activeChain.idByHeight(height)
 
+  def activeChainSince(blockId: ModifierId, limit: Option[Int]): Seq[ModifierId] = activeChain.chainSince(blockId, limit)
+
   def activeChainAfter(blockId: ModifierId, limit: Option[Int]): Seq[ModifierId] = activeChain.chainAfter(blockId, limit)
 
   def getSidechainBlockContainingMainchainHeader(mainchainHeaderHash: Array[Byte]): Option[PM] = {

--- a/sdk/src/test/scala/io/horizen/chain/ActiveChainTest.scala
+++ b/sdk/src/test/scala/io/horizen/chain/ActiveChainTest.scala
@@ -61,6 +61,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     assertTrue("Empty ActiveChain expected not to find modifier for inconsistent height", chain.blockInfoByHeight(1).isEmpty)
     assertTrue("Empty ActiveChain expected not to find modifier id for inconsistent height", chain.idByHeight(0).isEmpty)
     assertTrue("Empty ActiveChain expected not to find modifier id for inconsistent height", chain.idByHeight(1).isEmpty)
+    assertTrue("Empty ActiveChain expected to return empty chain from nonexistent modifier", chain.chainSince(getRandomModifier(), None).isEmpty)
     assertTrue("Empty ActiveChain expected to return empty chain from nonexistent modifier", chain.chainAfter(getRandomModifier(), None).isEmpty)
 
     val randomMainchainHash: MainchainHeaderHash = generateMainchainHeaderHash(111L)
@@ -82,7 +83,7 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
                                     mainchainInitialHeight: Int,
                                     allMainchainReferences: Seq[MainchainHeaderHash] // TODO: in general we need to pass MainchainHeaders and RefData info separately
                                    ): Unit = {
-    assertTrue("Chain from shall not be empty for added element", chain.chainAfter(id, None).nonEmpty)
+    assertTrue("Chain from shall not be empty for added element", chain.chainSince(id, None).nonEmpty)
     assertTrue("Element shall be present in chain", chain.contains(id))
     assertEquals("Data shall be reachable by height", data, chain.blockInfoByHeight(height).get)
     assertEquals("Data shall be reachable by id", data, chain.blockInfoById(id).get)
@@ -297,26 +298,27 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     assertTrue("ActiveChain expected to find modifier id for height 1", chain.idByHeight(1).isDefined)
     assertTrue("ActiveChain expected to find modifier id for chain current height", chain.idByHeight(chainHeight).isDefined)
 
+    assertTrue("ActiveChain expected to return empty chain from nonexistent modifier", chain.chainSince(getRandomModifier(), None).isEmpty)
     assertTrue("ActiveChain expected to return empty chain from nonexistent modifier", chain.chainAfter(getRandomModifier(), None).isEmpty)
 
-    var chainAfter: Seq[ModifierId] = chain.chainAfter(blockInfoData.head._1, None)
-    assertEquals("ActiveChain chainAfter expected to return chain with different height for first(genesis) modifier",
-      blockInfoData.size, chainAfter.size)
-    for(i <- chainAfter.indices)
-      assertEquals("ActiveChain chainAfter item at index %d is different".format(i), blockInfoData(i)._1, chainAfter(i))
+    var chainSince: Seq[ModifierId] = chain.chainSince(blockInfoData.head._1, None)
+    assertEquals("ActiveChain chainSince expected to return chain with different height for first(genesis) modifier",
+      blockInfoData.size, chainSince.size)
+    for(i <- chainSince.indices)
+      assertEquals("ActiveChain chainAfter item at index %d is different".format(i), blockInfoData(i)._1, chainSince(i))
 
 
     val startingIndex = 3
-    chainAfter = chain.chainAfter(blockInfoData(startingIndex)._1, None)
+    chainSince = chain.chainSince(blockInfoData(startingIndex)._1, None)
     assertEquals("ActiveChain chainAfter expected to return chain with different height for 4th modifier",
-      chainHeight - startingIndex, chainAfter.size)
-    for(i <- chainAfter.indices)
-      assertEquals("ActiveChain chainAfter item at index %d is different".format(i), blockInfoData(i + startingIndex)._1, chainAfter(i))
+      chainHeight - startingIndex, chainSince.size)
+    for(i <- chainSince.indices)
+      assertEquals("ActiveChain chainAfter item at index %d is different".format(i), blockInfoData(i + startingIndex)._1, chainSince(i))
 
 
-    chainAfter = chain.chainAfter(blockInfoData.last._1, None)
-    assertEquals("ActiveChain chainAfter expected to return chain with size 1 for tip modifier", 1, chainAfter.size)
-    assertEquals("ActiveChain chainAfter item at index 0 is different", blockInfoData.last._1, chainAfter.head)
+    chainSince = chain.chainSince(blockInfoData.last._1, None)
+    assertEquals("ActiveChain chainAfter expected to return chain with size 1 for tip modifier", 1, chainSince.size)
+    assertEquals("ActiveChain chainAfter item at index 0 is different", blockInfoData.last._1, chainSince.head)
   }
 
 
@@ -335,12 +337,14 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, firstId, firstData, 1, 0, mainchainDataAfterFirst)
     checkElementIsBest(chain, firstId, firstData, 1)
-    assertEquals("ChainFrom the beginning should contain just a tip", Seq(firstId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain just a tip", Seq(firstId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should be empty", Seq(), chain.chainAfter(firstId, None))
 
     // Try to add the same element second time
     addNewBestBlockShallBeFailed(chain, firstId, firstData, firstMainchainParent)
     checkElementIsBest(chain, firstId, firstData, 1)
-    assertEquals("ChainFrom the beginning should contain just a tip", Seq(firstId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain just a tip", Seq(firstId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should be empty", Seq(), chain.chainAfter(firstId, None))
 
     // Add second element
     val (secondId: ModifierId, secondData: SidechainBlockInfo, secondMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(firstId)
@@ -349,7 +353,8 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, secondId, secondData, 2, mainchainDataAfterFirst.size, mainchainDataAfterSecond)
     checkElementIsBest(chain, secondId, secondData, 2)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain all ids", Seq(firstId, secondId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should contain second id", Seq(secondId), chain.chainAfter(firstId, None))
     checkElementIsNotBest(chain, firstId, firstData, 1)
 
     // Add third element
@@ -359,7 +364,8 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, thirdId, thirdData, 3, mainchainDataAfterSecond.size, mainchainDataAfterThird)
     checkElementIsBest(chain, thirdId, thirdData, 3)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain all ids", Seq(firstId, secondId, thirdId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should contain second and third ids", Seq(secondId, thirdId), chain.chainAfter(firstId, None))
     checkElementIsNotBest(chain, secondId, secondData, 2)
 
     // Add fourth element
@@ -368,7 +374,8 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     val mainchainDataAfterFourth = mainchainDataAfterThird ++ fourthData.mainchainHeaderHashes
 
     checkElementIsPresent(chain, fourthId, fourthData, 4, mainchainDataAfterThird.size, mainchainDataAfterFourth)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId, fourthId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain all ids", Seq(firstId, secondId, thirdId, fourthId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should contain second, third and fourth ids", Seq(secondId, thirdId, fourthId), chain.chainAfter(firstId, None))
 
     //replace last element
     val (otherFourthId: ModifierId, otherFourthData: SidechainBlockInfo, otherFourthMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(thirdId)
@@ -377,7 +384,8 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, otherFourthId, otherFourthData, 4, mainchainDataAfterThird.size, mainchainDataAfterOtherFourth)
     checkElementIsNotPresent(chain, fourthId, fourthData, 4)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId, otherFourthId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain all ids", Seq(firstId, secondId, thirdId, otherFourthId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should contain second, third and other fourth ids", Seq(secondId, thirdId, otherFourthId), chain.chainAfter(firstId, None))
 
 
     // do fork on the second element and add element
@@ -388,7 +396,8 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     checkElementIsPresent(chain, otherThirdId, otherThirdData, 3, mainchainDataAfterSecond.size, mainchainDataAfterOtherThird)
     checkElementIsBest(chain, otherThirdId, otherThirdData, 3)
     checkElementIsNotPresent(chain, otherFourthId, otherFourthData, 4)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, otherThirdId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain all ids", Seq(firstId, secondId, otherThirdId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should contain second and other third ids", Seq(secondId, otherThirdId), chain.chainAfter(firstId, None))
 
     val (afterThirdId: ModifierId, afterThirdData: SidechainBlockInfo, afterThirdMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(otherThirdId)
     addNewBestBlockIsSuccessful(chain, afterThirdId, afterThirdData, afterThirdMainchainParent)
@@ -396,14 +405,16 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, afterThirdId, afterThirdData, 4, mainchainDataAfterOtherThird.size, mainchainDataAfterAfterThird)
     checkElementIsBest(chain, afterThirdId, afterThirdData, 4)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, otherThirdId, afterThirdId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain all ids", Seq(firstId, secondId, otherThirdId, afterThirdId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should contain second, other third and after third ids", Seq(secondId, otherThirdId, afterThirdId), chain.chainAfter(firstId, None))
 
     // try to add unconnected element
     val (unconnectedId: ModifierId, unconnectedData: SidechainBlockInfo, unconnectedMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(getRandomModifier())
     addNewBestBlockShallBeFailed(chain, unconnectedId, unconnectedData, unconnectedMainchainParent)
     checkElementIsPresent(chain, afterThirdId, afterThirdData, 4, mainchainDataAfterOtherThird.size, mainchainDataAfterAfterThird)
     checkElementIsBest(chain, afterThirdId, afterThirdData, 4)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, otherThirdId, afterThirdId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain all ids", Seq(firstId, secondId, otherThirdId, afterThirdId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should contain second, other third and after third ids", Seq(secondId, otherThirdId, afterThirdId), chain.chainAfter(firstId, None))
   }
 
   @Test
@@ -443,13 +454,15 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
 
     checkElementIsPresent(chain, firstId, firstData, 1, 0, mainchainDataAfterFirst)
     checkElementIsBest(chain, firstId, firstData, 1)
-    assertEquals("ChainFrom the beginning should contain just a tip", Seq(firstId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain just a tip", Seq(firstId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter should be empty", Seq(), chain.chainAfter(firstId, None))
 
     // Add second element
     val (secondId: ModifierId, secondData: SidechainBlockInfo, secondMainchainParent: Option[MainchainHeaderHash]) = getNewDataForParent(firstId, Seq(generateMainchainBlockReference()))
     addNewBestBlockIsSuccessful(chain, secondId, secondData, secondMainchainParent)
     checkElementIsBest(chain, secondId, secondData, 2)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain all ids", Seq(firstId, secondId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should contain the second id", Seq(secondId), chain.chainAfter(firstId, None))
     val mainchainDataAfterSecond = mainchainDataAfterFirst ++ secondData.mainchainHeaderHashes
 
     // Add third element
@@ -458,7 +471,8 @@ class ActiveChainTest extends JUnitSuite with SidechainBlockInfoFixture {
     val mainchainDataAfterThird = mainchainDataAfterSecond ++ thirdData.mainchainHeaderHashes
     checkElementIsPresent(chain, thirdId, thirdData, 3, mainchainDataAfterSecond.size, mainchainDataAfterThird)
     checkElementIsBest(chain, thirdId, thirdData, 3)
-    assertEquals("ChainFrom the beginning should contain all ids", Seq(firstId, secondId, thirdId), chain.chainAfter(firstId, None))
+    assertEquals("ChainSince the beginning should contain all ids", Seq(firstId, secondId, thirdId), chain.chainSince(firstId, None))
+    assertEquals("ChainAfter the beginning should contain the second and thitr ids", Seq(secondId, thirdId), chain.chainAfter(firstId, None))
   }
 
   @Test

--- a/sdk/src/test/scala/io/horizen/chain/ElementsChainTest.scala
+++ b/sdk/src/test/scala/io/horizen/chain/ElementsChainTest.scala
@@ -85,6 +85,7 @@ class ElementsChainTest extends JUnitSuite {
     assertTrue("Empty ChainStorage expected not to find modifier for inconsistent height", chainStorage.dataByHeight(1).isEmpty)
     assertTrue("Empty ChainStorage expected not to find modifier id for inconsistent height", chainStorage.idByHeight(0).isEmpty)
     assertTrue("Empty ChainStorage expected not to find modifier id for inconsistent height", chainStorage.idByHeight(1).isEmpty)
+    assertTrue("Empty ChainStorage expected to return empty chain from nonexistent modifier", chainStorage.chainSince(id, None).isEmpty)
     assertTrue("Empty ChainStorage expected to return empty chain from nonexistent modifier", chainStorage.chainAfter(id, None).isEmpty)
     assertEquals("No parent shall be found for empty chain", None, chainStorage.parentOf(id))
   }
@@ -116,31 +117,38 @@ class ElementsChainTest extends JUnitSuite {
     checkAddNewBestBlockIsSuccessfully(chainStorage, id1, data1)
     checkStorageElementIsPresent(chainStorage, id1, data1, 1)
     checkBestElementIs(chainStorage, id1, data1, 1)
-    assertEquals("Chain from shall be equal", Seq(id1), chainStorage.chainAfter(id1, None))
+    assertEquals("Chain since shall be equal", Seq(id1), chainStorage.chainSince(id1, None))
+    assertEquals("Chain after shall be equal", Seq(), chainStorage.chainAfter(id1, None))
     assertEquals("Id shall be found for height 0", None, chainStorage.idByHeight(0))
 
     val (id2, data2) = dataGenerator.getNextData
     checkAddNewBestBlockIsSuccessfully(chainStorage, id2, data2)
     checkStorageElementIsPresent(chainStorage, id2, data2, 2)
     checkBestElementIs(chainStorage, id2, data2, 2)
-    assertEquals("Chain from shall be equal", Seq(id1, id2), chainStorage.chainAfter(id1, None))
+    assertEquals("Chain since shall be equal", Seq(id1, id2), chainStorage.chainSince(id1, None))
+    assertEquals("Chain after shall be equal", Seq(id2), chainStorage.chainAfter(id1, None))
 
     val (id3, data3) = dataGenerator.getNextData
     checkAddNewBestBlockIsSuccessfully(chainStorage, id3, data3)
-    assertEquals("Chain from shall be equal", Seq(id2, id3), chainStorage.chainAfter(id2, None))
+    assertEquals("Chain since shall be equal", Seq(id2, id3), chainStorage.chainSince(id2, None))
+    assertEquals("Chain after shall be equal", Seq(id3), chainStorage.chainAfter(id2, None))
 
     val (id4, data4) = dataGenerator.getNextData
     checkAddNewBestBlockIsSuccessfully(chainStorage, id4, data4)
     checkStorageElementIsPresent(chainStorage, id4, data4, 4)
     checkBestElementIs(chainStorage, id4, data4, 4)
-    assertEquals("Chain from shall be equal", Seq(id4), chainStorage.chainAfter(id4, None))
+    assertEquals("Chain since shall be equal", Seq(id4), chainStorage.chainSince(id4, None))
+    assertEquals("Chain after shall be equal", Seq(), chainStorage.chainAfter(id4, None))
 
     //Test with only one block requested
-    assertEquals("Chain from shall be equal", Seq(id2), chainStorage.chainAfter(id2, Some(1)))
+    assertEquals("Chain since shall be equal", Seq(id2), chainStorage.chainSince(id2, Some(1)))
+    assertEquals("Chain after shall be equal", Seq(id3), chainStorage.chainAfter(id2, Some(1)))
     //Test by asking all the blocks
-    assertEquals("Chain from shall be equal", Seq(id3, id4), chainStorage.chainAfter(id3, Some(2)))
+    assertEquals("Chain since shall be equal", Seq(id3, id4), chainStorage.chainSince(id3, Some(2)))
+    assertEquals("Chain after shall be equal", Seq(id4), chainStorage.chainAfter(id3, Some(2)))
     //Test by asking more than the maximum blocks
-    assertEquals("Chain from shall be equal", Seq(id3, id4), chainStorage.chainAfter(id3, Some(4)))
+    assertEquals("Chain since shall be equal", Seq(id3, id4), chainStorage.chainSince(id3, Some(4)))
+    assertEquals("Chain after shall be equal", Seq(id4), chainStorage.chainAfter(id3, Some(4)))
 
     val (newId4, newData4) = dataGenerator.setParentId(3).getNextData
     checkAddNewBestBlockIsSuccessfully(chainStorage, newId4, newData4)
@@ -148,7 +156,8 @@ class ElementsChainTest extends JUnitSuite {
     checkBestElementIsNot(chainStorage, id4, data4)
     checkStorageElementIsPresent(chainStorage, newId4, newData4, 4)
     checkBestElementIs(chainStorage, newId4, newData4, 4)
-    assertEquals("Chain from shall be equal", Seq(), chainStorage.chainAfter(id4, None))
+    assertEquals("Chain since shall be equal", Seq(), chainStorage.chainSince(id4, None))
+    assertEquals("Chain after shall be equal", Seq(), chainStorage.chainAfter(id4, None))
     assertEquals("Searching by predicate had been failed", Some(data3), chainStorage.getLastDataByPredicate(data => data.getParentId == data3.getParentId))
     assertEquals("Searching by predicate had been failed", Some(data2), chainStorage.getLastDataByPredicateTillHeight(2)(data => data.getParentId == data2.getParentId))
 

--- a/sdk/src/test/scala/io/horizen/utxo/integration/storage/SidechainHistoryStorageTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/integration/storage/SidechainHistoryStorageTest.scala
@@ -58,7 +58,8 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertEquals("HistoryStorage different block info expected", genesisBlockInfo, historyStorage.blockInfoOptionById(genesisBlock.id).get)
     assertTrue("HistoryStorage genesis block expected to be a part of active chain", historyStorage.isInActiveChain(genesisBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", genesisBlock.id, historyStorage.activeChainBlockId(expectedHeight).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id), historyStorage.activeChainSince(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(), historyStorage.activeChainAfter(genesisBlock.id, None))
 
 
     // Add one more block
@@ -75,7 +76,8 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertEquals("HistoryStorage different block expected", secondBlock.id, historyStorage.blockById(secondBlock.id).get.id)
     assertFalse("HistoryStorage next block expected NOT to be a part of active chain", historyStorage.isInActiveChain(secondBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", genesisBlock.id, historyStorage.activeChainBlockId(1).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id), historyStorage.activeChainSince(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(), historyStorage.activeChainAfter(genesisBlock.id, None))
     assertEquals("HistoryStorage different semantic validity expected", ModifierSemanticValidity.Unknown, historyStorage.blockInfoOptionById(secondBlock.id).get.semanticValidity)
 
     // Update best block and validity -> active chain related data should change
@@ -90,7 +92,8 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertEquals("HistoryStorage different bestBlock expected", secondBlock.id, historyStorage.bestBlock.id)
     assertTrue("HistoryStorage block expected to be a part of active chain", historyStorage.isInActiveChain(secondBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", secondBlock.id, historyStorage.activeChainBlockId(expectedHeight).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, secondBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, secondBlock.id), historyStorage.activeChainSince(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(secondBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
 
 
     // Add one more block
@@ -112,10 +115,10 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertEquals("HistoryStorage different bestBlock expected", thirdBlock.id, historyStorage.bestBlock.id)
     assertTrue("HistoryStorage block expected to be a part of active chain", historyStorage.isInActiveChain(thirdBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", thirdBlock.id, historyStorage.activeChainBlockId(expectedHeight).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, secondBlock.id, thirdBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(secondBlock.id, thirdBlock.id), historyStorage.activeChainAfter(secondBlock.id, None))
-
-
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, secondBlock.id, thirdBlock.id), historyStorage.activeChainSince(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(secondBlock.id, thirdBlock.id), historyStorage.activeChainSince(secondBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(secondBlock.id, thirdBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(thirdBlock.id), historyStorage.activeChainAfter(secondBlock.id, None))
 
     // Add block from another chain after genesis one, which lead to Fork
     val forkBlock: SidechainBlock = generateNextSidechainBlock(genesisBlock, sidechainTransactionsCompanion, params, basicSeed = 991919L)
@@ -138,7 +141,9 @@ class SidechainHistoryStorageTest extends JUnitSuite with SidechainBlockFixture 
     assertTrue("HistoryStorage block expected to be a part of active chain", historyStorage.isInActiveChain(forkBlock.id))
     assertFalse("HistoryStorage block expected NOT to be a part of active chain", historyStorage.isInActiveChain(thirdBlock.id))
     assertEquals("HistoryStorage different block expected form active chain", forkBlock.id, historyStorage.activeChainBlockId(expectedHeight).get)
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, forkBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
-    assertEquals("HistoryStorage different block chain expected form active chain", Seq(forkBlock.id), historyStorage.activeChainAfter(forkBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(genesisBlock.id, forkBlock.id), historyStorage.activeChainSince(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(forkBlock.id), historyStorage.activeChainSince(forkBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(forkBlock.id), historyStorage.activeChainAfter(genesisBlock.id, None))
+    assertEquals("HistoryStorage different block chain expected form active chain", Seq(), historyStorage.activeChainAfter(forkBlock.id, None))
   }
 }

--- a/sdk/src/test/scala/io/horizen/utxo/storage/SidechainHistoryStorageTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/storage/SidechainHistoryStorageTest.scala
@@ -346,13 +346,17 @@ class SidechainHistoryStorageTest extends JUnitSuite with MockitoSugar with Side
 
     // Test 11: get activeChainFrom
     // active chain from genesis block
-    assertEquals("Storage returned wrong active chain size", height, historyStorage.activeChainAfter(activeChainBlockList.head.id, None).size)
+    assertEquals("Storage returned wrong active chain size", height, historyStorage.activeChainSince(activeChainBlockList.head.id, None).size)
+    assertEquals("Storage returned wrong active chain size", height - 1, historyStorage.activeChainAfter(activeChainBlockList.head.id, None).size)
     // active chain from 5th block
-    assertEquals("Storage returned wrong active chain size", height - 4, historyStorage.activeChainAfter(activeChainBlockList(4).id, None).size)
+    assertEquals("Storage returned wrong active chain size", height - 4, historyStorage.activeChainSince(activeChainBlockList(4).id, None).size)
+    assertEquals("Storage returned wrong active chain size", height - 5, historyStorage.activeChainAfter(activeChainBlockList(4).id, None).size)
     // active chain last block id height
-    assertEquals("Storage returned wrong active chain size", 1, historyStorage.activeChainAfter(activeChainBlockList.last.id, None).size)
+    assertEquals("Storage returned wrong active chain size", 1, historyStorage.activeChainSince(activeChainBlockList.last.id, None).size)
+    assertEquals("Storage returned wrong active chain size", 0, historyStorage.activeChainAfter(activeChainBlockList.last.id, None).size)
     // active chain from fork last block id
-    assertTrue("Storage active chain from forked block should be empty", historyStorage.activeChainAfter(forkChainBlockList.last.id, None).isEmpty)
+    assertTrue("Storage active chain since forked block should be empty", historyStorage.activeChainSince(forkChainBlockList.last.id, None).isEmpty)
+    assertTrue("Storage active chain after forked block should be empty", historyStorage.activeChainAfter(forkChainBlockList.last.id, None).isEmpty)
 
 
     // Test 12: get semanticValidity


### PR DESCRIPTION
Old `chainAfter` method converted in the new `chainSince` method that return the list of IDs including the input starting one, new `chainAfter` method added.
Details in task: https://horizenlabs.atlassian.net/browse/SDK-394
Unit tests updated