### PR TITLE
SDK-1070 - eth_feeHistory bug fix

### DIFF
--- a/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
@@ -1002,31 +1002,34 @@ class EthService(
       // limit the range of blocks by the number of available blocks and cap at 1024
       val blocks = blockCount.intValueExact().min(requestedBlockInfo.height).min(1024)
       // geth comment: returning with no data and no error means there are no retrievable blocks
-      if (blocks < 1) return new EthereumFeeHistoryView()
-      // calculate block number of the "oldest" block in the range
-      val oldestBlock = requestedBlockInfo.height + 1 - blocks
+      if (blocks < 1) {
+        new EthereumFeeHistoryView()
+      } else {
+        // calculate block number of the "oldest" block in the range
+        val oldestBlock = requestedBlockInfo.height + 1 - blocks
 
-      // include the calculated base fee of the next block after the requested range
-      val baseFeePerGas = new Array[BigInteger](blocks + 1)
-      val gasUsedRatio = new Array[Double](blocks)
-      val reward = if (percentiles.nonEmpty) new Array[Array[BigInteger]](blocks) else null
+        // include the calculated base fee of the next block after the requested range
+        val baseFeePerGas = new Array[BigInteger](blocks + 1)
+        val gasUsedRatio = new Array[Double](blocks)
+        val reward = if (percentiles.nonEmpty) new Array[Array[BigInteger]](blocks) else null
 
-      using(nodeView.state.getView) { stateView =>
-        for (i <- 0 until blocks) {
-          val block = nodeView.history
-            .blockIdByHeight(oldestBlock + i)
-            .map(ModifierId(_))
-            .flatMap(nodeView.history.getStorageBlockById)
-            .get
-          baseFeePerGas(i) = block.header.baseFee
-          gasUsedRatio(i) = block.header.gasUsed.doubleValue() / block.header.gasLimit.doubleValue()
-          if (percentiles.nonEmpty) reward(i) = Backend.getRewardsForBlock(block, stateView, percentiles)
+        using(nodeView.state.getView) { stateView =>
+          for (i <- 0 until blocks) {
+            val block = nodeView.history
+              .blockIdByHeight(oldestBlock + i)
+              .map(ModifierId(_))
+              .flatMap(nodeView.history.getStorageBlockById)
+              .get
+            baseFeePerGas(i) = block.header.baseFee
+            gasUsedRatio(i) = block.header.gasUsed.doubleValue() / block.header.gasLimit.doubleValue()
+            if (percentiles.nonEmpty) reward(i) = Backend.getRewardsForBlock(block, stateView, percentiles)
+          }
         }
-      }
-      // calculate baseFee for the next block after the requested range
-      baseFeePerGas(blocks) = calculateNextBaseFee(requestedBlock)
+        // calculate baseFee for the next block after the requested range
+        baseFeePerGas(blocks) = calculateNextBaseFee(requestedBlock)
 
-      new EthereumFeeHistoryView(oldestBlock, baseFeePerGas, gasUsedRatio, reward)
+        new EthereumFeeHistoryView(oldestBlock, baseFeePerGas, gasUsedRatio, reward)
+      }
     }
   }
 

--- a/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
@@ -1316,6 +1316,18 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
     val validCases = Table(
       ("Block count", "Newest block (tag)", "Reward percentiles", "Expected output"),
       (
+        "0x0",
+        "latest",
+        null,
+        """{"oldestBlock":"0x0","baseFeePerGas":null,"gasUsedRatio":null,"reward":null}"""
+      ),
+      (
+        "0x0",
+        "latest",
+        Array(20, 50, 70),
+        """{"oldestBlock":"0x0","baseFeePerGas":null,"gasUsedRatio":null,"reward":null}"""
+      ),
+      (
         "0x1",
         "latest",
         Array(20, 50, 70),


### PR DESCRIPTION
Bug details in task [SDK-1070](https://horizenlabs.atlassian.net/browse/SDK-1070). The bug was due to the `return` statement of the `if (blocks < 1)` condition.

For a bit of context if we try to use a `return` statement inside a lambda function that is defined inside a method, we will get a compilation error in _Scala_ (not managed in our case). This is because the `return` statement would try to exit the enclosing method, not just the lambda function. However, in _Scala_, a lambda function is not allowed to have side-effects outside of its own body. This means that it cannot modify any variables outside of its own scope or exit the enclosing method.

To use the `return` statement a workaround might be use a named function instead of a lambda function but, in general, using `return` in functional programming is discouraged as it can lead to code that is more difficult to read and test. In _Scala_, it is common to use expressions and function composition to achieve the desired result so an `if-else` expression is introduced with this _PR_.
Link: https://www.scala-lang.org/files/archive/spec/2.11/06-expressions.html#return-expressions (section _6.20 Return Expressions_)

Unit test updated with the bug case.


[SDK-1070]: https://horizenlabs.atlassian.net/browse/SDK-1070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ