### PR TITLE
SDK-960 - avoid nodes sync indefinitely

### DIFF
--- a/sdk/src/main/scala/io/horizen/history/AbstractHistory.scala
+++ b/sdk/src/main/scala/io/horizen/history/AbstractHistory.scala
@@ -344,14 +344,12 @@ abstract class AbstractHistory[
   // check the presence of a block on the current history at the second divergent suffix sequence height
   // it is used to check the presence of forks
   private def checkForkAtPreviousIndexBlock(otherBestKnownBlockHeight: Int, dSuffixSize: Int): Boolean = {
-    var heightAtPreviousIndex = 0
-    if (dSuffixSize > 10) {
-      heightAtPreviousIndex = otherBestKnownBlockHeight + math.pow(2, dSuffixSize-10).toInt
+    val heightAtPreviousIndex = if (dSuffixSize > 10) {
+      otherBestKnownBlockHeight + math.pow(2, dSuffixSize-10).toInt
     } else {
-      heightAtPreviousIndex = otherBestKnownBlockHeight + dSuffixSize
+      otherBestKnownBlockHeight + dSuffixSize
     }
-    if (heightAtPreviousIndex < storage.height)
-      true else false
+    heightAtPreviousIndex < storage.height
   }
 
   override def syncInfo: SidechainSyncInfo = {

--- a/sdk/src/main/scala/io/horizen/history/AbstractHistory.scala
+++ b/sdk/src/main/scala/io/horizen/history/AbstractHistory.scala
@@ -326,7 +326,7 @@ abstract class AbstractHistory[
       // It is not possible to calculate the other node best block approximate height in this case.
       // If the only common block is the genesis one (height 1) it is not possible to correctly calculate the other node
       // best block because the method knownBlocksHeightToSync used to create the other node sequence always push the
-      // genesis block index at the end of the list and in this way we don't know how much block separate the genesis
+      // genesis block index at the end of the list and in this way we don't know how many blocks separate the genesis
       // from the second last sequence index height.
       -1
     } else {

--- a/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
@@ -534,14 +534,14 @@ class SidechainHistoryTest extends JUnitSuite
 
     // Test 4: compare history1 syncInfo with history2, they have fork on lasts block, height is the same.
     comparisonResult = history2.compare(history1SyncInfo)
-    assertEquals("History 1 chain expected to be younger then history 2 chain", History.Fork, comparisonResult)
+    assertEquals("History 1 chain expected to be a fork related to history 2 chain", History.Fork, comparisonResult)
     // Verify history2 continuationIds for history1 info
     continuationIds = history2.continuationIds(history1SyncInfo, Int.MaxValue -1)
     assertEquals("History 1 continuation Ids for history 2 info expected to be with given size empty.", 1, continuationIds.size)
     assertEquals("History 1 continuation Ids for history 2 should contain different data.", history2blockSeq.last.id, continuationIds.head._2)
 
 
-    // Test 5: Append history1.bestblock to history2 , but don't make it best.
+    // Test 5: Append history1.bestblock to history2, but don't make it best.
     // compare history1 syncInfo with history2, they have fork on lasts block, height is the same.
     history2.append(history1blockSeq.last) match {
       case Success((hist, _)) =>
@@ -549,11 +549,122 @@ class SidechainHistoryTest extends JUnitSuite
       case Failure(e) => assertFalse("Unexpected Exception occurred during block appending: %s".format(e.getMessage), true)
     }
     comparisonResult = history2.compare(history1SyncInfo)
-    assertEquals("History 1 chain expected to be equal then history 2 chain", History.Fork, comparisonResult)
+    assertEquals("History 1 chain expected to be a fork related to history 2 chain", History.Fork, comparisonResult)
     // Verify history2 continuationIds for history1 info
     continuationIds = history2.continuationIds(history1SyncInfo, Int.MaxValue -1)
     assertEquals("History 1 continuation Ids for history 2 info expected to be with given size empty.", 1, continuationIds.size)
     assertEquals("History 1 continuation Ids for history 2 should contain different data.", history2blockSeq.last.id, continuationIds.head._2)
+  }
+
+  @Test
+  def synchronizationTestWithHighBlockNumber(): Unit = {
+    // -----------------------------------------------------------------------------------------------------------------
+    // Create first history object
+    val sidechainHistoryStorage1 = new SidechainHistoryStorage(getStorage(), sidechainTransactionsCompanion, params)
+    val consensusDataStorage1 = new ConsensusDataStorage(getStorage())
+    val history1Try = SidechainHistory.createGenesisHistory(sidechainHistoryStorage1, consensusDataStorage1, params, genesisBlock, Seq(new SidechainBlockSemanticValidator[SidechainTypes#SCBT, SidechainBlock](params)), Seq(), StakeConsensusEpochInfo(idToBytes(genesisBlock.id), 0L))
+    var history1: SidechainHistory = history1Try.get
+
+    // Init history1 with 299 more blocks
+    var history1blockSeq = Seq[SidechainBlock](genesisBlock)
+    var blocksToAppend = 299
+    while (blocksToAppend > 0) {
+      val block = generateNextSidechainBlock(history1blockSeq.last, sidechainTransactionsCompanion, params, basicSeed = 443356L)
+      history1.append(block) match {
+        case Success((hist, _)) =>
+          history1 = hist
+        case Failure(e) => assertFalse("Unexpected Exception occurred during block appending: %s".format(e.getMessage), true)
+      }
+      history1 = history1.reportModifierIsValid(block).get
+      history1blockSeq = history1blockSeq :+ block
+      blocksToAppend -= 1
+    }
+    assertEquals("Expected to have different height", 300, history1.height)
+
+    // Create second history object
+    val sidechainHistoryStorage2 = new SidechainHistoryStorage(getStorage(), sidechainTransactionsCompanion, params)
+    val consensusDataStorage2 = new ConsensusDataStorage(getStorage())
+    val history2Try = SidechainHistory.createGenesisHistory(sidechainHistoryStorage2, consensusDataStorage2, params, genesisBlock, Seq(new SidechainBlockSemanticValidator[SidechainTypes#SCBT, SidechainBlock](params)), Seq(), StakeConsensusEpochInfo(idToBytes(genesisBlock.id), 0L))
+    assertTrue("Genesis history2 creation expected to be successful. ", history2Try.isSuccess)
+    var history2: SidechainHistory = history2Try.get
+
+    // Init history2 with 150 blocks taken from history1
+    var history2blockSeq = history1blockSeq.take(150)
+    for (block <- history2blockSeq.tail) { // without genesis
+      history2.append(block) match {
+        case Success((hist, _)) =>
+          history2 = hist
+        case Failure(e) => assertFalse("Unexpected Exception occurred during block appending: %s".format(e.getMessage), true)
+      }
+      history2 = history2.reportModifierIsValid(block).get
+    }
+    assertEquals("Expected to have different height", 150, history2.height)
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Test 1:
+    // retrieve history1 sync info and check against history2, a Older status is expected
+    var history1SyncInfo: SidechainSyncInfo = history1.syncInfo
+    var comparisonResult: History.HistoryComparisonResult = history2.compare(history1SyncInfo)
+    assertEquals("History 1 chain expected to be older then history 2 chain", History.Older, comparisonResult)
+    // retrieve history2 sync info and check against history1, a Younger status is expected
+    var history2SyncInfo: SidechainSyncInfo = history2.syncInfo
+    comparisonResult = history1.compare(history2SyncInfo)
+    assertEquals("History 2 chain expected to be younger then history 1 chain", History.Younger, comparisonResult) // TODO update comment
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // update history2 with 50 more blocks (introduce a fork)
+    blocksToAppend = 50
+    while (blocksToAppend > 0) {
+      val block = generateNextSidechainBlock(history2blockSeq.last, sidechainTransactionsCompanion, params, basicSeed = 334456L)
+      history2.append(block) match {
+        case Success((hist, _)) =>
+          history2 = hist
+        case Failure(e) => assertFalse("Unexpected Exception occurred during block appending: %s".format(e.getMessage), true)
+      }
+      history2 = history2.reportModifierIsValid(block).get
+      history2blockSeq = history2blockSeq :+ block
+      blocksToAppend -= 1
+    }
+    assertEquals("Expected to have different height", 200, history2.height)
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Test 2:
+    // retrieve history1 sync info and check against history2, a Fork status is expected
+    history1SyncInfo = history1.syncInfo
+    comparisonResult = history2.compare(history1SyncInfo)
+    assertEquals("History 1 chain expected to be a fork related to history 2 chain", History.Fork, comparisonResult)
+    // retrieve history2 sync info and check against history1, a Fork status is expected
+    history2SyncInfo = history2.syncInfo
+    comparisonResult = history1.compare(history2SyncInfo)
+    assertEquals("History 2 chain expected to be a fork related to history 1 chain", History.Fork, comparisonResult)
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // update history2 with 150 more blocks
+    blocksToAppend = 150
+    while (blocksToAppend > 0) {
+      val block = generateNextSidechainBlock(history2blockSeq.last, sidechainTransactionsCompanion, params, basicSeed = 334456L)
+      history2.append(block) match {
+        case Success((hist, _)) =>
+          history2 = hist
+        case Failure(e) => assertFalse("Unexpected Exception occurred during block appending: %s".format(e.getMessage), true)
+      }
+      // notify history that appended block is valid
+      history2 = history2.reportModifierIsValid(block).get
+      history2blockSeq = history2blockSeq :+ block
+      blocksToAppend -= 1
+    }
+    assertEquals("Expected to have different height", 350, history2.height)
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Test 3:
+    // retrieve history1 sync info and check against history2, a Fork status is expected
+    history1SyncInfo = history1.syncInfo
+    comparisonResult = history2.compare(history1SyncInfo)
+    assertEquals("History 1 chain expected to be a fork related to history 2 chain", History.Fork, comparisonResult)
+    // retrieve history2 sync info and check against history1, a Fork status is expected
+    history2SyncInfo = history2.syncInfo
+    comparisonResult = history1.compare(history2SyncInfo)
+    assertEquals("History 2 chain expected to be a fork related to history 1 chain", History.Fork, comparisonResult)
   }
 
   @Test

--- a/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
@@ -559,6 +559,7 @@ class SidechainHistoryTest extends JUnitSuite
   @Test
   def synchronizationTestWithHighBlockNumber(): Unit = {
     // -----------------------------------------------------------------------------------------------------------------
+    // Test 1:
     // Create first history object
     val sidechainHistoryStorage1 = new SidechainHistoryStorage(getStorage(), sidechainTransactionsCompanion, params)
     val consensusDataStorage1 = new ConsensusDataStorage(getStorage())
@@ -601,7 +602,6 @@ class SidechainHistoryTest extends JUnitSuite
     assertEquals("Expected to have different height", 150, history2.height)
 
     // -----------------------------------------------------------------------------------------------------------------
-    // Test 1:
     // retrieve history1 sync info and check against history2, a Older status is expected
     var history1SyncInfo: SidechainSyncInfo = history1.syncInfo
     var comparisonResult: History.HistoryComparisonResult = history2.compare(history1SyncInfo)
@@ -612,8 +612,43 @@ class SidechainHistoryTest extends JUnitSuite
     assertEquals("History 2 chain expected to be younger then history 1 chain", History.Younger, comparisonResult)
 
     // -----------------------------------------------------------------------------------------------------------------
-    // update history2 with 50 more blocks (introduce a fork)
-    blocksToAppend = 50
+    // Test 2:
+    // update history2 with 10 more blocks (introduce a fork).
+    // Here we can test a corner case in which the comparison between two histories will result in a Older state even if there is Fork
+    // The node1 (at height 300) will send the node2 a list with the modifiers ID at the following height:
+    // 300 - 299 - 298 - 297 - 296 - 295 - 294 - 293 - 292 - 291 - 289 - 285 - 277 - 261 - 229 - 165 - 37 - 1
+    // The divergent suffix list will be the modifiers at the following height (size 17):
+    // 37 - 165 - 229 - 261 - 277 - 285 - 289 - 291 - 292 - 293 - 294 - 295 - 296 - 297 - 298 - 299 - 300
+    // The internal logic will calculate the second divergent suffix height.
+    // The result (165) is less than the current height (110) and the final result will be an Older status
+    blocksToAppend = 10
+    while (blocksToAppend > 0) {
+      val block = generateNextSidechainBlock(history2blockSeq.last, sidechainTransactionsCompanion, params, basicSeed = 334456L)
+      history2.append(block) match {
+        case Success((hist, _)) =>
+          history2 = hist
+        case Failure(e) => assertFalse("Unexpected Exception occurred during block appending: %s".format(e.getMessage), true)
+      }
+      history2 = history2.reportModifierIsValid(block).get
+      history2blockSeq = history2blockSeq :+ block
+      blocksToAppend -= 1
+    }
+    assertEquals("Expected to have different height", 160, history2.height)
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // retrieve history1 sync info and check against history2, an Older status is expected even if we have a Fork
+    history1SyncInfo = history1.syncInfo
+    comparisonResult = history2.compare(history1SyncInfo)
+    assertEquals("History 1 chain expected to be a fork related to history 2 chain", History.Older, comparisonResult)
+    // retrieve history2 sync info and check against history1, a Fork status is expected
+    history2SyncInfo = history2.syncInfo
+    comparisonResult = history1.compare(history2SyncInfo)
+    assertEquals("History 2 chain expected to be a fork related to history 1 chain", History.Fork, comparisonResult)
+
+    // -----------------------------------------------------------------------------------------------------------------
+    // Test 3:
+    // update history2 with 40 more blocks
+    blocksToAppend = 40
     while (blocksToAppend > 0) {
       val block = generateNextSidechainBlock(history2blockSeq.last, sidechainTransactionsCompanion, params, basicSeed = 334456L)
       history2.append(block) match {
@@ -628,7 +663,6 @@ class SidechainHistoryTest extends JUnitSuite
     assertEquals("Expected to have different height", 200, history2.height)
 
     // -----------------------------------------------------------------------------------------------------------------
-    // Test 2:
     // retrieve history1 sync info and check against history2, a Fork status is expected
     history1SyncInfo = history1.syncInfo
     comparisonResult = history2.compare(history1SyncInfo)
@@ -639,6 +673,7 @@ class SidechainHistoryTest extends JUnitSuite
     assertEquals("History 2 chain expected to be a fork related to history 1 chain", History.Fork, comparisonResult)
 
     // -----------------------------------------------------------------------------------------------------------------
+    // Test 4:
     // update history2 with 150 more blocks
     blocksToAppend = 150
     while (blocksToAppend > 0) {
@@ -656,7 +691,6 @@ class SidechainHistoryTest extends JUnitSuite
     assertEquals("Expected to have different height", 350, history2.height)
 
     // -----------------------------------------------------------------------------------------------------------------
-    // Test 3:
     // retrieve history1 sync info and check against history2, a Fork status is expected
     history1SyncInfo = history1.syncInfo
     comparisonResult = history2.compare(history1SyncInfo)

--- a/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
@@ -618,7 +618,7 @@ class SidechainHistoryTest extends JUnitSuite
     // The node1 (at height 300) will send the node2 a list with the modifiers ID at the following height:
     // 300 - 299 - 298 - 297 - 296 - 295 - 294 - 293 - 292 - 291 - 289 - 285 - 277 - 261 - 229 - 165 - 37 - 1
     // The divergent suffix list will be the modifiers at the following height (size 17):
-    // 1 - 37 - 165 - 229 - 261 - 277 - 285 - 289 - 291 - 292 - 293 - 294 - 295 - 296 - 297 - 298 - 299 - 300
+    // 37 - 165 - 229 - 261 - 277 - 285 - 289 - 291 - 292 - 293 - 294 - 295 - 296 - 297 - 298 - 299 - 300
     // The internal logic will calculate the second divergent suffix height.
     // The result (165) is greater than the current height (160) and the final result will be an Older status
     blocksToAppend = 10

--- a/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
@@ -543,14 +543,13 @@ class SidechainHistoryTest extends JUnitSuite
 
     // Test 5: Append history1.bestblock to history2 , but don't make it best.
     // compare history1 syncInfo with history2, they have fork on lasts block, height is the same.
-    // Expected to be equal, but history2 will try to provide hist best block inside continuation ids
     history2.append(history1blockSeq.last) match {
       case Success((hist, _)) =>
         history2 = hist
       case Failure(e) => assertFalse("Unexpected Exception occurred during block appending: %s".format(e.getMessage), true)
     }
     comparisonResult = history2.compare(history1SyncInfo)
-    assertEquals("History 1 chain expected to be equal then history 2 chain", History.Equal, comparisonResult)
+    assertEquals("History 1 chain expected to be equal then history 2 chain", History.Fork, comparisonResult)
     // Verify history2 continuationIds for history1 info
     continuationIds = history2.continuationIds(history1SyncInfo, Int.MaxValue -1)
     assertEquals("History 1 continuation Ids for history 2 info expected to be with given size empty.", 1, continuationIds.size)

--- a/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
@@ -609,7 +609,7 @@ class SidechainHistoryTest extends JUnitSuite
     // retrieve history2 sync info and check against history1, a Younger status is expected
     var history2SyncInfo: SidechainSyncInfo = history2.syncInfo
     comparisonResult = history1.compare(history2SyncInfo)
-    assertEquals("History 2 chain expected to be younger then history 1 chain", History.Younger, comparisonResult) // TODO update comment
+    assertEquals("History 2 chain expected to be younger then history 1 chain", History.Younger, comparisonResult)
 
     // -----------------------------------------------------------------------------------------------------------------
     // update history2 with 50 more blocks (introduce a fork)

--- a/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/integration/SidechainHistoryTest.scala
@@ -618,9 +618,9 @@ class SidechainHistoryTest extends JUnitSuite
     // The node1 (at height 300) will send the node2 a list with the modifiers ID at the following height:
     // 300 - 299 - 298 - 297 - 296 - 295 - 294 - 293 - 292 - 291 - 289 - 285 - 277 - 261 - 229 - 165 - 37 - 1
     // The divergent suffix list will be the modifiers at the following height (size 17):
-    // 37 - 165 - 229 - 261 - 277 - 285 - 289 - 291 - 292 - 293 - 294 - 295 - 296 - 297 - 298 - 299 - 300
+    // 1 - 37 - 165 - 229 - 261 - 277 - 285 - 289 - 291 - 292 - 293 - 294 - 295 - 296 - 297 - 298 - 299 - 300
     // The internal logic will calculate the second divergent suffix height.
-    // The result (165) is less than the current height (110) and the final result will be an Older status
+    // The result (165) is greater than the current height (160) and the final result will be an Older status
     blocksToAppend = 10
     while (blocksToAppend > 0) {
       val block = generateNextSidechainBlock(history2blockSeq.last, sidechainTransactionsCompanion, params, basicSeed = 334456L)


### PR DESCRIPTION
## Description
On the current implementation there is a problem in the way we calculate and send `SyncInfo` to the other nodes. The other node height retrieved from the  `SyncInfo` message is not correctly estimated and this lead in some cases to consider another node more updated as younger. In this situation the node consider itself more developed and stop processing other `SyncInfo` messages remaining stuck at certain height.
With the current PR we introduced a new method to correctly calculate the other node height (method `calculateOtherNodeApproxHeight`).
The Equal return statement in case the divergent suffix sequence size is greater than one was  removed because it is currently a fork situation, an existing comment on the code reported exactly that.

## Jira Ticket
details in task [SDK-960](https://horizenlabs.atlassian.net/browse/SDK-960)

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly


[SDK-960]: https://horizenlabs.atlassian.net/browse/SDK-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ