### PR TITLE
SDK-1209 - check on jsonrpc request in 

### DIFF
--- a/sdk/src/main/java/io/horizen/account/api/rpc/request/RpcRequest.java
+++ b/sdk/src/main/java/io/horizen/account/api/rpc/request/RpcRequest.java
@@ -18,6 +18,7 @@ public class RpcRequest {
 
     private static final List<String> mandatoryFields = List.of("jsonrpc", "id", "method");
     private static final List<String> stringFields = List.of("jsonrpc", "method");
+    private static final String JSON_RPC_VERSION = "2.0";
 
     public RpcRequest(JsonNode json) throws RpcException {
         for (var field : mandatoryFields) {
@@ -31,13 +32,20 @@ public class RpcRequest {
                 throw new RpcException(
                     RpcError.fromCode(RpcCode.InvalidRequest, String.format("field must be string: %s", field)));
             }
+
         }
         try {
             id = new RpcId(json.get("id"));
         } catch (IllegalArgumentException e) {
             throw new RpcException(RpcError.fromCode(RpcCode.InvalidRequest, e.getMessage()));
         }
+
         jsonrpc = json.get("jsonrpc").asText();
+        // check if the jsonrpc value has the correct version
+        if(!jsonrpc.equals(JSON_RPC_VERSION)) {
+            throw new RpcException(RpcError.fromCode(RpcCode.InvalidRequest, "jsonrpc value is not valid"));
+        }
+
         method = json.get("method").asText();
         // params might be null, which is allowed
         params = json.get("params");


### PR DESCRIPTION
Check added on jsonrpc value, it must be `2.0` as require by json rpc v2.0 specs.
Details in Jira task [SDK-1209](https://horizenlabs.atlassian.net/browse/SDK-1209).

[SDK-1209]: https://horizenlabs.atlassian.net/browse/SDK-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ