### PR TITLE
SDK-1215

### DIFF
--- a/sdk/src/main/scala/io/horizen/SidechainSettings.scala
+++ b/sdk/src/main/scala/io/horizen/SidechainSettings.scala
@@ -94,6 +94,16 @@ case class EthServiceSettings(
      * might require more gas than is ever required during a transaction.
      */
     globalRpcGasCap: BigInteger = BigInteger.valueOf(50000000),
+
+    /**
+     * Size limit of the number of results returned by the RPC call eth_getLogs
+     */
+    getLogsSizeLimit: Int = 10000,
+
+    /**
+     * Timeout limit for the RPC call eth_getLogs
+     */
+    getLogsQueryTimeout: FiniteDuration = 10.seconds
 ) extends SensitiveStringer
 
 // Default values are the same as in Geth/Erigon

--- a/sdk/src/main/scala/io/horizen/params/MainNetParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/MainNetParams.scala
@@ -42,9 +42,7 @@ case class MainNetParams(
                           override val sidechainCreationVersion: SidechainCreationVersion = SidechainCreationVersion1,
                           override val chainId: Long = 33333333,
                           override val isCSWEnabled: Boolean = true,
-                          override val isNonCeasing: Boolean = false,
-                          override val getLogsSizeLimit: Int = 10000,
-                          override val getLogsQueryTimeout: FiniteDuration = 10.seconds,
+                          override val isNonCeasing: Boolean = false
                         ) extends NetworkParams {
   override val EquihashN: Int = 200
   override val EquihashK: Int = 9

--- a/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
@@ -66,8 +66,6 @@ trait NetworkParams {
   val consensusSlotsInEpoch: Int
   val initialCumulativeCommTreeHash: Array[Byte] // CumulativeCommTreeHash value before genesis block
   val isNonCeasing: Boolean
-  val getLogsSizeLimit: Int
-  val getLogsQueryTimeout: FiniteDuration
 
   val minVirtualWithdrawalEpochLength: Int
 

--- a/sdk/src/main/scala/io/horizen/params/RegTestParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/RegTestParams.scala
@@ -40,9 +40,7 @@ case class RegTestParams(
                           override val sidechainCreationVersion: SidechainCreationVersion = SidechainCreationVersion1,
                           override val chainId: Long = 1111111,
                           override val isCSWEnabled: Boolean = true,
-                          override val isNonCeasing: Boolean = false,
-                          override val getLogsSizeLimit: Int = 10,
-                          override val getLogsQueryTimeout: FiniteDuration = 2.seconds,
+                          override val isNonCeasing: Boolean = false
                         ) extends NetworkParams {
   override val EquihashN: Int = 48
   override val EquihashK: Int = 5

--- a/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
@@ -39,9 +39,7 @@ case class TestNetParams(
                           override val sidechainCreationVersion: SidechainCreationVersion = SidechainCreationVersion1,
                           override val chainId: Long = 22222222,
                           override val isCSWEnabled: Boolean = true,
-                          override val isNonCeasing: Boolean = false,
-                          override val getLogsSizeLimit: Int = 10000,
-                          override val getLogsQueryTimeout: FiniteDuration = 10.seconds,
+                          override val isNonCeasing: Boolean = false
                         ) extends NetworkParams {
   override val EquihashN: Int = 200
   override val EquihashK: Int = 9

--- a/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
+++ b/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
@@ -249,7 +249,7 @@ public class BytesUtilsTest {
     @Test
     public void fromHorizenPublicKeyAddress() {
         // Test 1: valid MainNet addresses in MainNet network
-        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, 10000, null);
+        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false);
         String pubKeyAddressMainNet = "znc3p7CFNTsz1s6CceskrTxKevQLPoDK4cK";
         byte[] expectedPublicKeyHashBytesMainNet = BytesUtils.fromHexString("7843a3fcc6ab7d02d40946360c070b13cf7b9795");
 
@@ -292,7 +292,7 @@ public class BytesUtilsTest {
 
 
         // Test 5: valid TestNet addresses in TestNet network
-        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, 120, 720,  null,null, CircuitTypes.NaiveThresholdSignatureCircuit(),0,  null,null, null, null, null, null, null, false, null, null, 11111111, true, false, 0, null);
+        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, 120, 720,  null,null, CircuitTypes.NaiveThresholdSignatureCircuit(),0,  null,null, null, null, null, null, null, false, null, null, 11111111, true, false);
         String pubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";
         byte[] expectedPublicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         assertArrayEquals("Horizen base 58 check address expected to have different public key hash.",
@@ -314,7 +314,7 @@ public class BytesUtilsTest {
     @Test
     public void toHorizenPublicKeyAddress() {
         // Test 1: valid MainNet addresses in MainNet network
-        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, 10, FiniteDuration.apply(2, TimeUnit.SECONDS));
+        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false);
 
         byte[] publicKeyHashBytesMainNet = BytesUtils.fromHexString("7843a3fcc6ab7d02d40946360c070b13cf7b9795");
         String expectedPubKeyAddressMainNet = "znc3p7CFNTsz1s6CceskrTxKevQLPoDK4cK";
@@ -325,7 +325,7 @@ public class BytesUtilsTest {
 
 
         // Test 2: valid TestNet addresses in TestNet network
-        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, 0, FiniteDuration.apply(2, TimeUnit.SECONDS));
+        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, 120, 720, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false);
 
         byte[] publicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         String expectedPubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";

--- a/sdk/src/test/scala/io/horizen/fixtures/sidechainblock/generation/SidechainBlocksGenerator.scala
+++ b/sdk/src/test/scala/io/horizen/fixtures/sidechainblock/generation/SidechainBlocksGenerator.scala
@@ -548,8 +548,6 @@ object SidechainBlocksGenerator extends CompanionsFixture {
       override val chainId: Long = 11111111
       override val isCSWEnabled: Boolean = params.isCSWEnabled
       override val isNonCeasing: Boolean = params.isNonCeasing
-      override val getLogsSizeLimit: Int = params.getLogsSizeLimit
-      override val getLogsQueryTimeout: FiniteDuration = params.getLogsQueryTimeout
       override val minVirtualWithdrawalEpochLength: Int = 10
     }
   }

--- a/sdk/src/test/scala/io/horizen/utils/TimeToEpochUtilsTest.scala
+++ b/sdk/src/test/scala/io/horizen/utils/TimeToEpochUtilsTest.scala
@@ -52,8 +52,6 @@ class TimeToEpochUtilsTest extends JUnitSuite {
     override val chainId: Long = 11111111
     override val isCSWEnabled: Boolean = true
     override val isNonCeasing: Boolean = false
-    override val getLogsSizeLimit: Int = 10000
-    override val getLogsQueryTimeout: FiniteDuration = 10.seconds
     override val minVirtualWithdrawalEpochLength: Int = 10
   }
 


### PR DESCRIPTION
## Description
This PR introduces fixes the bug raised by the QA team related to the RPC call **eth_getLogs**

## Jira Ticket
[1215](https://horizenlabs.atlassian.net/browse/SDK-1215)

## Changes

- Added a customizable timeout inside the `applyOnAccountView` function of `EthService` class
- Move the `getLogsSizeLimit` and `getLogsQueryTimeout` treshold from `NetworkParams` to `SidechainSettings`

## Checks
- [✔] Project Builds
- [✔] Project passes unit tests
- [✔] Additional checks performed locally:

Added a Thread.sleep() exceeding the `getLogsQueryTimeout` treshold inside the eth_getLogs to simulate node slowness

![eth_logs_timeout](https://github.com/HorizenOfficial/Sidechains-SDK/assets/57944077/522017b2-a0f1-452e-887a-577eb87a82d7)


Simulated a result size > `getLogsSizeLimit` treshold inside the eth_getLogs to simulate lot of logs found.

![eth_get_Logs_size_limit](https://github.com/HorizenOfficial/Sidechains-SDK/assets/57944077/f5684e7d-31a9-4637-874e-a70871ec3978)

I've also checked that the custom timeout is not affecting the other RPC calls.

