### PR TITLE
SDK-1255 - default gas limit for key rotation tx increased

### DIFF
--- a/qa/SidechainTestFramework/account/httpCalls/transaction/createKeyRotationTransaction.py
+++ b/qa/SidechainTestFramework/account/httpCalls/transaction/createKeyRotationTransaction.py
@@ -4,7 +4,7 @@ import json
 def http_create_key_rotation_transaction_evm(sidechainNode, key_type, key_index, new_key,
                                              signing_key_signature, master_key_signature, new_key_signature,
                                              nonce=None, gas_limit=300000, max_fee_per_gas=900000000,
-                                             max_priority_fee_per_gas=900000000, api_key=None):
+                                             max_priority_fee_per_gas=900000000, api_key=None, include_gas_info=True):
     j = {
         "keyType": key_type,
         "keyIndex": key_index,
@@ -12,13 +12,14 @@ def http_create_key_rotation_transaction_evm(sidechainNode, key_type, key_index,
         "signingKeySignature": signing_key_signature,
         "masterKeySignature": master_key_signature,
         "newKeySignature": new_key_signature,
-        "nonce": nonce,
-        "gasInfo": {
+        "nonce": nonce
+    }
+    if include_gas_info:
+        j["gasInfo"] = {
             "gasLimit": gas_limit,
             "maxFeePerGas": max_fee_per_gas,
             "maxPriorityFeePerGas": max_priority_fee_per_gas
         }
-    }
     request = json.dumps(j)
     if api_key is not None:
         response = sidechainNode.transaction_createKeyRotationTransaction(request, api_key)

--- a/qa/SidechainTestFramework/account/httpCalls/transaction/createKeyRotationTransaction.py
+++ b/qa/SidechainTestFramework/account/httpCalls/transaction/createKeyRotationTransaction.py
@@ -3,8 +3,8 @@ import json
 
 def http_create_key_rotation_transaction_evm(sidechainNode, key_type, key_index, new_key,
                                              signing_key_signature, master_key_signature, new_key_signature,
-                                             nonce=None, gas_limit=300000, max_fee_per_gas=900000000,
-                                             max_priority_fee_per_gas=900000000, api_key=None, include_gas_info=True):
+                                             nonce=None, gas_limit=None, max_fee_per_gas=900000000,
+                                             max_priority_fee_per_gas=900000000, api_key=None):
     j = {
         "keyType": key_type,
         "keyIndex": key_index,
@@ -14,7 +14,7 @@ def http_create_key_rotation_transaction_evm(sidechainNode, key_type, key_index,
         "newKeySignature": new_key_signature,
         "nonce": nonce
     }
-    if include_gas_info:
+    if gas_limit is not None:
         j["gasInfo"] = {
             "gasLimit": gas_limit,
             "maxFeePerGas": max_fee_per_gas,

--- a/qa/sc_evm_cert_key_rotation.py
+++ b/qa/sc_evm_cert_key_rotation.py
@@ -47,13 +47,17 @@ Test:
     - End the WE and verify that the certificates is added to the MC and SC.
     ######## WITHDRAWAL EPOCH 2 ##########
     - Call the getKeyRotationProof endpoint and verify that we don't have any key rotation proof stored for epoch 2.
+    - Create a keyRotationTransaction with sdk's default gas info and change the signer key 0 (SK4 -> SK5).
+    - End the WE and verify that the certificates is added to the MC and SC.
+    ######## WITHDRAWAL EPOCH 3 ##########
+    - Call the getKeyRotationProof endpoint and verify that we don't have any key rotation proof stored for epoch 2.
     - Call the getCertificateSigners endpoint and verify that the signers key 0 = SK4.
     - Update ALL the signing and master keys.
     - Call the getKeyRotationProof endpoint and verify that we have a KeyRotationProof for each signing and master keys.
     - End the WE and verify that the certificates is added to the MC and SC.
-     ######## WITHDRAWAL EPOCH 3 ##########
-    - Call the getCertificateSigners endpoint and verify that all the signing and master keys are updated.
      ######## WITHDRAWAL EPOCH 4 ##########
+    - Call the getCertificateSigners endpoint and verify that all the signing and master keys are updated.
+     ######## WITHDRAWAL EPOCH 5 ##########
     - Verify that certificate was created using all new keys
 """
 
@@ -144,6 +148,8 @@ class SCKeyRotationTest(AccountChainSetup):
         new_public_key_3 = new_master_key.publicKey
         new_signing_key_4 = generate_cert_signer_secrets("random_seed4", 1, self.model)[0]
         new_public_key_4 = new_signing_key_4.publicKey
+        new_signing_key_5 = generate_cert_signer_secrets("random_seed5_default_gas", 1, self.model)[0]
+        new_public_key_5 = new_signing_key_5.publicKey
 
         private_master_keys.append(new_signing_key.secret)
         public_master_keys.append(new_public_key)
@@ -153,6 +159,8 @@ class SCKeyRotationTest(AccountChainSetup):
         public_master_keys.append(new_public_key_3)
         private_master_keys.append(new_signing_key_4.secret)
         public_master_keys.append(new_public_key_4)
+        private_master_keys.append(new_signing_key_5.secret)
+        public_master_keys.append(new_public_key_5)
 
         # Change ALL the signing keys and ALL tee master keys
         new_signing_keys = []
@@ -469,6 +477,7 @@ class SCKeyRotationTest(AccountChainSetup):
 
         # ******************** WITHDRAWAL EPOCH 2 START ********************
         logging.info("******************** WITHDRAWAL EPOCH 2 START ********************")
+
         # Generate first mc block of the next epoch
         mc_node.generate(1)
         epoch_mc_blocks_left = self.withdrawalEpochLength - 1
@@ -502,6 +511,80 @@ class SCKeyRotationTest(AccountChainSetup):
             assert_equal(signer_key_rotation_proof, {})
             assert_equal(master_key_rotation_proof, {})
 
+        # Update again the signing key 0 (SK4 -> SK5)
+        epoch = get_withdrawal_epoch(sc_node)
+        signing_key_message_5 = http_get_key_rotation_message_to_sign_for_signing_key(sc_node, new_public_key_5, epoch)[
+            "keyRotationMessageToSign"]
+
+        # Sign the new signing key with the old keys
+        master_signature_5 = self.secure_enclave_create_signature(message_to_sign=signing_key_message_5, # current master key
+                                                                  key=new_master_key.secret)["signature"]
+        signing_signature_5 = self.secure_enclave_create_signature(message_to_sign=signing_key_message_5, # current signing key
+                                                                   key=new_signing_key_4.secret)["signature"]
+        new_key_signature_5 = self.secure_enclave_create_signature(message_to_sign=signing_key_message_5, # new signing key
+                                                                   key=new_signing_key_5.secret)["signature"]
+
+        # Create the key rotation transaction with sdk's default gas info
+        response = http_create_key_rotation_transaction_evm(sc_node,
+                                                            key_type=0,
+                                                            key_index=0,
+                                                            new_key=new_public_key_5,
+                                                            signing_key_signature=signing_signature_5,
+                                                            master_key_signature=master_signature_5,
+                                                            new_key_signature=new_key_signature_5,
+                                                            include_gas_info=False)
+        assert_false("error" in response)
+
+        self.sc_sync_all()
+        generate_next_blocks(sc_node, "first node", 1)
+        self.sc_sync_all()
+
+        # Generate enough MC blocks to reach the end of the withdrawal epoch
+        we0_end_mcblock_hash = mc_node.generate(epoch_mc_blocks_left)[0]
+        sc_block_id = generate_next_block(sc_node, "first node")
+
+        check_mcreferencedata_presence(we0_end_mcblock_hash, sc_block_id, sc_node)
+
+        # Verify that we have the updated key
+        certificate_signers_keys = http_get_certifiers_keys(sc_node, 2)
+        epoch_three_keys_root_hash = certificate_signers_keys["keysRootHash"]
+        assert_equal(certificate_signers_keys["certifiersKeys"]["signingKeys"][0]["publicKey"], new_public_key_5)
+
+        # ******************** WITHDRAWAL EPOCH 3 START ********************
+        logging.info("******************** WITHDRAWAL EPOCH 3 START ********************")
+        # Generate first mc block of the next epoch
+        mc_node.generate(1)
+        epoch_mc_blocks_left = self.withdrawalEpochLength - 1
+        generate_next_blocks(sc_node, "first node", 1)
+
+        # Wait until Certificate will appear in MC node mempool
+        time.sleep(10)
+        while mc_node.getmempoolinfo()["size"] == 0 and sc_node.submitter_isCertGenerationActive()["result"]["state"]:
+            print("Wait for certificate in mc mempool...")
+            time.sleep(2)
+            sc_node.block_best()  # just a ping to SC node. For some reason, STF can't request SC node API after a while idle.
+        assert_equal(1, mc_node.getmempoolinfo()["size"], "Certificate was not added to Mc node mempool.")
+        cert_hash = mc_node.getrawmempool()[0]
+        cert = mc_node.getrawtransaction(cert_hash, 1)['cert']
+        assert_equal(epoch_three_keys_root_hash, cert['vFieldElementCertificateField'][0],
+                     "Certificate Keys Root Hash incorrect")
+        assert_equal(self.cert_max_keys, cert['quality'], "Certificate quality is wrong.")
+
+        # Generate MC and SC blocks with Cert
+        we1_2_mcblock_hash = mc_node.generate(1)[0]
+        epoch_mc_blocks_left -= 1
+
+        # Generate SC block and verify that certificate is synced back
+        scblock_id = generate_next_blocks(sc_node, "first node", 1)[0]
+        check_mcreference_presence(we1_2_mcblock_hash, scblock_id, sc_node)
+
+        # Verify that we don't have any key rotation in this epoch
+        for i in range(self.cert_max_keys):
+            signer_key_rotation_proof = http_get_key_rotation_proof(sc_node, 3, i, 0)["result"]
+            master_key_rotation_proof = http_get_key_rotation_proof(sc_node, 3, i, 1)["result"]
+            assert_equal(signer_key_rotation_proof, {})
+            assert_equal(master_key_rotation_proof, {})
+
         epoch = get_withdrawal_epoch(sc_node)
         for i in range(self.cert_max_keys):
             new_signing_key = new_signing_keys[i]
@@ -519,7 +602,7 @@ class SCKeyRotationTest(AccountChainSetup):
                 new_sign_master_signature = self.secure_enclave_create_signature(message_to_sign=new_signing_key_hash,
                                                                                  key=new_master_key.secret)["signature"]
                 new_sign_signing_signature = self.secure_enclave_create_signature(message_to_sign=new_signing_key_hash,
-                                                                                  key=new_signing_key_4.secret)[
+                                                                                  key=new_signing_key_5.secret)[
                     "signature"]
 
                 # Master key signatures
@@ -527,7 +610,7 @@ class SCKeyRotationTest(AccountChainSetup):
                                                                                    key=new_master_key.secret)[
                     "signature"]
                 new_master_signing_signature = self.secure_enclave_create_signature(message_to_sign=new_master_key_hash,
-                                                                                    key=new_signing_key_4.secret)[
+                                                                                    key=new_signing_key_5.secret)[
                     "signature"]
 
             else:
@@ -577,12 +660,12 @@ class SCKeyRotationTest(AccountChainSetup):
 
         # Verify that we changed all the signing keys
         for i in range(self.cert_max_keys):
-            signer_key_rotation_proof = http_get_key_rotation_proof(sc_node, 2, i, 0)["result"]["keyRotationProof"]
+            signer_key_rotation_proof = http_get_key_rotation_proof(sc_node, 3, i, 0)["result"]["keyRotationProof"]
             assert_equal(signer_key_rotation_proof["index"], i)
             assert_equal(signer_key_rotation_proof["keyType"]["value"], "SigningKeyRotationProofType")
             assert_equal(signer_key_rotation_proof["newKey"]["publicKey"], new_signing_keys[i].publicKey)
 
-            master_key_rotation_proof = http_get_key_rotation_proof(sc_node, 2, i, 1)["result"]["keyRotationProof"]
+            master_key_rotation_proof = http_get_key_rotation_proof(sc_node, 3, i, 1)["result"]["keyRotationProof"]
             assert_equal(master_key_rotation_proof["index"], i)
             assert_equal(master_key_rotation_proof["keyType"]["value"], "MasterKeyRotationProofType")
             assert_equal(master_key_rotation_proof["newKey"]["publicKey"], new_master_keys[i].publicKey)
@@ -594,14 +677,14 @@ class SCKeyRotationTest(AccountChainSetup):
         check_mcreferencedata_presence(we0_end_mcblock_hash, sc_block_id, sc_node)
 
         # Verify that we have all the singing keys updated
-        certificate_signers_keys = http_get_certifiers_keys(sc_node, 3)["certifiersKeys"]
+        certificate_signers_keys = http_get_certifiers_keys(sc_node, 4)["certifiersKeys"]
         for i in range(len(certificate_signers_keys["signingKeys"])):
             assert_equal(certificate_signers_keys["signingKeys"][i]["publicKey"], new_signing_keys[i].publicKey)
             assert_equal(certificate_signers_keys["masterKeys"][i]["publicKey"], new_master_keys[i].publicKey)
-        epoch_three_keys_root_hash = http_get_certifiers_keys(sc_node, 3)['keysRootHash']
+        epoch_four_keys_root_hash = http_get_certifiers_keys(sc_node, 4)['keysRootHash']
 
-        # ******************** WITHDRAWAL EPOCH 3 START ********************
-        logging.info("******************** WITHDRAWAL EPOCH 3 START ********************")
+        # ******************** WITHDRAWAL EPOCH 4 START ********************
+        logging.info("******************** WITHDRAWAL EPOCH 4 START ********************")
 
         # Generate first mc block of the next epoch
         mc_node.generate(1)
@@ -617,7 +700,7 @@ class SCKeyRotationTest(AccountChainSetup):
         assert_equal(1, mc_node.getmempoolinfo()["size"], "Certificate was not added to Mc node mempool.")
         cert_hash = mc_node.getrawmempool()[0]
         cert = mc_node.getrawtransaction(cert_hash, 1)['cert']
-        assert_equal(epoch_three_keys_root_hash, cert['vFieldElementCertificateField'][0],
+        assert_equal(epoch_four_keys_root_hash, cert['vFieldElementCertificateField'][0],
                      "Certificate Keys Root Hash incorrect")
         assert_equal(self.cert_max_keys, cert['quality'], "Certificate quality is wrong.")
 
@@ -631,8 +714,8 @@ class SCKeyRotationTest(AccountChainSetup):
         mc_node.generate(epoch_mc_blocks_left - 1)
         generate_next_block(sc_node, "first node")
 
-        # ******************** WITHDRAWAL EPOCH 4 START ********************
-        logging.info("******************** WITHDRAWAL EPOCH 4 START ********************")
+        # ******************** WITHDRAWAL EPOCH 5 START ********************
+        logging.info("******************** WITHDRAWAL EPOCH 5 START ********************")
 
         # Generate first mc block of the next epoch
         mc_node.generate(1)
@@ -647,7 +730,7 @@ class SCKeyRotationTest(AccountChainSetup):
         assert_equal(1, mc_node.getmempoolinfo()["size"], "Certificate was not added to Mc node mempool.")
         cert_hash = mc_node.getrawmempool()[0]
         cert = mc_node.getrawtransaction(cert_hash, 1)['cert']
-        assert_equal(epoch_three_keys_root_hash, cert['vFieldElementCertificateField'][0],
+        assert_equal(epoch_four_keys_root_hash, cert['vFieldElementCertificateField'][0],
                      "Certificate Keys Root Hash incorrect")
         assert_equal(self.cert_max_keys, cert['quality'], "Certificate quality is wrong.")
 

--- a/qa/sc_evm_cert_key_rotation.py
+++ b/qa/sc_evm_cert_key_rotation.py
@@ -50,8 +50,8 @@ Test:
     - Create a keyRotationTransaction with sdk's default gas info and change the signer key 0 (SK4 -> SK5).
     - End the WE and verify that the certificates is added to the MC and SC.
     ######## WITHDRAWAL EPOCH 3 ##########
-    - Call the getKeyRotationProof endpoint and verify that we don't have any key rotation proof stored for epoch 2.
-    - Call the getCertificateSigners endpoint and verify that the signers key 0 = SK4.
+    - Call the getKeyRotationProof endpoint and verify that we don't have any key rotation proof stored for epoch 3.
+    - Call the getCertificateSigners endpoint and verify that the signers key 0 = SK5.
     - Update ALL the signing and master keys.
     - Call the getKeyRotationProof endpoint and verify that we have a KeyRotationProof for each signing and master keys.
     - End the WE and verify that the certificates is added to the MC and SC.

--- a/sdk/src/main/scala/io/horizen/account/api/http/route/AccountTransactionApiRoute.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/http/route/AccountTransactionApiRoute.scala
@@ -680,7 +680,7 @@ case class AccountTransactionApiRoute(override val settings: RESTApiSettings,
                     val baseFee = sidechainNodeView.getNodeHistory.getBestBlock.header.baseFee
                     var maxPriorityFeePerGas = BigInteger.valueOf(120)
                     var maxFeePerGas = BigInteger.TWO.multiply(baseFee).add(maxPriorityFeePerGas)
-                    var gasLimit = BigInteger.TWO.multiply(GasUtil.TxGas)
+                    var gasLimit = BigInteger.valueOf(500000)
 
                     if (gasInfo.isDefined) {
                       maxFeePerGas = gasInfo.get.maxFeePerGas


### PR DESCRIPTION
## Description
The default gas limit for key rotation transactions increased from 42000 to 500000 after discovering that it was not enough.
Testing shows 276988 gas is used, but after discussion with @MarcoOl94 we put 500000 just to be sure that it's enough to be executed since this type of transaction is rare.
## Jira Ticket
[SDK-1255](https://horizenlabs.atlassian.net/browse/SDK-1255?atlOrigin=eyJpIjoiYmI1M2Q4Mzg5ZmFjNDg2YmEzMjMzMmU3Yjc4MGEyZGIiLCJwIjoiaiJ9)

## Changes
The default limit increased.
sc_evm_cert_key_rotation.py updated to include 1 key rotation transaction with default gas info.

## Breaking Changes
/

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly
- [ ] Breaking changes have been correctly tagged and notified
 
## Additional information


[SDK-1255]: https://horizenlabs.atlassian.net/browse/SDK-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ