### PR TITLE
SDK-1465 : New unit test for epoch switch in AccountStateTest

### DIFF
--- a/sdk/src/main/scala/io/horizen/account/state/AccountState.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/AccountState.scala
@@ -313,12 +313,26 @@ class AccountState(
   }
 
   // Note: Equal to SidechainState.isSwitchingConsensusEpoch
+  //ovo se koristi da se updajtuje history i wallet i poziva se sa sledecim block timestamp koji dolazi
   override def isSwitchingConsensusEpoch(blockTimeStamp: Long): Boolean = {
+    //ovo uzima timestamp (unix time) od sc genesis blocka i novog blocka i onda izracuna kojoj epohi pripada
     val blockConsensusEpoch: ConsensusEpochNumber = TimeToEpochUtils.timeStampToEpochNumber(params.sidechainGenesisBlockTimestamp, blockTimeStamp)
+
+    // ovo uzima koja je trenutna epoha
     val currentConsensusEpoch: ConsensusEpochNumber = getConsensusEpochNumber.getOrElse(intToConsensusEpochNumber(0))
+
+
+    //zasto ovako, nesto tu nevalja
+    //ispada da se ne desava switch jedino kad su dve epohe jednake
+
+    //cek sada - da li ova metoda obavestava kada je nova epoha, tj kada se sledeci block nalazi u drugoj epohi
+    //ili obavestava kada se sl block nalazi u novoj epohi koja pripada narednom consensus epoch parameter fork  - bice da je ovo jer pravi novu istoriju
 
     blockConsensusEpoch != currentConsensusEpoch
   }
+
+  //AHA, dakle ovo se koristi na kraju za proveru da li je hard fork concensus epohe jer ako su razlicite epohe sadasnjeg i
+  //sledeceg bloka onda znaci da je doslo do promene consensusa
 
   override def rollbackTo(version: VersionTag): Try[AccountState] = Try {
     require(version != null, "Version to rollback to must be NOT NULL.")

--- a/sdk/src/main/scala/io/horizen/account/state/AccountState.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/AccountState.scala
@@ -313,26 +313,11 @@ class AccountState(
   }
 
   // Note: Equal to SidechainState.isSwitchingConsensusEpoch
-  //ovo se koristi da se updajtuje history i wallet i poziva se sa sledecim block timestamp koji dolazi
   override def isSwitchingConsensusEpoch(blockTimeStamp: Long): Boolean = {
-    //ovo uzima timestamp (unix time) od sc genesis blocka i novog blocka i onda izracuna kojoj epohi pripada
     val blockConsensusEpoch: ConsensusEpochNumber = TimeToEpochUtils.timeStampToEpochNumber(params.sidechainGenesisBlockTimestamp, blockTimeStamp)
-
-    // ovo uzima koja je trenutna epoha
     val currentConsensusEpoch: ConsensusEpochNumber = getConsensusEpochNumber.getOrElse(intToConsensusEpochNumber(0))
-
-
-    //zasto ovako, nesto tu nevalja
-    //ispada da se ne desava switch jedino kad su dve epohe jednake
-
-    //cek sada - da li ova metoda obavestava kada je nova epoha, tj kada se sledeci block nalazi u drugoj epohi
-    //ili obavestava kada se sl block nalazi u novoj epohi koja pripada narednom consensus epoch parameter fork  - bice da je ovo jer pravi novu istoriju
-
     blockConsensusEpoch != currentConsensusEpoch
   }
-
-  //AHA, dakle ovo se koristi na kraju za proveru da li je hard fork concensus epohe jer ako su razlicite epohe sadasnjeg i
-  //sledeceg bloka onda znaci da je doslo do promene consensusa
 
   override def rollbackTo(version: VersionTag): Try[AccountState] = Try {
     require(version != null, "Version to rollback to must be NOT NULL.")

--- a/sdk/src/main/scala/io/horizen/fork/ConsensusParamsFork.scala
+++ b/sdk/src/main/scala/io/horizen/fork/ConsensusParamsFork.scala
@@ -4,8 +4,8 @@ import io.horizen.utils.Pair
 
 
 case class ConsensusParamsFork(
-    consensusSlotsInEpoch: Int = 720, // how many block are in epoch => 720 blocks in 1 epoch; epoch size
-    consensusSecondsInSlot: Int = 12 // block appears on average every 17 seconds. f=0.7 which means 70% of slots are expected to have at least one leader. so 12/0.7 = 17
+    consensusSlotsInEpoch: Int = 720,
+    consensusSecondsInSlot: Int = 12
    ) extends OptionalSidechainFork
 
 object ConsensusParamsFork {

--- a/sdk/src/main/scala/io/horizen/fork/ConsensusParamsFork.scala
+++ b/sdk/src/main/scala/io/horizen/fork/ConsensusParamsFork.scala
@@ -4,8 +4,8 @@ import io.horizen.utils.Pair
 
 
 case class ConsensusParamsFork(
-    consensusSlotsInEpoch: Int = 720,
-    consensusSecondsInSlot: Int = 12
+    consensusSlotsInEpoch: Int = 720, // how many block are in epoch => 720 blocks in 1 epoch; epoch size
+    consensusSecondsInSlot: Int = 12 // block appears on average every 17 seconds. f=0.7 which means 70% of slots are expected to have at least one leader. so 12/0.7 = 17
    ) extends OptionalSidechainFork
 
 object ConsensusParamsFork {

--- a/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
@@ -187,22 +187,27 @@ class AccountStateTest
       TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp + 720 * 12 * 20) //starting 20 (old) epoch, it resets to 0 (new) epoch
     ))
 
-    // Test 1. check the first consensus params fork
+    // Test 1. check the first consensus params fork epochs match
     Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(11)))
     // assert that block with this timestamp belongs to 11th epoch
     var blockTimestamp = 720 * 12 * 10
     assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(blockTimestamp)))
 
 
-    // Test 2. check the second consensus params fork
+    // Test 2. check the second consensus params fork epochs match
     Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(18)))
     // assert that block with this timestamp belongs to 18th epoch
 
     // in this timestamp, 2nd consensus params fork has been running for 2 (old) epochs (20 and 21) which is equal to 18 new
     // 2 old epochs have 17280 slots, while the new epoch has 1000 slots
     blockTimestamp = 720 * 12 * 21
-
     assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(blockTimestamp)))
+
+
+    // Test 3. check the second consensus params fork epochs don't match
+    // add another (new) epoch to the timestamp and check if there is mismatch between epochs
+    blockTimestamp = 720 * 12 * 21 + 100 * 10
+    assertEquals(true, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(blockTimestamp)))
   }
 
   @Test

--- a/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
@@ -167,45 +167,9 @@ class AccountStateTest
     assertEquals(s"Total fee value is wrong", totalFee, forgerTotalFee)
   }
 
-  // todo david
   @Test
   def testSwitchingConsensusEpoch(): Unit = {
-    Mockito.when(params.sidechainGenesisBlockTimestamp).thenReturn(1694091721)
-//1694091721 - juce
-//1694178121 - danas
-//1694264521 - sutra
-    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
-      ConsensusParamsForkInfo(15, ConsensusParamsFork.DefaultConsensusParamsFork),
-    ))
-    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(1694264521)))//kada stavim 0 onda se aktivira odmah ova 15, a kad stavim 8620 (da se kontrira sa onih -8628) onda je 0
-//    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(1699282725))
-
-    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(1694178121)))
-
-    val currentEpochNumber = state.getConsensusEpochNumber
-
-    assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(currentEpochNumber.get)))
-
-
-//    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp)))
-//
-//    assertEquals(state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(currentEpochNumber.get)), true)
-
-    /*
-    * sta tacno treba da uradim?
-    * fork se aktivira odmah od genesis blocka tako da mozda da testiram nekako da mockujem da se ne aktivira od genesis vec od 5og npr i onda
-    * da proverim za prve 4 epoche(ili blocka pojma nemam) i treba da bude false isSwitchingConsensusEpoch, a onda od 5te true?
-    * */
-  }
-
-  @Test
-  def testSwitchingConsensusEpochOriginalReal(): Unit = {
-    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
-      ConsensusParamsForkInfo(0, ConsensusParamsFork.DefaultConsensusParamsFork),
-    ))
-    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp)))
-
-    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(86400))) //ovo je current consensus epoch (nema konverzije ikakve)
+    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(86400)))
 
     val currentEpochNumber = state.getConsensusEpochNumber
 
@@ -213,55 +177,7 @@ class AccountStateTest
   }
 
   @Test
-  def testSwitchingConsensusEpochOriginalFake(): Unit = {
-    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
-      ConsensusParamsForkInfo(0, ConsensusParamsFork.DefaultConsensusParamsFork),
-    ))
-    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp)))
-
-    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(11))) //ovo je current consensus epoch (nema konverzije ikakve)
-
-    val currentEpochNumber = state.getConsensusEpochNumber
-
-    assertEquals(state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(86400)), true)
-  }
-
-  @Test
-  def testSwitchingConsensusEpochTrialsRealData(): Unit = {
-    Mockito.when(params.sidechainGenesisBlockTimestamp).thenReturn(1676035728L)
-
-    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
-      ConsensusParamsForkInfo(20, ConsensusParamsFork.DefaultConsensusParamsFork),
-    ))
-    //aktivira se na 20. epohi i to sam izracunao tako sto sam na genesis dodao 720*12*20
-    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(1676208528L)))
-
-    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(11))) //ovo je current consensus epoch (nema konverzije ikakve)
-
-    val currentEpochNumber = state.getConsensusEpochNumber
-
-    //ovde sam namestio da proveri za block koji je na 10.toj epohi
-    assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(1676044368)))
-  }
-
-  @Test
-  def testSwitchingConsensusEpochTrialsFakeData(): Unit = {
-    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
-      ConsensusParamsForkInfo(20, ConsensusParamsFork.DefaultConsensusParamsFork),
-    ))
-    //aktivira se na 20. epohi i to sam izracunao tako sto sam na genesis dodao 720*12*20
-    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp + 720*12*20)))
-
-    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(11))) //ovo je current consensus epoch (nema konverzije ikakve)
-
-    val currentEpochNumber = state.getConsensusEpochNumber
-
-    //ovde sam namestio da proveri za block koji je na 10.toj epohi
-    assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(720*12*10)))
-  }
-
-  @Test
-  def testSwitchingConsensusEpochTrialsFakeDataWith2ConsensusForks(): Unit = {
+  def testSwitchingConsensusEpochsWith2Forks(): Unit = {
     ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
       ConsensusParamsForkInfo(0, ConsensusParamsFork.DefaultConsensusParamsFork),
       ConsensusParamsForkInfo(0, ConsensusParamsFork(100,10)),

--- a/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
@@ -38,13 +38,6 @@ class AccountStateTest
   var params: NetworkParams = mock[NetworkParams]
   val metadataStorage: AccountStateMetadataStorage = mock[AccountStateMetadataStorage]
   var state: AccountState = _
-
-  //todo this seems redundant because it's already in @Before method
-//  ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
-//    ConsensusParamsForkInfo(0, ConsensusParamsFork.DefaultConsensusParamsFork),
-//  ))
-//  ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp)))
-
   private def addMockBalance(account: Address, value: BigInteger) = {
     val stateDB = new StateDB(stateDbStorage, new Hash(metadataStorage.getAccountStateRoot))
     stateDB.addBalance(account, value)
@@ -62,12 +55,7 @@ class AccountStateTest
     val messageProcessors: Seq[MessageProcessor] = Seq()
 
     Mockito.when(params.chainId).thenReturn(1997)
-    //Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(None)
     Mockito.when(metadataStorage.getAccountStateRoot).thenReturn(Hash.ZERO.toBytes)
-//    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
-//      ConsensusParamsForkInfo(0, ConsensusParamsFork.DefaultConsensusParamsFork),
-//    ))
-//    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp)))
 
     state = new AccountState(
       params,
@@ -182,18 +170,21 @@ class AccountStateTest
   // todo david
   @Test
   def testSwitchingConsensusEpoch(): Unit = {
-
+    Mockito.when(params.sidechainGenesisBlockTimestamp).thenReturn(1694091721)
+//1694091721 - juce
+//1694178121 - danas
+//1694264521 - sutra
     ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
       ConsensusParamsForkInfo(15, ConsensusParamsFork.DefaultConsensusParamsFork),
     ))
-    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(0)))//kada stavim 0 onda se aktivira odmah ova 15, a kad stavim 8620 (da se kontrira sa onih -8628) onda je 0
+    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(1694264521)))//kada stavim 0 onda se aktivira odmah ova 15, a kad stavim 8620 (da se kontrira sa onih -8628) onda je 0
 //    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(1699282725))
 
-    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(10)))
+    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(1694178121)))
 
     val currentEpochNumber = state.getConsensusEpochNumber
 
-    assertEquals(state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(currentEpochNumber.get)), false)
+    assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(currentEpochNumber.get)))
 
 
 //    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp)))
@@ -208,30 +199,95 @@ class AccountStateTest
   }
 
   @Test
-  def testSwitchingConsensusEpochOriginal(): Unit = {
+  def testSwitchingConsensusEpochOriginalReal(): Unit = {
     ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
       ConsensusParamsForkInfo(0, ConsensusParamsFork.DefaultConsensusParamsFork),
     ))
     ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp)))
 
-    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(86400)))
+    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(86400))) //ovo je current consensus epoch (nema konverzije ikakve)
 
     val currentEpochNumber = state.getConsensusEpochNumber
 
     assertEquals(state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(currentEpochNumber.get)), true)
   }
 
-//  @Test
-//  def testSwitchingConsensusEpochTrials(): Unit = {
-//    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq())
-//    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq())
-//
-//    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(86400)))
-//
-//    val currentEpochNumber = state.getConsensusEpochNumber
-//
-//    assertEquals(state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(currentEpochNumber.get)), true)
-//  }
+  @Test
+  def testSwitchingConsensusEpochOriginalFake(): Unit = {
+    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
+      ConsensusParamsForkInfo(0, ConsensusParamsFork.DefaultConsensusParamsFork),
+    ))
+    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp)))
+
+    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(11))) //ovo je current consensus epoch (nema konverzije ikakve)
+
+    val currentEpochNumber = state.getConsensusEpochNumber
+
+    assertEquals(state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(86400)), true)
+  }
+
+  @Test
+  def testSwitchingConsensusEpochTrialsRealData(): Unit = {
+    Mockito.when(params.sidechainGenesisBlockTimestamp).thenReturn(1676035728L)
+
+    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
+      ConsensusParamsForkInfo(20, ConsensusParamsFork.DefaultConsensusParamsFork),
+    ))
+    //aktivira se na 20. epohi i to sam izracunao tako sto sam na genesis dodao 720*12*20
+    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(1676208528L)))
+
+    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(11))) //ovo je current consensus epoch (nema konverzije ikakve)
+
+    val currentEpochNumber = state.getConsensusEpochNumber
+
+    //ovde sam namestio da proveri za block koji je na 10.toj epohi
+    assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(1676044368)))
+  }
+
+  @Test
+  def testSwitchingConsensusEpochTrialsFakeData(): Unit = {
+    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
+      ConsensusParamsForkInfo(20, ConsensusParamsFork.DefaultConsensusParamsFork),
+    ))
+    //aktivira se na 20. epohi i to sam izracunao tako sto sam na genesis dodao 720*12*20
+    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp + 720*12*20)))
+
+    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(11))) //ovo je current consensus epoch (nema konverzije ikakve)
+
+    val currentEpochNumber = state.getConsensusEpochNumber
+
+    //ovde sam namestio da proveri za block koji je na 10.toj epohi
+    assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(720*12*10)))
+  }
+
+  @Test
+  def testSwitchingConsensusEpochTrialsFakeDataWith2ConsensusForks(): Unit = {
+    ConsensusParamsUtil.setConsensusParamsForkActivation(Seq(
+      ConsensusParamsForkInfo(0, ConsensusParamsFork.DefaultConsensusParamsFork),
+      ConsensusParamsForkInfo(0, ConsensusParamsFork(100,10)),
+    ))
+    ConsensusParamsUtil.setConsensusParamsForkTimestampActivation(Seq(
+      TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp), //runs for 19 epochs
+      TimeToEpochUtils.virtualGenesisBlockTimeStamp(params.sidechainGenesisBlockTimestamp + 720 * 12 * 20) //starting 20 (old) epoch, it resets to 0 (new) epoch
+    ))
+
+    // Test 1. check the first consensus params fork
+    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(11)))
+    // assert that block with this timestamp belongs to 11th epoch
+    var blockTimestamp = 720 * 12 * 10
+    assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(blockTimestamp)))
+
+
+    // Test 2. check the second consensus params fork
+    Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(18)))
+    // assert that block with this timestamp belongs to 18th epoch
+
+    // in this timestamp, 2nd consensus params fork has been running for 2 (old) epochs (20 and 21) which is equal to 18 new
+    // 2 old epochs have 17280 slots, while the new epoch has 1000 slots
+    blockTimestamp = 720 * 12 * 21
+
+    assertEquals(false, state.isSwitchingConsensusEpoch(intToConsensusEpochNumber(blockTimestamp)))
+  }
 
   @Test
   def testTransactionLimitExceedsBlockGasLimit(): Unit = {


### PR DESCRIPTION
## Description
A new test is added in `AccountStateTest.scala` which tests the epoch switch between 2 consensus forks.

## Jira Ticket
[SDK-1465](https://horizenlabs.atlassian.net/browse/SDK-1465?atlOrigin=eyJpIjoiYjg2NzlmMTY3YzE4NGNkMWIwMmQxMDBjNzJmMmEyYjIiLCJwIjoiaiJ9)

## Changes
Added new test `testSwitchingConsensusEpochsWith2Forks` which creates 2 consensus params forks, one with default consensus params forks (720, 12) , and another one with 100 slots in epoch and 10 seconds for each slot. The test validates that correct epochs are calculated for certain block timestamps w.r.t. active consensus params fork.

## Breaking Changes
No breaking changes.

## Checks
- [X] Project Builds
- [X] Project passes tests and checks
- [ ] Updated documentation accordingly
- [ ] Breaking changes have been correctly tagged and notified
 
## Additional information


[SDK-1465]: https://horizenlabs.atlassian.net/browse/SDK-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ