### PR TITLE
As/zendao nsc dynamic abi

### DIFF
--- a/qa/sc_evm_mc_addr_ownership.py
+++ b/qa/sc_evm_mc_addr_ownership.py
@@ -100,11 +100,15 @@ def check_get_key_ownership(abiReturnValue, exp_dict):
     end_offset = start_data_offset + 64 # read 32 bytes
     list_size = decode(['uint32'], hex_str_to_bytes(abiReturnValue[start_data_offset:end_offset]))[0]
 
+    abi_list = abiReturnValue[end_offset:]
+    start_offset = 0
+
     sc_associations_dict = {}
     for i in range(list_size):
-        start_offset = end_offset
-        end_offset = start_offset + 192 # read (32 + 32 + 32) bytes
-        (address_pref, mca3, mca32) = decode(['address', 'bytes3', 'bytes32'], hex_str_to_bytes(abiReturnValue[start_offset:end_offset]))
+        # read offset of the i-dynamic struct
+        dyn_str_offset = (decode(['uint32'], hex_str_to_bytes(abi_list[start_offset:start_offset + 64]))[0])*2
+        start_offset = start_offset + 64
+        (address_pref, mc_addr) = decode(['address', 'string'], hex_str_to_bytes(abi_list[dyn_str_offset:dyn_str_offset+(5*64)]))
         sc_address_checksum_fmt = to_checksum_address(address_pref)
         print("sc addr=" + sc_address_checksum_fmt)
         if sc_associations_dict.get(sc_address_checksum_fmt) is not None:
@@ -112,7 +116,6 @@ def check_get_key_ownership(abiReturnValue, exp_dict):
         else:
             sc_associations_dict[sc_address_checksum_fmt] = []
             mc_addr_list = []
-        mc_addr = (mca3 + mca32).decode('utf-8')
         mc_addr_list.append(mc_addr)
         print("mc addr=" + mc_addr)
         sc_associations_dict[sc_address_checksum_fmt] = mc_addr_list
@@ -438,8 +441,15 @@ class SCEvmMcAddressOwnership(AccountChainSetup):
         abiReturnValue = remove_0x_prefix(response['result'])
         print(abiReturnValue)
         resultStringLength = len(abiReturnValue)
-        # we have an offset of 64 bytes and 12 records with 3 chunks of 32 bytes
-        exp_len = 32 + 32 + 12*(3*32)
+        # we have:
+        #  - an offset of 64 bytes (byte alignment and list size)
+        #  - 12 offsets (32 bytes) pointing to the dynamic structs
+        #  - 12 dynamic structs:
+        #     - offset (32 bytes) pointing to dynamic part (string)
+        #     - address (20 bytes padded to 32)
+        #     - string length (padded to 32)
+        #     - 35 string bytes (2 * 32 bytes chunks)
+        exp_len = (32 + 32) + 12 * 32 + 12*(5 * 32)
         assert_equal(resultStringLength, 2*exp_len)
 
         check_get_key_ownership(abiReturnValue, list_all_associations['keysOwnership'])
@@ -461,8 +471,15 @@ class SCEvmMcAddressOwnership(AccountChainSetup):
         abiReturnValue = remove_0x_prefix(response['result'])
         print(abiReturnValue)
         resultStringLength = len(abiReturnValue)
-        # we have an offset of 64 bytes and 11 records with 3 chunks of 32 bytes
-        exp_len = 32 + 32 + 11 * (3 * 32)
+        # we have:
+        #  - an offset of 64 bytes (byte alignment and list size)
+        #  - 11 offset (32 bytes) pointing to the dynamic structs
+        #  - 11 dynamic structs:
+        #     - offset (32 bytes) pointing to dynamic part (string)
+        #     - address (20 bytes padded to 32)
+        #     - string length (padded to 32)
+        #     - 35 string bytes (2 * 32 bytes chunks)
+        exp_len = (32 + 32) + 11 * 32 + 11*(5 * 32)
         assert_equal(resultStringLength, 2 * exp_len)
 
         check_get_key_ownership(abiReturnValue, list_associations_sc_address['keysOwnership'])

--- a/sdk/src/main/java/io/horizen/account/abi/ABIDecoder.java
+++ b/sdk/src/main/java/io/horizen/account/abi/ABIDecoder.java
@@ -2,7 +2,7 @@ package io.horizen.account.abi;
 
 import org.web3j.abi.DefaultFunctionReturnDecoder;
 import org.web3j.abi.TypeReference;
-import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.*;
 
 import java.util.List;
 
@@ -10,14 +10,46 @@ public interface ABIDecoder<T> {
 
     List<TypeReference<Type>> getListOfABIParamTypes();
 
-    default int getABIDataParamsLengthInBytes(){
-         return Type.MAX_BYTE_LENGTH * getListOfABIParamTypes().size();
+
+    default int getABIDataParamsStaticLengthInBytes(){
+        return Type.MAX_BYTE_LENGTH * getListOfABIParamTypes().size();
     }
 
-    default T decode(byte[] abiEncodedData) {
-        if (abiEncodedData.length != getABIDataParamsLengthInBytes()){
-            throw  new IllegalArgumentException("Wrong message data field length: " + abiEncodedData.length +
-                    ", expected: " + getABIDataParamsLengthInBytes());
+    // this must be overridden by decoders who want the dynamic abiEncodedData size to be checked, for instance when
+    // using an Utf8String of fixed size
+    int DO_NOT_CHECK_DYNAMIC_SIZE = -1;
+    default int getABIDataParamsDynamicLengthInBytes() { return DO_NOT_CHECK_DYNAMIC_SIZE;}
+
+    default boolean areAllArgumentsFixedLength() throws ClassNotFoundException {
+        List<TypeReference<Type>> paramsTypes = getListOfABIParamTypes();
+        for (TypeReference<Type> t : paramsTypes) {
+            Class<Type> classType = t.getClassType();
+            if (isDynamicType(classType)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    default boolean isDynamicType(Class<Type> classType) {
+        return DynamicArray.class.isAssignableFrom(classType) ||
+                DynamicBytes.class.isAssignableFrom(classType) ||
+                Utf8String.class.isAssignableFrom(classType);
+    }
+
+    default T decode(byte[] abiEncodedData) throws ClassNotFoundException {
+        if (areAllArgumentsFixedLength()) {
+            if(abiEncodedData.length != getABIDataParamsStaticLengthInBytes()) {
+                throw new IllegalArgumentException("Wrong message data field length: " + abiEncodedData.length +
+                        ", expected: " + getABIDataParamsStaticLengthInBytes());
+            }
+        } else {
+            int dynamicLength = getABIDataParamsDynamicLengthInBytes();
+            // check size of the dynamic struct if needed for this decoder
+            if (dynamicLength != DO_NOT_CHECK_DYNAMIC_SIZE && abiEncodedData.length != dynamicLength){
+                throw  new IllegalArgumentException("Wrong message data field length: " + abiEncodedData.length +
+                        ", expected: " + dynamicLength);
+            }
         }
         String inputParamsString = org.web3j.utils.Numeric.toHexString(abiEncodedData);
         DefaultFunctionReturnDecoder decoder = new DefaultFunctionReturnDecoder();

--- a/sdk/src/main/java/io/horizen/account/abi/ABIEncodable.java
+++ b/sdk/src/main/java/io/horizen/account/abi/ABIEncodable.java
@@ -1,6 +1,7 @@
 package io.horizen.account.abi;
 
 import org.web3j.abi.DefaultFunctionEncoder;
+import org.web3j.abi.TypeEncoder;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.utils.Numeric;
 
@@ -10,11 +11,12 @@ import java.util.List;
 public interface  ABIEncodable<T extends Type> {
 
     default byte[] encode() {
-        DefaultFunctionEncoder encoder = new DefaultFunctionEncoder();
         List<Type> listOfABIObjs = List.of(asABIType());
-        String encodedString = encoder.encodeParameters(listOfABIObjs);
-        return Numeric.hexStringToByteArray(encodedString);
-
+        StringBuilder sb = new StringBuilder();
+        for (Type t : listOfABIObjs) {
+            sb.append(TypeEncoder.encode(t));
+        }
+        return Numeric.hexStringToByteArray(sb.toString());
     }
 
     T asABIType();

--- a/sdk/src/main/scala/io/horizen/account/state/CertificateKeyRotationMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/CertificateKeyRotationMsgProcessor.scala
@@ -185,7 +185,7 @@ case class CertificateKeyRotationMsgProcessor(params: NetworkParams) extends Nat
   private def checkMessageValidity(msg: Message): Unit = {
     val msgValue = msg.getValue
 
-    if (msg.getData.length != METHOD_ID_LENGTH + SubmitKeyRotationCmdInputDecoder.getABIDataParamsLengthInBytes) {
+    if (msg.getData.length != METHOD_ID_LENGTH + SubmitKeyRotationCmdInputDecoder.getABIDataParamsStaticLengthInBytes) {
       throw new ExecutionRevertedException(s"Wrong message data field length: ${msg.getData.length}")
     } else if (msgValue.signum() != 0) {
       throw new ExecutionRevertedException(s"SubmitKeyRotation message value is non-zero: $msg")

--- a/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessor.scala
@@ -317,8 +317,8 @@ object McAddrOwnershipMsgProcessor {
   val LinkedListTipKey: Array[Byte] = Blake2b256.hash("OwnershipTip")
   val LinkedListNullValue: Array[Byte] = Blake2b256.hash("OwnershipNull")
 
-  val AddNewOwnershipCmd: String = getABIMethodId("sendKeysOwnership(bytes3,bytes32,bytes24,bytes32,bytes32)")
-  val RemoveOwnershipCmd: String = getABIMethodId("removeKeysOwnership(bytes3,bytes32)")
+  val AddNewOwnershipCmd: String = getABIMethodId("sendKeysOwnership(string, string)")
+  val RemoveOwnershipCmd: String = getABIMethodId("removeKeysOwnership(string)")
   val GetListOfAllOwnershipsCmd: String = getABIMethodId("getAllKeyOwnerships()")
   val GetListOfOwnershipsCmd: String = getABIMethodId("getKeyOwnerships(address)")
 

--- a/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorData.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorData.scala
@@ -2,21 +2,22 @@ package io.horizen.account.state
 
 import com.fasterxml.jackson.annotation.JsonView
 import io.horizen.account.abi.{ABIDecoder, ABIEncodable, ABIListEncoder, MsgProcessorInputDecoder}
-import io.horizen.account.state.McAddrOwnershipData.{decodeMcAddress, decodeMcSignature}
+import io.horizen.account.state.McAddrOwnershipData.decodeMcSignature
 import io.horizen.json.Views
 import io.horizen.evm.Address
 import io.horizen.utils.BytesUtils
 import org.web3j.abi.TypeReference
-import org.web3j.abi.datatypes.generated.{Bytes24, Bytes3, Bytes32}
-import org.web3j.abi.datatypes.{StaticStruct, Type, Address => AbiAddress}
+import org.web3j.abi.datatypes.generated.{Bytes24, Bytes32}
+import org.web3j.abi.datatypes.{DynamicStruct, StaticStruct, Type, Utf8String, Address => AbiAddress}
 import sparkz.core.serialization.{BytesSerializable, SparkzSerializer}
 import sparkz.util.serialization.{Reader, Writer}
+
 import java.nio.charset.StandardCharsets
 import java.util
 
 
 case class AddNewOwnershipCmdInput(mcTransparentAddress: String, mcSignature: String)
-  extends ABIEncodable[StaticStruct] {
+  extends ABIEncodable[DynamicStruct] {
 
   require(mcTransparentAddress.length == BytesUtils.HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH,
     s"Invalid mc address length: ${mcTransparentAddress.length}")
@@ -24,19 +25,16 @@ case class AddNewOwnershipCmdInput(mcTransparentAddress: String, mcSignature: St
   require(mcSignature.length == BytesUtils.HORIZEN_MC_SIGNATURE_BASE_64_LENGTH,
     s"Invalid mc signature length: ${mcSignature.length}")
 
-  override def asABIType(): StaticStruct = {
+  override def asABIType(): DynamicStruct = {
 
-
-    val mcAddrBytes = mcTransparentAddress.getBytes(StandardCharsets.UTF_8)
     val mcSignatureBytes = mcSignature.getBytes(StandardCharsets.UTF_8)
 
     val listOfParams: util.List[Type[_]] = util.Arrays.asList(
-      new Bytes3(util.Arrays.copyOfRange(mcAddrBytes, 0, 3)),
-      new Bytes32(util.Arrays.copyOfRange(mcAddrBytes, 3, BytesUtils.HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH)),
+      new Utf8String(mcTransparentAddress),
       new Bytes24(util.Arrays.copyOfRange(mcSignatureBytes, 0, 24)),
       new Bytes32(util.Arrays.copyOfRange(mcSignatureBytes, 24, 56)),
       new Bytes32(util.Arrays.copyOfRange(mcSignatureBytes, 56, BytesUtils.HORIZEN_MC_SIGNATURE_BASE_64_LENGTH)))
-    new StaticStruct(listOfParams)
+    new DynamicStruct(listOfParams)
 
   }
 
@@ -50,11 +48,16 @@ object AddNewOwnershipCmdInputDecoder
   extends ABIDecoder[AddNewOwnershipCmdInput]
     with MsgProcessorInputDecoder[AddNewOwnershipCmdInput] {
 
+  override def getABIDataParamsDynamicLengthInBytes: Int =
+    Type.MAX_BYTE_LENGTH + // offset of the dynamic utf8string (it is placed at the end of the struct)
+      3 * Type.MAX_BYTE_LENGTH + // three chiunks of 32 bytes for 88 bytes signature
+        Type.MAX_BYTE_LENGTH + // the 32 padded utf8String size
+          2 * Type.MAX_BYTE_LENGTH  // two chunks for the 35 bytes mc address string
+
   override val getListOfABIParamTypes: util.List[TypeReference[Type[_]]] = {
     org.web3j.abi.Utils.convert(util.Arrays.asList(
       // mc transparent address
-      new TypeReference[Bytes3]() {},
-      new TypeReference[Bytes32]() {},
+      new TypeReference[Utf8String]() {},
       // signature
       new TypeReference[Bytes24]() {},
       new TypeReference[Bytes32]() {},
@@ -63,15 +66,13 @@ object AddNewOwnershipCmdInputDecoder
 
 
   override def createType(listOfParams: util.List[Type[_]]): AddNewOwnershipCmdInput = {
-    val mcTransparentAddrress = decodeMcAddress(
-      listOfParams.get(0).asInstanceOf[Bytes3],
-      listOfParams.get(1).asInstanceOf[Bytes32])
+    val mcTransparentAddress = listOfParams.get(0).asInstanceOf[Utf8String].getValue
     val mcSignature = decodeMcSignature(
-      listOfParams.get(2).asInstanceOf[Bytes24],
-      listOfParams.get(3).asInstanceOf[Bytes32],
-      listOfParams.get(4).asInstanceOf[Bytes32])
+      listOfParams.get(1).asInstanceOf[Bytes24],
+      listOfParams.get(2).asInstanceOf[Bytes32],
+      listOfParams.get(3).asInstanceOf[Bytes32])
 
-    AddNewOwnershipCmdInput(mcTransparentAddrress, mcSignature)
+    AddNewOwnershipCmdInput(mcTransparentAddress, mcSignature)
   }
 }
 
@@ -93,10 +94,10 @@ case class GetOwnershipsCmdInput(scAddress: Address)
 }
 
 case class RemoveOwnershipCmdInput(mcTransparentAddressOpt: Option[String])
-  extends ABIEncodable[StaticStruct] {
+  extends ABIEncodable[DynamicStruct] {
 
 
-  override def asABIType(): StaticStruct = {
+  override def asABIType(): DynamicStruct = {
     val mcAddrBytes = mcTransparentAddressOpt match {
       case Some(mcTransparentAddress) =>
         require(mcTransparentAddress.length == BytesUtils.HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH,
@@ -107,10 +108,9 @@ case class RemoveOwnershipCmdInput(mcTransparentAddressOpt: Option[String])
     }
 
     val listOfParams: util.List[Type[_]] = util.Arrays.asList(
-      new Bytes3(util.Arrays.copyOfRange(mcAddrBytes, 0, 3)),
-      new Bytes32(util.Arrays.copyOfRange(mcAddrBytes, 3, BytesUtils.HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH))
+      new Utf8String(new String(mcAddrBytes, StandardCharsets.UTF_8))
     )
-    new StaticStruct(listOfParams)
+    new DynamicStruct(listOfParams)
   }
 
   override def toString: String = "%s(mcAddress: %s)"
@@ -139,17 +139,19 @@ object RemoveOwnershipCmdInputDecoder
   extends ABIDecoder[RemoveOwnershipCmdInput]
     with MsgProcessorInputDecoder[RemoveOwnershipCmdInput] {
 
+  override def getABIDataParamsDynamicLengthInBytes: Int =
+    2 * Type.MAX_BYTE_LENGTH + // Utf8String bytes32PaddedLength
+      2 * Type.MAX_BYTE_LENGTH // twochunks of 32 bytes needed for 35 bytes string
+
   override val getListOfABIParamTypes: util.List[TypeReference[Type[_]]] = {
     org.web3j.abi.Utils.convert(util.Arrays.asList(
       // mc transparent address
-      new TypeReference[Bytes3]() {},
-      new TypeReference[Bytes32]() {},
+      new TypeReference[Utf8String]() {}
     ))
   }
 
   override def createType(listOfParams: util.List[Type[_]]): RemoveOwnershipCmdInput = {
-    val mcTransparentAddress =
-      decodeMcAddress(listOfParams.get(0).asInstanceOf[Bytes3], listOfParams.get(1).asInstanceOf[Bytes32])
+    val mcTransparentAddress = listOfParams.get(0).asInstanceOf[Utf8String].getValue
 
     RemoveOwnershipCmdInput(Some(mcTransparentAddress))
   }
@@ -159,7 +161,7 @@ object RemoveOwnershipCmdInputDecoder
 
 @JsonView(Array(classOf[Views.Default]))
 case class McAddrOwnershipData(scAddress: String, mcTransparentAddress: String)
-  extends BytesSerializable  with ABIEncodable[StaticStruct] {
+  extends BytesSerializable  with ABIEncodable[DynamicStruct] {
 
   require(mcTransparentAddress.length == BytesUtils.HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH,
     s"Invalid mc address length: ${mcTransparentAddress.length}")
@@ -171,29 +173,24 @@ case class McAddrOwnershipData(scAddress: String, mcTransparentAddress: String)
   override def toString: String = "%s(scAddress: %s, mcAddress: %s)"
     .format(this.getClass.toString, scAddress, mcTransparentAddress)
 
-  override def asABIType(): StaticStruct = {
-    val mcAddrBytes = mcTransparentAddress.getBytes(StandardCharsets.UTF_8)
+  override def asABIType(): DynamicStruct = {
 
     val listOfParams: util.List[Type[_]] = util.Arrays.asList(
       new AbiAddress(scAddress),
-      new Bytes3(util.Arrays.copyOfRange(mcAddrBytes, 0, 3)),
-      new Bytes32(util.Arrays.copyOfRange(mcAddrBytes, 3, BytesUtils.HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH))
+      new Utf8String(mcTransparentAddress)
     )
-    new StaticStruct(listOfParams)
+    new DynamicStruct(listOfParams)
   }
 }
 
 object McAddrOwnershipData {
-  def decodeMcAddress(first3Bytes: Bytes3, last32Bytes: Bytes32): String = {
-    new String(first3Bytes.getValue ++ last32Bytes.getValue, StandardCharsets.UTF_8)
-  }
   def decodeMcSignature(first24Bytes: Bytes24, middle32Bytes: Bytes32, last32Bytes: Bytes32): String = {
     new String(first24Bytes.getValue ++ middle32Bytes.getValue ++ last32Bytes.getValue, StandardCharsets.UTF_8)
   }
 }
 
-object McAddrOwnershipDataListEncoder extends ABIListEncoder[McAddrOwnershipData, StaticStruct]{
-  override def getAbiClass: Class[StaticStruct] = classOf[StaticStruct]
+object McAddrOwnershipDataListEncoder extends ABIListEncoder[McAddrOwnershipData, DynamicStruct]{
+  override def getAbiClass: Class[DynamicStruct] = classOf[DynamicStruct]
 }
 
 object McAddrOwnershipDataSerializer extends SparkzSerializer[McAddrOwnershipData] {

--- a/sdk/src/main/scala/io/horizen/account/state/WithdrawalMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/WithdrawalMsgProcessor.scala
@@ -76,7 +76,7 @@ object WithdrawalMsgProcessor extends NativeSmartContractMsgProcessor with Withd
       throw new ExecutionRevertedException("Call value must be zero")
     }
 
-    if (msg.getData.length != METHOD_ID_LENGTH + GetListOfWithdrawalRequestsCmdInputDecoder.getABIDataParamsLengthInBytes)
+    if (msg.getData.length != METHOD_ID_LENGTH + GetListOfWithdrawalRequestsCmdInputDecoder.getABIDataParamsStaticLengthInBytes)
       throw new ExecutionRevertedException(s"Wrong message data field length: ${msg.getData.length}")
 
     val inputParams : GetListOfWithdrawalRequestsCmdInput = Try {
@@ -94,7 +94,7 @@ object WithdrawalMsgProcessor extends NativeSmartContractMsgProcessor with Withd
   private[horizen] def checkWithdrawalRequestValidity(msg: Message): Unit = {
     val withdrawalAmount = msg.getValue
 
-    if (msg.getData.length != METHOD_ID_LENGTH + AddWithdrawalRequestCmdInputDecoder.getABIDataParamsLengthInBytes) {
+    if (msg.getData.length != METHOD_ID_LENGTH + AddWithdrawalRequestCmdInputDecoder.getABIDataParamsStaticLengthInBytes) {
       throw new ExecutionRevertedException(s"Wrong message data field length: ${msg.getData.length}")
     } else if (!ZenWeiConverter.isValidZenAmount(withdrawalAmount)) {
       throw new ExecutionRevertedException(s"Withdrawal amount is not a valid Zen amount: $withdrawalAmount")

--- a/sdk/src/test/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorTest.scala
@@ -102,8 +102,8 @@ class McAddrOwnershipMsgProcessorTest
   @Test
   def testMethodIds(): Unit = {
     //The expected methodIds were calculated using this site: https://emn178.github.io/online-tools/keccak_256.html
-    assertEquals("Wrong MethodId for AddNewOwnershipCmd", "579465dd", McAddrOwnershipMsgProcessor.AddNewOwnershipCmd)
-    assertEquals("Wrong MethodId for RemoveOwnershipCmd", "9183c0da", McAddrOwnershipMsgProcessor.RemoveOwnershipCmd)
+    assertEquals("Wrong MethodId for AddNewOwnershipCmd", "f8429ba7", McAddrOwnershipMsgProcessor.AddNewOwnershipCmd)
+    assertEquals("Wrong MethodId for RemoveOwnershipCmd", "edfe0ba2", McAddrOwnershipMsgProcessor.RemoveOwnershipCmd)
     assertEquals("Wrong MethodId for GetListOfAllOwnershipsCmd", "8ef05457", McAddrOwnershipMsgProcessor.GetListOfAllOwnershipsCmd)
     assertEquals("Wrong MethodId for GetListOfOwnershipsCmd", "169e2d15", McAddrOwnershipMsgProcessor.GetListOfOwnershipsCmd)
   }


### PR DESCRIPTION
## Description
Using Utf8String for mc_signature / mc address in AddNewOwnershipCmdInput instead of splitting the correspondent strings into Byte chunks; changed abi signature for changed methods

