### PR TITLE
Optimization of lookup strategy in modifiersCache

### DIFF
--- a/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
@@ -49,7 +49,7 @@ abstract class AbstractSidechainNodeViewHolder[
    * Cache for modifiers. If modifiers are coming out-of-order, they are to be stored in this cache.
    */
   protected override lazy val modifiersCache: ModifiersCache[PMOD, HIS] =
-    new DefaultModifiersCache[PMOD, HIS](sparksSettings.network.maxModifiersCacheSize)
+    new ParentIdModifiersCache[PMOD, HIS](sparksSettings.network.maxModifiersCacheSize)
 
 
   case class SidechainNodeUpdateInformation(history: HIS,
@@ -168,7 +168,7 @@ abstract class AbstractSidechainNodeViewHolder[
    */
   override def processRemoteModifiers: Receive = {
     case sparkz.core.NodeViewHolder.ReceivableMessages.ModifiersFromRemote(mods: Seq[PMOD]) =>
-      mods.foreach(m => modifiersCache.put(m.id, m))
+      mods.foreach(m => modifiersCache.put(m.parentId, m))
 
       log.debug(s"Cache size before: ${modifiersCache.size}")
 

--- a/sdk/src/main/scala/io/horizen/ParentIdModifiersCache.scala
+++ b/sdk/src/main/scala/io/horizen/ParentIdModifiersCache.scala
@@ -1,0 +1,42 @@
+package io.horizen
+
+import sparkz.core.consensus.HistoryReader
+import sparkz.core.validation.RecoverableModifierError
+import sparkz.core.{DefaultModifiersCache, PersistentNodeViewModifier}
+
+import scala.collection.mutable
+import scala.util.{Failure, Success}
+
+class ParentIdModifiersCache[PMOD <: PersistentNodeViewModifier, HR <: HistoryReader[PMOD, _]](override val maxSize: Int)
+  extends DefaultModifiersCache[PMOD, HR](maxSize) {
+
+  override protected val cache: mutable.Map[K, V] = mutable.LinkedHashMap[K, V]()
+
+  override def popCandidate(history: HR): Option[V] = {
+    // get bestBlockId from history and check if there is a modifier with this parentId in cache
+    val maybeParentId: Option[K] = history.openSurfaceIds().collectFirst { case id if contains(id) => id }
+
+    val maybeK = maybeParentId.filter { parentId =>
+      // current tip in cache, check the modifier. (now this just checks that parentId is in history)
+      val modifier = cache(parentId)
+      history.applicableTry(modifier) match {
+        case Failure(e) if e.isInstanceOf[RecoverableModifierError] =>
+          // do nothing - modifier may be applied in future
+          false
+        case Failure(e) =>
+          // non-recoverable error - remove modifier from cache
+          log.warn(s"Modifier ${modifier.encodedId} became permanently invalid and will be removed from cache", e)
+          remove(modifier.parentId)
+          false
+        case Success(_) =>
+          true
+      }
+    }
+    val candidateModifierKey = maybeK.orElse {
+      // current tip not in cache, maybe fork occurred, scan all modifiers
+      findCandidateKey(history)
+    }
+
+    candidateModifierKey.flatMap(k => remove(k))
+  }
+}

--- a/sdk/src/test/scala/io/horizen/ParentIdModifiersCacheSpecification.scala
+++ b/sdk/src/test/scala/io/horizen/ParentIdModifiersCacheSpecification.scala
@@ -1,0 +1,86 @@
+package io.horizen
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.{clearInvocations, times, verify, when}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import sparkz.core.consensus.History.ModifierIds
+import sparkz.core.consensus.{HistoryReader, SyncInfo}
+import sparkz.core.serialization.SparkzSerializer
+import sparkz.core.validation.RecoverableModifierError
+import sparkz.core.{ModifierTypeId, PersistentNodeViewModifier, bytesToId}
+import sparkz.crypto.hash.Blake2b256
+
+import scala.util.{Failure, Random, Success}
+
+//noinspection NotImplementedCode
+class ParentIdModifiersCacheSpecification extends AnyPropSpec
+  with Matchers {
+
+  private class FakeModifier(val idValue: sparkz.util.ModifierId, val parentIdValue: sparkz.util.ModifierId) extends PersistentNodeViewModifier {
+    override def parentId: sparkz.util.ModifierId = parentIdValue
+
+    override val modifierTypeId: ModifierTypeId = ModifierTypeId @@ (0: Byte)
+
+    override def id: sparkz.util.ModifierId = idValue
+
+    override type M = this.type
+
+    override def serializer: SparkzSerializer[FakeModifier.this.type] = ???
+  }
+
+  private class FakeSyncInfo extends SyncInfo {
+    override def startingPoints: ModifierIds = _
+
+    override type M = this.type
+
+    override def serializer: SparkzSerializer[FakeSyncInfo.this.type] = ???
+  }
+
+  property("cache should use parentId when possible and preserve order of insertion") {
+    val historyReader = Mockito.mock(classOf[HistoryReader[FakeModifier, FakeSyncInfo]])
+    val limit = 5
+    val random = Random
+
+    val k1 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k2 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k3 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k4 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k5 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k6 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val v3 = new FakeModifier(k4, k3)
+    val v4 = new FakeModifier(k5, k4)
+
+    when(historyReader.openSurfaceIds()).thenReturn(Seq(k4))
+    when(historyReader.applicableTry(any())).thenAnswer(_ => Failure(new RecoverableModifierError("Parent block IS NOT in history yet")))
+    when(historyReader.applicableTry(v3)).thenAnswer(_ => Success(Unit))
+    when(historyReader.applicableTry(v4)).thenAnswer(_ => Success(Unit))
+
+    val cache = new ParentIdModifiersCache[FakeModifier, HistoryReader[FakeModifier, FakeSyncInfo]](limit)
+
+    cache.put(k1, new FakeModifier(k2, k1))
+    cache.put(k2, new FakeModifier(k3, k2))
+    cache.put(k3, v3)
+    cache.put(k4, v4)
+    cache.put(k5, new FakeModifier(k6, k5))
+
+    // pop first candidate that can be found by parentId
+    cache.size shouldBe 5
+    cache.popCandidate(historyReader) shouldBe Some(v4)
+    verify(historyReader, times(1)).applicableTry(any())
+
+    // pop second candidate that is chosen by iterating over all modifiers in the order they were inserted
+    clearInvocations(historyReader)
+    cache.popCandidate(historyReader) shouldBe Some(v3)
+    verify(historyReader, times(3)).applicableTry(any())
+    cache.size shouldBe 3
+
+    // try pop third candidate - fail because no suitable parentId found in the cache
+    clearInvocations(historyReader)
+    cache.popCandidate(historyReader) shouldBe None
+    verify(historyReader, times(3)).applicableTry(any())
+    cache.size shouldBe 3
+  }
+
+}

--- a/sdk/src/test/scala/io/horizen/ParentIdModifiersCacheSpecification.scala
+++ b/sdk/src/test/scala/io/horizen/ParentIdModifiersCacheSpecification.scala
@@ -31,7 +31,7 @@ class ParentIdModifiersCacheSpecification extends AnyPropSpec
   }
 
   private class FakeSyncInfo extends SyncInfo {
-    override def startingPoints: ModifierIds = _
+    override def startingPoints: ModifierIds = ???
 
     override type M = this.type
 


### PR DESCRIPTION
## Description
The default lookup strategy is simple scan - check every modifier in the cache one by one to try and find one that 

## Jira Ticket
[SDK-1263](https://horizenlabs.atlassian.net/browse/SDK-1263)

## Changes
This PR introduces 2 changes:
1. Make modifiersCache inner structure a LinkedHashMap - this preserves ordering of insertion, so that when we traverse the modifiers to find an applicable one, we will always traverse in the order of insertion.
2. Store modifiers in the map using parentId

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
- [x] Breaking changes have been correctly tagged and notified
 
## Additional information


[SDK-1263]: https://horizenlabs.atlassian.net/browse/SDK-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ