### PR TITLE
SDK-1027 - extraData and sha3Uncles format fix

### DIFF
--- a/sdk/src/main/java/io/horizen/account/api/rpc/types/EthereumBlockView.java
+++ b/sdk/src/main/java/io/horizen/account/api/rpc/types/EthereumBlockView.java
@@ -41,9 +41,9 @@ public class EthereumBlockView {
     // no PoW, no nonce, but we explicity set it to all zeroes as some RPC clients are very strict here (e.g. GETH)
     public final String nonce = "0x0000000000000000";
     // we do not have uncles
-    public final String sha3Uncles = "0x";
+    public final String sha3Uncles = "0x0000000000000000000000000000000000000000000000000000000000000000";
     // we do not have extraData in the block
-    public final String extraData = "0x";
+    public final String extraData = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
     private EthereumBlockView(Long blockNumber, Hash blockHash, AccountBlock block, List<?> txs) {
         var header = block.header();

--- a/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
@@ -89,7 +89,7 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
     s"""{
         "baseFeePerGas": "0x342770c0",
         "difficulty": "0x0",
-        "extraData": "0x",
+        "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "gasLimit": "0x1c9c380",
         "gasUsed": "0x3b9aca01",
         "hash": "0xdc7ac3d7de9d7fc524bbb95025a98c3e9290b041189ee73c638cf981e7f99bfc",
@@ -100,7 +100,7 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
         "number": "0x1",
         "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000123",
         "receiptsRoot": "0x1234567891011121314112345678910111213141010203040506070809111444",
-        "sha3Uncles": "0x",
+        "sha3Uncles": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "size": "0x100",
         "stateRoot": "0x1234567891011121314112345678910111213141010203040506070809111333",
         "timestamp": "0x3b9aca00",


### PR DESCRIPTION
`extraData` and `sha3Uncles` format fixed, now they are returned with pattern 0x followed by 64 0s
Unit test updated