### PR TITLE
SDK-1265: before searching in the storage, look up in active chain if…

### DIFF
--- a/sdk/src/main/scala/io/horizen/history/AbstractHistory.scala
+++ b/sdk/src/main/scala/io/horizen/history/AbstractHistory.scala
@@ -260,7 +260,7 @@ abstract class AbstractHistory[
 
   override def isEmpty: Boolean = height <= 0
 
-  override def contains(id: ModifierId): Boolean = storage.blockInfoOptionById(id).isDefined
+  override def contains(id: ModifierId): Boolean = storage.contains(id)
 
   override def applicableTry(block: PM): Try[Unit] = {
     if (!contains(block.parentId)) {

--- a/sdk/src/main/scala/io/horizen/storage/AbstractHistoryStorage.scala
+++ b/sdk/src/main/scala/io/horizen/storage/AbstractHistoryStorage.scala
@@ -120,6 +120,10 @@ abstract class AbstractHistoryStorage[
     activeChain.blockInfoById(blockId).orElse(blockInfoOptionByIdFromStorage(blockId))
   }
 
+  def contains(blockId: ModifierId): Boolean = {
+    isInActiveChain(blockId) || blockInfoOptionByIdFromStorage(blockId).nonEmpty
+  }
+
   private def blockInfoOptionByIdFromStorage(blockId: ModifierId): Option[SidechainBlockInfo] = {
     storage.get(blockInfoKey(blockId)).asScala.flatMap(baw => SidechainBlockInfoSerializer.parseBytesTry(baw.data).toOption)
   }


### PR DESCRIPTION
## Description
AbstractHistory.contains(modifierId) actually fetches the modifier id instead of just checking if it exists: this PR improves the performance by first checking if it exists in the `activeChain` and then try to fetch it from the `storage`.

## Jira Ticket
[SDK-1265](https://horizenlabs.atlassian.net/browse/SDK-1265)

## Changes
`AbstractHistory.contains(modifiersId)` -> `activeChain.contains(modifersId)`
  -> yes: `return true`
  -> no: `stoget.get(modiferId)` -> `isNonEmpty()`

## Breaking Changes
No breaking changes

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
- [x] Breaking changes have been correctly tagged and notified
 
## Additional information
Note: unfortunately the storage where this function is supposed to search does not expose a lookup function, just getters. This implementation optimizes the search time if the modifier id is in the `activeChain`, otherwise, the time remains as before. If we want to avoid also the `storage.get(modifierId)` we should introduce a new data structure where to look for.


[SDK-1265]: https://horizenlabs.atlassian.net/browse/SDK-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ