### PR TITLE
Updated list of native smart contracts addresses

### DIFF
--- a/sdk/src/main/java/io/horizen/account/state/EvmMessageProcessor.java
+++ b/sdk/src/main/java/io/horizen/account/state/EvmMessageProcessor.java
@@ -1,6 +1,5 @@
 package io.horizen.account.state;
 
-import io.horizen.account.utils.WellKnownAddresses;
 import io.horizen.evm.*;
 import io.horizen.utils.BytesUtils;
 import scala.Array;
@@ -10,10 +9,14 @@ import scala.compat.java8.OptionConverters;
 import java.math.BigInteger;
 
 public class EvmMessageProcessor implements MessageProcessor {
-    protected Address[] nativeContractAddresses = new Address[] {
-        WellKnownAddresses.WITHDRAWAL_REQ_SMART_CONTRACT_ADDRESS(),
-        WellKnownAddresses.FORGER_STAKE_SMART_CONTRACT_ADDRESS(),
-    };
+    protected Address[] nativeContractAddresses = null;
+
+    protected Address[] getNativeContractAddresses(BaseAccountStateView view) {
+        if (nativeContractAddresses == null)  {
+            nativeContractAddresses = view.getNativeSmartContractAddressList();
+        }
+        return nativeContractAddresses;
+    }
 
     @Override
     public boolean customTracing() {
@@ -62,7 +65,7 @@ public class EvmMessageProcessor implements MessageProcessor {
             var nativeContractProxy = new NativeContractProxy(context)
         ) {
             evmContext.blockHashCallback = blockHashGetter;
-            evmContext.externalContracts = nativeContractAddresses;
+            evmContext.externalContracts = getNativeContractAddresses(view);
             evmContext.externalCallback = nativeContractProxy;
             evmContext.tracer = block.getTracer().orElse(null);
             // Minus one because the depth is incremented for the call to the EvmMessageProcessor itself.

--- a/sdk/src/main/java/io/horizen/account/state/EvmMessageProcessor.java
+++ b/sdk/src/main/java/io/horizen/account/state/EvmMessageProcessor.java
@@ -9,12 +9,13 @@ import scala.compat.java8.OptionConverters;
 import java.math.BigInteger;
 
 public class EvmMessageProcessor implements MessageProcessor {
-    protected Address[] nativeContractAddresses = null;
+    private Address[] nativeContractAddresses = null;
 
-    protected Address[] getNativeContractAddresses(BaseAccountStateView view) {
+    private Address[] getNativeContractAddresses(BaseAccountStateView view) {
         if (nativeContractAddresses == null)  {
             nativeContractAddresses = view.getNativeSmartContractAddressList();
         }
+        assert nativeContractAddresses != null : "List of native smart contract addresses cannot be null";
         return nativeContractAddresses;
     }
 

--- a/sdk/src/main/scala/io/horizen/account/state/BaseAccountStateView.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/BaseAccountStateView.scala
@@ -23,4 +23,6 @@ trait BaseAccountStateView extends AccountStateReader {
   def addLog(log: EthereumConsensusDataLog): Unit
 
   def getGasTrackedView(gas: GasPool): BaseAccountStateView
+
+  def getNativeSmartContractAddressList(): Array[Address]
 }

--- a/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateView.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateView.scala
@@ -361,4 +361,7 @@ class StateDbAccountStateView(
    * Disable write protection.
    */
   def disableWriteProtection(): Unit = readOnly = false
+
+  override def getNativeSmartContractAddressList(): Array[Address] = messageProcessors.collect{
+    case msgProcessor: NativeSmartContractMsgProcessor => msgProcessor.contractAddress}.toArray
 }

--- a/sdk/src/test/scala/io/horizen/account/state/ContractInteropTestBase.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/ContractInteropTestBase.scala
@@ -34,10 +34,7 @@ abstract class ContractInteropTestBase extends MessageProcessorFixture {
   def setup(): Unit = {
     processors = Seq(
       processorToTest,
-      new EvmMessageProcessor() {
-        // pass address for the EVM to recognize native contract
-        nativeContractAddresses = Array[Address](processorToTest.contractAddress)
-      }
+      new EvmMessageProcessor()
     )
     db = new MemoryDatabase()
     stateView = new AccountStateView(metadataStorageView, new StateDB(db, Hash.ZERO), processors)


### PR DESCRIPTION
## Description
Modified the list of native smart contracts addresses used for EVM callbacks. Now it is created starting from the list of message processors.

## Jira Ticket
[SDK-1349](<(https://horizenlabs.atlassian.net/browse/SDK-1349?atlOrigin=eyJpIjoiNzc1MjlmN2JiNTU5NDhmZTk0YjFjOTMxZjZjODhmYTUiLCJwIjoiaiJ9)>)

## Changes
Added getNativeSmartContractAddressList method to BaseAccountStateView trait
Modified EvmMessageProcessor so nativeContractAddresses is initialized calling getNativeSmartContractAddressList on BaseAccountStateView object

## Breaking Changes

## Checks
- [X ] Project Builds
- [ X] Project passes tests and checks
- [ ] Updated documentation accordingly
- [ ] Breaking changes have been correctly tagged and notified
 
## Additional information


[SDK-1349]: https://horizenlabs.atlassian.net/browse/SDK-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ