### PR TITLE
Increasing timeout for bestBlockReferenceInfo api test

### DIFF
--- a/sdk/src/test/scala/io/horizen/api/http/route/MainchainBlockApiRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/api/http/route/MainchainBlockApiRouteTest.scala
@@ -8,9 +8,11 @@ import io.horizen.chain.MainchainBlockReferenceInfo
 import io.horizen.json.SerializationUtil
 import io.horizen.utils.BytesUtils
 import org.junit.Assert._
+import org.mockito.Mockito.when
 
 import java.util.{Optional => JOptional}
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.DurationInt
 
 class MainchainBlockApiRouteTest extends SidechainApiRouteTest {
 
@@ -45,6 +47,7 @@ class MainchainBlockApiRouteTest extends SidechainApiRouteTest {
     }
 
     "reply at /bestBlockReferenceInfo" in {
+      when(mockedRESTSettings.timeout).thenReturn(5.seconds)
       Post(basePath + "bestBlockReferenceInfo") ~> mainchainBlockApiRoute ~> check {
         status.intValue() shouldBe StatusCodes.OK.intValue
         responseEntity.getContentType() shouldEqual ContentTypes.`application/json`


### PR DESCRIPTION
## Description
Increasing the timout for bestBlockReferenceInfo api test

## Changes
Added `when(mockedRESTSettings.timeout).thenReturn(5.seconds)` to increase test time

## Breaking Changes
None

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
- [x] Breaking changes have been correctly tagged and notified
