### PR TITLE
check for NPE in calls that expect tracerResult from evm

### DIFF
--- a/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.horizen.EthServiceSettings
 import io.horizen.account.api.rpc.handler.RpcException
 import io.horizen.account.api.rpc.types._
@@ -916,7 +917,12 @@ class EthService(
         tagStateView.applyTransaction(requestedTx, previousTransactions.length, gasPool, blockContext)
 
         // return the tracer result from the evm
-        blockContext.getEvmResult.tracerResult
+        if (blockContext.getEvmResult != null && blockContext.getEvmResult.tracerResult != null)
+          blockContext.getEvmResult.tracerResult
+        else {
+          logger.warn("Unable to get tracer result from EVM")
+          JsonNodeFactory.instance.objectNode()
+        }
       }
     }
   }
@@ -940,7 +946,12 @@ class EthService(
           tagStateView.applyMessage(msg, new GasPool(msg.getGasLimit), blockContext)
 
           // return the tracer result from the evm
-          blockContext.getEvmResult.tracerResult
+          if (blockContext.getEvmResult != null && blockContext.getEvmResult.tracerResult != null)
+            blockContext.getEvmResult.tracerResult
+          else {
+            logger.warn("Unable to get tracer result from EVM")
+            JsonNodeFactory.instance.objectNode()
+          }
       }
     }
   }


### PR DESCRIPTION
## Description
traceTrancastion can be called for a eoa2eoa transaction, that is not processed by EvmMessageProcessor, so there's no trace to return.

## Jira Ticket
https://horizenlabs.atlassian.net/browse/SDK-1282

## Changes
Adds a null check before getting tracerResult


## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
- [x] Breaking changes have been correctly tagged and notified
 
## Additional information
