### PR TITLE
SDK-1295 - Content-Type HTTP header fix in SecureEnclaveApiClient

### DIFF
--- a/qa/SidechainTestFramework/secure_enclave_http_api_server.py
+++ b/qa/SidechainTestFramework/secure_enclave_http_api_server.py
@@ -5,6 +5,8 @@ import subprocess
 
 from flask import Flask, request, json
 
+from test_framework.util import assert_equal
+
 
 class SecureEnclaveApiServer(object):
 
@@ -26,6 +28,9 @@ class SecureEnclaveApiServer(object):
         @self.app.route('/api/v1/createSignature', methods=['POST'])
         def sign_message():
             content = json.loads(request.data)
+            if "akka-http" in request.headers['User-Agent']:
+                assert_equal("application/json", request.headers['Content-Type'])
+                assert_equal("application/json", request.headers['Accept'])
             logging.info("SecureEnclaveApiServer /api/v1/createSignature received request " + str(content))
             if 'privateKey' not in content:
                 pk = content['publicKey']

--- a/sdk/src/main/scala/io/horizen/api/http/client/SecureEnclaveApiClient.scala
+++ b/sdk/src/main/scala/io/horizen/api/http/client/SecureEnclaveApiClient.scala
@@ -2,7 +2,7 @@ package io.horizen.api.http.client
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.client.RequestBuilding.Post
-import akka.http.scaladsl.model.headers.{Accept, RawHeader}
+import akka.http.scaladsl.model.headers.Accept
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpHeader, HttpRequest, HttpResponse, MediaTypes, StatusCodes}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.{Http, HttpExt}
@@ -27,13 +27,13 @@ class SecureEnclaveApiClient(settings: RemoteKeysManagerSettings)(implicit syste
   val SCHNORR = "schnorr"
 
   val headers: List[HttpHeader] = List(
-    Accept(MediaTypes.`application/json`),
-    RawHeader("Content-Type", "application/json")
+    Accept(MediaTypes.`application/json`)
   )
 
   def isEnabled: Boolean = settings.enabled
 
   def listPublicKeys(): Future[Seq[SchnorrProposition]] = {
+    logger.info("Sending listKeys request to secure enclave")
     http.singleRequest(
       Post(settings.address + "/api/v1/listKeys")
         .withEntity(HttpEntity(ContentTypes.`application/json`, ListPublicKeysRequest(SCHNORR).asJson.noSpaces))
@@ -61,6 +61,7 @@ class SecureEnclaveApiClient(settings: RemoteKeysManagerSettings)(implicit syste
   }
 
   def signWithEnclave(message: Array[Byte], publicKey_index: (SchnorrProposition, Int)): Future[Option[CertificateSignatureInfo]] = {
+    logger.info("Sending createSignature request to secure enclave")
     http.singleRequest(buildSignMessageRequest(message, publicKey_index._1))
       .flatMap {
         case response@HttpResponse(StatusCodes.OK, _, _, _) =>

--- a/sdk/src/test/scala/io/horizen/api/http/client/SecureEnclaveApiClientTest.scala
+++ b/sdk/src/test/scala/io/horizen/api/http/client/SecureEnclaveApiClientTest.scala
@@ -150,7 +150,6 @@ class SecureEnclaveApiClientTest extends AnyWordSpec with Matchers with MockitoS
 
       when(serverMock.singleRequest(any(), any(), any(), any()))
         .thenAnswer(invocationArguments => {
-          assert(invocationArguments.getArgument(0).asInstanceOf[HttpRequest].getHeader("Content-Type").get().value() == "application/json")
           assert(invocationArguments.getArgument(0).asInstanceOf[HttpRequest].getHeader("Accept").get().value() == "application/json")
           Future.successful(HttpResponse(status = StatusCodes.OK, entity = response))
         })
@@ -169,7 +168,6 @@ class SecureEnclaveApiClientTest extends AnyWordSpec with Matchers with MockitoS
 
       when(serverMock.singleRequest(any(), any(), any(), any()))
         .thenAnswer(invocationArguments => {
-          assert(invocationArguments.getArgument(0).asInstanceOf[HttpRequest].getHeader("Content-Type").get().value() == "application/json")
           assert(invocationArguments.getArgument(0).asInstanceOf[HttpRequest].getHeader("Accept").get().value() == "application/json")
           Future.successful(HttpResponse(status = StatusCodes.OK, entity = response))
         })


### PR DESCRIPTION
## Description
This PR is addressing a bug introduced by [this PR](https://github.com/HorizenOfficial/Sidechains-SDK/pull/841) which is adding `Content-Type` and `Accept` HTTP headers to requests in the secure enclave.

After reading the docs, it turns out it's not advisable and is redundant to add Content-Type header manually, but it is inferred from the `contentType` field in `HttpEntity`. Adding it does not result in an error but in a warning message which is what this code is addressing [[source](https://doc.akka.io/docs/akka-http/current/common/http-model.html#:~:text=from%20%E2%80%9Cregular%E2%80%9D%20headers%3A-,Content%2DType,rendered%20onto%20the%20wire%20and%20trigger%20a%20warning%20being%20logged%20instead!,-Transfer%2DEncoding)]
The warning message is  `evmapp  | 2023-06-30T08:15:51.722386917Z [WARN] [06/30/2023 08:15:51.722] [2-Hop-akka.actor.default-dispatcher-35] [akka.actor.ActorSystemImpl(2-Hop)] Explicitly set HTTP header 'Content-Type: application/json' is ignored, illegal RawHeader`

By removing Content-Type header, it no longer appears in the `headers` field of the request, so it's not possible to test it with a unit test in `SecureEnclaveApiClientTest`. I tested it with python tests by asserting request headers in `secure_enclave_http_api_server.py` and running those tests that use `SecureEnclaveApiServer` to make sure it's not breaking anything.

## Jira Ticket
[SDK-1295](https://horizenlabs.atlassian.net/browse/SDK-1295?atlOrigin=eyJpIjoiOTM3N2QzZjI1OTFkNDk3MmEwZjQwYWZlNTIwNDkxZWQiLCJwIjoiaiJ9)

## Changes

- Content-Type header removed
- [INFO] level log message on every request to the remote signing service is added
- Assertion of Content-Type header in unit test removed, now it's in python test
- `secure_enclave_http_api_server.py` updated to assert request headers when user-agent is akka-http

## Breaking Changes
/

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly
- [ ] Breaking changes have been correctly tagged and notified
 
## Additional information


[SDK-1295]: https://horizenlabs.atlassian.net/browse/SDK-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ