### PR TITLE
SDK-1466: add test in ConsensusValidatorOmmersTest to introduce a cha…

### DIFF
--- a/sdk/src/test/scala/io/horizen/history/validation/ConsensusValidatorOmmersTest.scala
+++ b/sdk/src/test/scala/io/horizen/history/validation/ConsensusValidatorOmmersTest.scala
@@ -245,7 +245,7 @@ class ConsensusValidatorOmmersTest
 
 
     // Mock history
-    var slotsInEpoch: Int = 6
+    val slotsInEpoch: Int = 6
     var history = mockHistory(slotsInEpoch)
 
     val previousEpochNumber: ConsensusEpochNumber = ConsensusEpochNumber @@ 2
@@ -319,7 +319,6 @@ class ConsensusValidatorOmmersTest
        Ommers 2/3;2/4 is in `active` slots for nonce calculation, so for block 3/6 and ommer 3/5 nonce will be different.
      */
 
-    slotsInEpoch = 6
     history = mockHistory(slotsInEpoch)
 
     val anotherOmmers: Seq[Ommer[SidechainBlockHeader]] = Seq(
@@ -366,6 +365,168 @@ class ConsensusValidatorOmmersTest
 
     Try {
       switchedEpochConsensusValidator.verifyOmmers(verifiedBlock, currentFullConsensusEpochInfo, Some(previousFullConsensusEpochInfo), parentId, parentInfo, history, Seq())
+    } match {
+      case Success(_) =>
+      case Failure(e) => throw e // jFail(s"Block with ommers from both the same and previous epoch expected to be Valid, instead exception: ${e.getMessage}")
+    }
+  }
+
+  @Test
+  def switchingEpochOmmersValidationWithConsensusParamsForkActivation(): Unit = {
+    // Mock Consensus epoch info data
+    val postForkEpochNonceBytes: Array[Byte] = new Array[Byte](8)
+    scala.util.Random.nextBytes(postForkEpochNonceBytes)
+    val postForkFullConsensusEpochInfo = FullConsensusEpochInfo(mock[StakeConsensusEpochInfo],
+      NonceConsensusEpochInfo(byteArrayToConsensusNonce(postForkEpochNonceBytes)))
+
+    val preForkEpochNonceBytes: Array[Byte] = new Array[Byte](8)
+    scala.util.Random.nextBytes(preForkEpochNonceBytes)
+    val preForkFullConsensusEpochInfo = FullConsensusEpochInfo(mock[StakeConsensusEpochInfo],
+      NonceConsensusEpochInfo(byteArrayToConsensusNonce(preForkEpochNonceBytes)))
+
+    val switchedOmmersPostForkEpochNonceBytes: Array[Byte] = new Array[Byte](8)
+    scala.util.Random.nextBytes(switchedOmmersPostForkEpochNonceBytes)
+    val switchedOmmersFullConsensusEpochInfo = FullConsensusEpochInfo(postForkFullConsensusEpochInfo.stakeConsensusEpochInfo,
+      NonceConsensusEpochInfo(byteArrayToConsensusNonce(switchedOmmersPostForkEpochNonceBytes)))
+
+
+    /* Test 1: Valid Ommers in correct order from the previous and current epoch as VerifiedBlock
+      Notation <epoch_number>/<slot_number>
+      Slots in epoch:   6
+      Block slots number:   2/2 - 3/6
+                                   |
+      Ommers slots:   [2/5    ,   3/1   ,   3/5]
+      Ommer 2/5 is in `quite` slots, so for 3/6 block and 3/1 ommer nonce will be the same.
+    */
+
+
+    // Mock history
+    val preForkEpochNumber: ConsensusEpochNumber = ConsensusEpochNumber @@ 2
+    val postForkEpochNumber: ConsensusEpochNumber = ConsensusEpochNumber @@ 3
+
+    val slotsInEpoch: Int = 6
+    val slotsInEpochAfterFork: Int = 50
+    val consensusParamsForkSeq = Seq(
+      ConsensusParamsForkInfo(0, new ConsensusParamsFork(slotsInEpoch)),
+      ConsensusParamsForkInfo(postForkEpochNumber, new ConsensusParamsFork(slotsInEpochAfterFork))
+    )
+
+    var history = mockHistoryWithConsensusParameterForks(consensusParamsForkSeq)
+
+    // Mock ommers
+    val ommers: Seq[Ommer[SidechainBlockHeader]] = Seq(
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, preForkEpochNumber, ConsensusSlotNumber @@ 5)), // quite slot - no impact on nonce calculation
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 1)),
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 5))
+    )
+
+    // Set initialNonceData (reverse order expected)
+    val expectedInitialNonceData: Seq[(VrfOutput, ConsensusSlotNumber)] = Seq(
+      (generateDummyVrfOutput(ommers.head.header), ConsensusSlotNumber @@ 5)
+    )
+
+    // Mock block with ommers
+    val parentId: ModifierId = getRandomBlockId()
+    val parentInfo: SidechainBlockInfo = mock[SidechainBlockInfo]
+    val verifiedBlockTimestamp = TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 6)
+    val verifiedBlock: SidechainBlock = mock[SidechainBlock]
+    val header = mock[SidechainBlockHeader]
+    Mockito.when(header.timestamp).thenReturn(verifiedBlockTimestamp)
+    Mockito.when(verifiedBlock.header).thenReturn(header)
+    Mockito.when(verifiedBlock.ommers).thenReturn(ommers)
+
+
+    Mockito.when(history.calculateNonceForNonGenesisEpoch(
+      ArgumentMatchers.any[ModifierId],
+      ArgumentMatchers.any[SidechainBlockInfo],
+      ArgumentMatchers.any[Seq[(VrfOutput, ConsensusSlotNumber)]])).thenAnswer(answer => {
+      val lastBlockIdInEpoch: ModifierId = answer.getArgument(0)
+      val lastBlockInfoInEpoch: SidechainBlockInfo = answer.getArgument(1)
+      val initialNonceData: Seq[(VrfOutput, ConsensusSlotNumber)] = answer.getArgument(2)
+
+      assertEquals("On calculate nonce: lastBlockIdInEpoch is different", parentId, lastBlockIdInEpoch)
+      assertEquals("On calculate nonce: lastBlockInfoInEpoch is different", parentInfo, lastBlockInfoInEpoch)
+      assertEquals("On calculate nonce: initialNonceData is different", expectedInitialNonceData, initialNonceData)
+
+      // Return nonce same as current epoch nonce
+      postForkFullConsensusEpochInfo.nonceConsensusEpochInfo
+    })
+
+    var switchedEpochConsensusValidator = new BoxConsensusValidator(timeProvider) {
+      override private[horizen] def verifyForgingStakeInfo(header: SidechainBlockHeaderBase, stakeConsensusEpochInfo: StakeConsensusEpochInfo, vrfOutput: VrfOutput, percentageForkApplied: Boolean, activeSlotCoefficient: Double): Unit = {
+        val epochAndSlot = TimeToEpochUtils.timestampToEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, header.timestamp)
+        epochAndSlot.epochNumber match {
+          case `preForkEpochNumber` => assertEquals("Different stakeConsensusEpochInfo expected", preForkFullConsensusEpochInfo.stakeConsensusEpochInfo, stakeConsensusEpochInfo)
+          case `postForkEpochNumber` => assertEquals("Different stakeConsensusEpochInfo expected", postForkFullConsensusEpochInfo.stakeConsensusEpochInfo, stakeConsensusEpochInfo)
+          case epoch => jFail(s"Unknown epoch number: $epoch")
+        }
+        assertEquals("Different vrfOutput expected", generateDummyVrfOutput(header), vrfOutput)
+      }
+    }
+
+    Try {
+      switchedEpochConsensusValidator.verifyOmmers(verifiedBlock, postForkFullConsensusEpochInfo, Some(preForkFullConsensusEpochInfo), parentId, parentInfo, history, Seq())
+    } match {
+      case Success(_) =>
+      case Failure(e) => throw e // jFail(s"Block with ommers from both the same and previous epoch expected to be Valid, instead exception: ${e.getMessage}")
+    }
+
+
+    /* Test 2: Valid Ommers in correct order from the previous and current epoch as VerifiedBlock
+       Notation <epoch_number>/<slot_number>
+       Slots in epoch:   6
+       Block slots number:   2/2 - 3/6
+                                    |
+       Ommers slots:   [2/3    ,   2/4   ,   3/15]
+       Ommers 2/3;2/4 is in `active` slots for nonce calculation, so for block 3/6 and ommer 3/15 nonce will be different.
+     */
+
+    history = mockHistoryWithConsensusParameterForks(consensusParamsForkSeq)
+
+    val anotherOmmers: Seq[Ommer[SidechainBlockHeader]] = Seq(
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, preForkEpochNumber, ConsensusSlotNumber @@ 3)), // active slot - has impact on nonce calculation
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, preForkEpochNumber, ConsensusSlotNumber @@ 4)), // active slot - has impact on nonce calculation
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 15))
+    )
+
+    // Set initialNonceData (reverse order expected)
+    val anotherExpectedInitialNonceData: Seq[(VrfOutput, ConsensusSlotNumber)] = Seq(
+      (generateDummyVrfOutput(anotherOmmers(1).header), ConsensusSlotNumber @@ 4),
+      (generateDummyVrfOutput(anotherOmmers(0).header), ConsensusSlotNumber @@ 3)
+    )
+
+    Mockito.when(verifiedBlock.ommers).thenReturn(anotherOmmers)
+
+    Mockito.when(history.calculateNonceForNonGenesisEpoch(
+      ArgumentMatchers.any[ModifierId],
+      ArgumentMatchers.any[SidechainBlockInfo],
+      ArgumentMatchers.any[Seq[(VrfOutput, ConsensusSlotNumber)]])).thenAnswer(answer => {
+      val lastBlockIdInEpoch: ModifierId = answer.getArgument(0)
+      val lastBlockInfoInEpoch: SidechainBlockInfo = answer.getArgument(1)
+      val initialNonceData: Seq[(VrfOutput, ConsensusSlotNumber)] = answer.getArgument(2)
+
+      assertEquals("On calculate nonce: lastBlockIdInEpoch is different", parentId, lastBlockIdInEpoch)
+      assertEquals("On calculate nonce: lastBlockInfoInEpoch is different", parentInfo, lastBlockInfoInEpoch)
+      assertEquals("On calculate nonce: initialNonceData is different", anotherExpectedInitialNonceData, initialNonceData)
+
+      // Return nonce same different from current epoch nonce
+      switchedOmmersFullConsensusEpochInfo.nonceConsensusEpochInfo
+    })
+
+    switchedEpochConsensusValidator = new BoxConsensusValidator(timeProvider) {
+      override private[horizen] def verifyForgingStakeInfo(header: SidechainBlockHeaderBase, stakeConsensusEpochInfo: StakeConsensusEpochInfo, vrfOutput: VrfOutput, percentageForkApplied: Boolean, activeSlotCoefficient: Double): Unit = {
+        val epochAndSlot = TimeToEpochUtils.timestampToEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, header.timestamp)
+        epochAndSlot.epochNumber match {
+          case `preForkEpochNumber` => assertEquals("Different stakeConsensusEpochInfo expected", preForkFullConsensusEpochInfo.stakeConsensusEpochInfo, stakeConsensusEpochInfo)
+          case `postForkEpochNumber` => assertEquals("Different stakeConsensusEpochInfo expected", switchedOmmersFullConsensusEpochInfo.stakeConsensusEpochInfo, stakeConsensusEpochInfo)
+          case epoch => jFail(s"Unknown epoch number: $epoch")
+        }
+        assertEquals("Different vrfOutput expected", generateDummyVrfOutput(header), vrfOutput)
+      }
+    }
+
+    Try {
+      switchedEpochConsensusValidator.verifyOmmers(verifiedBlock, postForkFullConsensusEpochInfo, Some(preForkFullConsensusEpochInfo), parentId, parentInfo, history, Seq())
     } match {
       case Success(_) =>
       case Failure(e) => throw e // jFail(s"Block with ommers from both the same and previous epoch expected to be Valid, instead exception: ${e.getMessage}")
@@ -488,6 +649,129 @@ class ConsensusValidatorOmmersTest
 
   }
 
+  @Test
+  def switchingEpochOmmersWithSubOmmersValidationAfterConsensusParamsFork(): Unit = {
+    // Mock Consensus epoch info data
+    val postForkEpochNonceBytes: Array[Byte] = new Array[Byte](8)
+    scala.util.Random.nextBytes(postForkEpochNonceBytes)
+    val postForkFullConsensusEpochInfo = FullConsensusEpochInfo(mock[StakeConsensusEpochInfo],
+      NonceConsensusEpochInfo(byteArrayToConsensusNonce(postForkEpochNonceBytes)))
+
+    val preForkEpochNonceBytes: Array[Byte] = new Array[Byte](8)
+    scala.util.Random.nextBytes(preForkEpochNonceBytes)
+    val preForkFullConsensusEpochInfo = FullConsensusEpochInfo(mock[StakeConsensusEpochInfo],
+      NonceConsensusEpochInfo(byteArrayToConsensusNonce(preForkEpochNonceBytes)))
+
+    val switchedOmmersCurrentEpochNonceBytes: Array[Byte] = new Array[Byte](8)
+    scala.util.Random.nextBytes(switchedOmmersCurrentEpochNonceBytes)
+    val switchedOmmersFullConsensusEpochInfo = FullConsensusEpochInfo(postForkFullConsensusEpochInfo.stakeConsensusEpochInfo,
+      NonceConsensusEpochInfo(byteArrayToConsensusNonce(switchedOmmersCurrentEpochNonceBytes)))
+
+
+    /* Test 1: Valid Ommers with subommers in correct order from the previous and current epoch as VerifiedBlock
+       Notation <epoch_number>/<slot_number>
+       Slots in epoch:   6
+       Block slots number:   2/2 - 3/5
+                                    |
+       Ommers slots:   [2/4    ,   2/6   ,   3/4]
+                         |          |         |
+       Subommers slots:[2/3]      [2/5]  [3/2 , 3/3]
+                                           |
+       Subommers slots:                  [3/1]
+       Ommer 2/3 is in `active` slots for nonce calculation, so for block 3/5 and ommers 3/1; 3/2; 3/3; 3/4 nonce will be different.
+     */
+
+
+    // Mock history
+
+    val preForkEpochNumber: ConsensusEpochNumber = ConsensusEpochNumber @@ 2
+    val postForkEpochNumber: ConsensusEpochNumber = ConsensusEpochNumber @@ 3
+
+    val slotsInEpoch: Int = 6
+    val slotsInEpochAfterFork: Int = 50
+    val consensusParamsForkSeq = Seq(
+      ConsensusParamsForkInfo(0, new ConsensusParamsFork(slotsInEpoch)),
+      ConsensusParamsForkInfo(postForkEpochNumber, new ConsensusParamsFork(slotsInEpochAfterFork))
+    )
+
+    val history = mockHistoryWithConsensusParameterForks(consensusParamsForkSeq)
+
+    // Mock ommers
+    val ommers: Seq[Ommer[SidechainBlockHeader]] = Seq(
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, preForkEpochNumber, ConsensusSlotNumber @@ 4), // active slot - has impact on nonce calculation
+        Seq(
+          getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, preForkEpochNumber, ConsensusSlotNumber @@ 3))
+        )),
+
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, preForkEpochNumber, ConsensusSlotNumber @@ 6), // quite slot - no impact on nonce calculation
+        Seq(
+          getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, preForkEpochNumber, ConsensusSlotNumber @@ 5))
+        )),
+
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 4),
+        Seq(
+          getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 2),
+            Seq(
+              getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 1))
+            )),
+          getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 3))
+        ))
+    )
+
+    // Set initialNonceData (reverse order expected)
+    val expectedInitialNonceData: Seq[(VrfOutput, ConsensusSlotNumber)] = Seq(
+      (generateDummyVrfOutput(ommers(1).header), ConsensusSlotNumber @@ 6),
+      (generateDummyVrfOutput(ommers(0).header), ConsensusSlotNumber @@ 4)
+    )
+
+    // Mock block with ommers
+    val parentId: ModifierId = getRandomBlockId()
+    val parentInfo: SidechainBlockInfo = mock[SidechainBlockInfo]
+    val verifiedBlockTimestamp = TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 5)
+    val verifiedBlock: SidechainBlock = mock[SidechainBlock]
+    val header = mock[SidechainBlockHeader]
+    Mockito.when(header.timestamp).thenReturn(verifiedBlockTimestamp)
+    Mockito.when(verifiedBlock.header).thenReturn(header)
+    Mockito.when(verifiedBlock.ommers).thenReturn(ommers)
+
+
+    Mockito.when(history.calculateNonceForNonGenesisEpoch(
+      ArgumentMatchers.any[ModifierId],
+      ArgumentMatchers.any[SidechainBlockInfo],
+      ArgumentMatchers.any[Seq[(VrfOutput, ConsensusSlotNumber)]])).thenAnswer(answer => {
+      val lastBlockIdInEpoch: ModifierId = answer.getArgument(0)
+      val lastBlockInfoInEpoch: SidechainBlockInfo = answer.getArgument(1)
+      val initialNonceData: Seq[(VrfOutput, ConsensusSlotNumber)] = answer.getArgument(2)
+
+      assertEquals("On calculate nonce: lastBlockIdInEpoch is different", parentId, lastBlockIdInEpoch)
+      assertEquals("On calculate nonce: lastBlockInfoInEpoch is different", parentInfo, lastBlockInfoInEpoch)
+      assertEquals("On calculate nonce: initialNonceData is different", expectedInitialNonceData, initialNonceData)
+
+      // Return nonce same different from current epoch nonce
+      switchedOmmersFullConsensusEpochInfo.nonceConsensusEpochInfo
+    })
+
+    val switchedEpochConsensusValidator = new BoxConsensusValidator(timeProvider) {
+      override private[horizen] def verifyForgingStakeInfo(header: SidechainBlockHeaderBase, stakeConsensusEpochInfo: StakeConsensusEpochInfo, vrfOutput: VrfOutput, percentageForkApplied: Boolean, activeSlotCoefficient: Double): Unit = {
+        val epochAndSlot = TimeToEpochUtils.timestampToEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, header.timestamp)
+        epochAndSlot.epochNumber match {
+          case `preForkEpochNumber` => assertEquals("Different stakeConsensusEpochInfo expected", preForkFullConsensusEpochInfo.stakeConsensusEpochInfo, stakeConsensusEpochInfo)
+          case `postForkEpochNumber` => assertEquals("Different stakeConsensusEpochInfo expected", switchedOmmersFullConsensusEpochInfo.stakeConsensusEpochInfo, stakeConsensusEpochInfo)
+          case epoch => jFail(s"Unknown epoch number: $epoch")
+        }
+        assertEquals("Different vrfOutput expected", generateDummyVrfOutput(header), vrfOutput)
+      }
+    }
+
+    Try {
+      switchedEpochConsensusValidator.verifyOmmers(verifiedBlock, postForkFullConsensusEpochInfo, Some(preForkFullConsensusEpochInfo), parentId, parentInfo, history, Seq())
+    } match {
+      case Success(_) =>
+      case Failure(e) => throw e // jFail(s"Block with ommers from both the same and previous epoch expected to be Valid, instead exception: ${e.getMessage}")
+    }
+
+  }
+
   private def getMockedOmmer(timestamp: Long, subOmmers: Seq[Ommer[SidechainBlockHeader]] = Seq()): Ommer[SidechainBlockHeader] = {
     val header = mock[SidechainBlockHeader]
     Mockito.when(header.timestamp).thenReturn(timestamp)
@@ -508,6 +792,32 @@ class ConsensusValidatorOmmersTest
       ConsensusParamsForkInfo(0, new ConsensusParamsFork(slotsInEpoch)),
     ))
     ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp)))
+
+    val history: SidechainHistory = mock[SidechainHistory]
+
+    Mockito.when(history.params).thenReturn(params)
+
+    Mockito.when(history.getVrfOutput(ArgumentMatchers.any[SidechainBlockHeader], ArgumentMatchers.any[NonceConsensusEpochInfo])).thenAnswer(answer => {
+      val header: SidechainBlockHeader = answer.getArgument(0)
+      Some(generateDummyVrfOutput(header))
+    })
+
+    history
+  }
+
+  private def mockHistoryWithConsensusParameterForks(consensusParamsFork: Seq[ConsensusParamsForkInfo]): SidechainHistory = {
+    val params: NetworkParams = MainNetParams()
+
+    ConsensusParamsUtil.setConsensusParamsForkActivation(consensusParamsFork)
+
+    consensusParamsFork.foreach(paramsFork => {
+      ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(
+        Seq(
+          TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp),
+          TimeToEpochUtils.getTimeStampForEpochAndSlot(params.sidechainGenesisBlockTimestamp, ConsensusEpochNumber @@ paramsFork.activationEpoch, ConsensusSlotNumber @@ 0)
+        )
+      )
+    })
 
     val history: SidechainHistory = mock[SidechainHistory]
 

--- a/sdk/src/test/scala/io/horizen/history/validation/ConsensusValidatorOmmersTest.scala
+++ b/sdk/src/test/scala/io/horizen/history/validation/ConsensusValidatorOmmersTest.scala
@@ -673,7 +673,7 @@ class ConsensusValidatorOmmersTest
        Slots in epoch:   6
        Block slots number:   2/2 - 3/5
                                     |
-       Ommers slots:   [2/4    ,   2/6   ,   3/4]
+       Ommers slots:   [2/4    ,   2/6   ,   3/15]
                          |          |         |
        Subommers slots:[2/3]      [2/5]  [3/2 , 3/3]
                                            |
@@ -708,7 +708,7 @@ class ConsensusValidatorOmmersTest
           getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, preForkEpochNumber, ConsensusSlotNumber @@ 5))
         )),
 
-      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 4),
+      getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 15),
         Seq(
           getMockedOmmer(TimeToEpochUtils.getTimeStampForEpochAndSlot(history.params.sidechainGenesisBlockTimestamp, postForkEpochNumber, ConsensusSlotNumber @@ 2),
             Seq(
@@ -767,7 +767,7 @@ class ConsensusValidatorOmmersTest
       switchedEpochConsensusValidator.verifyOmmers(verifiedBlock, postForkFullConsensusEpochInfo, Some(preForkFullConsensusEpochInfo), parentId, parentInfo, history, Seq())
     } match {
       case Success(_) =>
-      case Failure(e) => throw e // jFail(s"Block with ommers from both the same and previous epoch expected to be Valid, instead exception: ${e.getMessage}")
+      case Failure(e) => throw e
     }
 
   }


### PR DESCRIPTION
## Description
ConsensusValidatorOmmersTest is testing ommers validation.
A test that checks ommers validation with an epoch switch in between is already present (switchingEpochOmmersValidation), and a new one that checks the same case with a consensus params change in between has been implemented. 

## Jira Ticket
[SDK-1466](https://horizenlabs.atlassian.net/browse/SDK-1466)

## Changes
Add new test cases: chacking the ommers validity while changing consensus parameters

## Breaking Changes
No breaking changes

## Checks
- [x] Project Builds
- [x] Project passes tests and checks


[SDK-1466]: https://horizenlabs.atlassian.net/browse/SDK-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ