### PR TITLE
eth_getLogs limit bug fix

### DIFF
--- a/sdk/src/main/scala/io/horizen/params/MainNetParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/MainNetParams.scala
@@ -11,6 +11,8 @@ import sparkz.core.block.Block
 import sparkz.util.ModifierId
 import sparkz.util.bytesToId
 
+import scala.concurrent.duration._
+
 case class MainNetParams(
                           override val sidechainId: Array[Byte] = new Array[Byte](32),
                           override val sidechainGenesisBlockId: ModifierId = bytesToId(new Array[Byte](32)),
@@ -40,7 +42,9 @@ case class MainNetParams(
                           override val sidechainCreationVersion: SidechainCreationVersion = SidechainCreationVersion1,
                           override val chainId: Long = 33333333,
                           override val isCSWEnabled: Boolean = true,
-                          override val isNonCeasing: Boolean = false
+                          override val isNonCeasing: Boolean = false,
+                          override val getLogsSizeLimit: Int = 10000,
+                          override val getLogsQueryTimeout: FiniteDuration = 10.seconds,
                         ) extends NetworkParams {
   override val EquihashN: Int = 200
   override val EquihashK: Int = 9

--- a/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
@@ -11,6 +11,8 @@ import io.horizen.proposition.{PublicKey25519Proposition, SchnorrProposition, Vr
 import sparkz.core.block.Block
 import sparkz.util.{ModifierId, bytesToId}
 
+import scala.concurrent.duration.FiniteDuration
+
 trait NetworkParams {
   // Mainchain ProofOfWork parameters:
   val EquihashN: Int
@@ -64,6 +66,8 @@ trait NetworkParams {
   val consensusSlotsInEpoch: Int
   val initialCumulativeCommTreeHash: Array[Byte] // CumulativeCommTreeHash value before genesis block
   val isNonCeasing: Boolean
+  val getLogsSizeLimit: Int
+  val getLogsQueryTimeout: FiniteDuration
 
   val minVirtualWithdrawalEpochLength: Int
 

--- a/sdk/src/main/scala/io/horizen/params/RegTestParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/RegTestParams.scala
@@ -11,6 +11,7 @@ import io.horizen.proposition.{PublicKey25519Proposition, SchnorrProposition, Vr
 import sparkz.core.block.Block
 import sparkz.util.ModifierId
 import sparkz.util.bytesToId
+import scala.concurrent.duration._
 
 case class RegTestParams(
                           override val sidechainId: Array[Byte] = new Array[Byte](32),
@@ -39,7 +40,9 @@ case class RegTestParams(
                           override val sidechainCreationVersion: SidechainCreationVersion = SidechainCreationVersion1,
                           override val chainId: Long = 1111111,
                           override val isCSWEnabled: Boolean = true,
-                          override val isNonCeasing: Boolean = false
+                          override val isNonCeasing: Boolean = false,
+                          override val getLogsSizeLimit: Int = 10,
+                          override val getLogsQueryTimeout: FiniteDuration = 2.seconds,
                         ) extends NetworkParams {
   override val EquihashN: Int = 48
   override val EquihashK: Int = 5

--- a/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
@@ -10,6 +10,7 @@ import io.horizen.proposition.{PublicKey25519Proposition, SchnorrProposition, Vr
 import sparkz.core.block.Block
 import sparkz.util.ModifierId
 import sparkz.util.bytesToId
+import scala.concurrent.duration._
 
 case class TestNetParams(
                           override val sidechainId: Array[Byte] = new Array[Byte](32),
@@ -38,7 +39,9 @@ case class TestNetParams(
                           override val sidechainCreationVersion: SidechainCreationVersion = SidechainCreationVersion1,
                           override val chainId: Long = 22222222,
                           override val isCSWEnabled: Boolean = true,
-                          override val isNonCeasing: Boolean = false
+                          override val isNonCeasing: Boolean = false,
+                          override val getLogsSizeLimit: Int = 10000,
+                          override val getLogsQueryTimeout: FiniteDuration = 10.seconds,
                         ) extends NetworkParams {
   override val EquihashN: Int = 200
   override val EquihashK: Int = 9

--- a/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
+++ b/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
@@ -8,8 +8,10 @@ import io.horizen.params.MainNetParams;
 import io.horizen.params.NetworkParams;
 import io.horizen.params.TestNetParams;
 import org.junit.Test;
+import scala.concurrent.duration.FiniteDuration;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import static io.horizen.account.utils.BigIntegerUInt256.getUnsignedByteArray;
 import static io.horizen.utils.BytesUtils.padWithZeroBytes;
@@ -247,7 +249,7 @@ public class BytesUtilsTest {
     @Test
     public void fromHorizenPublicKeyAddress() {
         // Test 1: valid MainNet addresses in MainNet network
-        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false);
+        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, 10000, null);
         String pubKeyAddressMainNet = "znc3p7CFNTsz1s6CceskrTxKevQLPoDK4cK";
         byte[] expectedPublicKeyHashBytesMainNet = BytesUtils.fromHexString("7843a3fcc6ab7d02d40946360c070b13cf7b9795");
 
@@ -290,7 +292,7 @@ public class BytesUtilsTest {
 
 
         // Test 5: valid TestNet addresses in TestNet network
-        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, 120, 720,  null,null, CircuitTypes.NaiveThresholdSignatureCircuit(),0,  null,null, null, null, null, null, null, false, null, null, 11111111, true, false);
+        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, 120, 720,  null,null, CircuitTypes.NaiveThresholdSignatureCircuit(),0,  null,null, null, null, null, null, null, false, null, null, 11111111, true, false, 0, null);
         String pubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";
         byte[] expectedPublicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         assertArrayEquals("Horizen base 58 check address expected to have different public key hash.",
@@ -312,7 +314,7 @@ public class BytesUtilsTest {
     @Test
     public void toHorizenPublicKeyAddress() {
         // Test 1: valid MainNet addresses in MainNet network
-        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false);
+        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, 10, FiniteDuration.apply(2, TimeUnit.SECONDS));
 
         byte[] publicKeyHashBytesMainNet = BytesUtils.fromHexString("7843a3fcc6ab7d02d40946360c070b13cf7b9795");
         String expectedPubKeyAddressMainNet = "znc3p7CFNTsz1s6CceskrTxKevQLPoDK4cK";
@@ -323,7 +325,7 @@ public class BytesUtilsTest {
 
 
         // Test 2: valid TestNet addresses in TestNet network
-        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false);
+        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, 0, FiniteDuration.apply(2, TimeUnit.SECONDS));
 
         byte[] publicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         String expectedPubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";

--- a/sdk/src/test/scala/io/horizen/fixtures/sidechainblock/generation/SidechainBlocksGenerator.scala
+++ b/sdk/src/test/scala/io/horizen/fixtures/sidechainblock/generation/SidechainBlocksGenerator.scala
@@ -30,6 +30,7 @@ import java.security.MessageDigest
 import java.time.Instant
 import java.util.Random
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 
 case class GeneratedBlockInfo(block: SidechainBlock, forger: SidechainForgingData)
@@ -547,6 +548,8 @@ object SidechainBlocksGenerator extends CompanionsFixture {
       override val chainId: Long = 11111111
       override val isCSWEnabled: Boolean = params.isCSWEnabled
       override val isNonCeasing: Boolean = params.isNonCeasing
+      override val getLogsSizeLimit: Int = params.getLogsSizeLimit
+      override val getLogsQueryTimeout: FiniteDuration = params.getLogsQueryTimeout
       override val minVirtualWithdrawalEpochLength: Int = 10
     }
   }

--- a/sdk/src/test/scala/io/horizen/utils/TimeToEpochUtilsTest.scala
+++ b/sdk/src/test/scala/io/horizen/utils/TimeToEpochUtilsTest.scala
@@ -12,6 +12,7 @@ import org.junit.Test
 import org.scalatestplus.junit.JUnitSuite
 import sparkz.util.{ModifierId, bytesToId}
 import sparkz.core.block.Block
+import scala.concurrent.duration._
 
 import java.math.BigInteger
 
@@ -51,6 +52,8 @@ class TimeToEpochUtilsTest extends JUnitSuite {
     override val chainId: Long = 11111111
     override val isCSWEnabled: Boolean = true
     override val isNonCeasing: Boolean = false
+    override val getLogsSizeLimit: Int = 10000
+    override val getLogsQueryTimeout: FiniteDuration = 10.seconds
     override val minVirtualWithdrawalEpochLength: Int = 10
   }
 

--- a/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
+++ b/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
@@ -31,6 +31,7 @@ import io.horizen.transaction.mainchain.SidechainRelatedMainchainOutput;
 import io.horizen.utils.*;
 import io.horizen.vrf.VrfOutput;
 import scala.Enumeration;
+import scala.concurrent.duration.FiniteDuration;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
@@ -40,6 +41,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class ScBootstrappingToolCommandProcessor extends CommandProcessor {
@@ -936,11 +938,11 @@ public class ScBootstrappingToolCommandProcessor extends CommandProcessor {
 
         switch(network) {
             case 0: // mainnet
-                return new MainNetParams(scId, null, null, null, null, 1, 0,100, 120, 720, null, null, circuitType,0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false);
+                return new MainNetParams(scId, null, null, null, null, 1, 0,100, 120, 720, null, null, circuitType,0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, 10000, FiniteDuration.apply(10, TimeUnit.SECONDS));
             case 1: // testnet
-                return new TestNetParams(scId, null, null, null, null, 1, 0, 100, 120, 720, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false);
+                return new TestNetParams(scId, null, null, null, null, 1, 0, 100, 120, 720, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false,10000, FiniteDuration.apply(10, TimeUnit.SECONDS));
             case 2: // regtest
-                return new RegTestParams(scId, null, null, null, null, 1, 0, 100, 120, 720, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false);
+                return new RegTestParams(scId, null, null, null, null, 1, 0, 100, 120, 720, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, 10, FiniteDuration.apply(2, TimeUnit.SECONDS));
             default:
                 throw new IllegalStateException("Unexpected network type: " + network);
         }


### PR DESCRIPTION
[Jira ticket](https://horizenlabs.atlassian.net/browse/SDK-1117?atlOrigin=eyJpIjoiNDk3MGY5MjFiMWYwNGVlM2FkNjZkOThhNzIwZTYwZWUiLCJwIjoiaiJ9)

After looking at how different EVM-compatible blockchains put limits on eth_getLogs, we decided on the following:

- max 10K results can be returned by a single query

- query duration must not exceed 10 seconds