### PR TITLE
Is/modifiers cache memory leak fix

### DIFF
--- a/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
@@ -175,7 +175,10 @@ abstract class AbstractSidechainNodeViewHolder[
         val bestBlockTimestampPlus24H = history().bestBlock.timestamp + TimeUnit.HOURS.toSeconds(24)
         val (modsToApply, modsToSkip) = mods.partition(m => m.timestamp <= bestBlockTimestampPlus24H)
         modsToApply.foreach(m => modifiersCache.put(m.id, m))
-        if (modsToSkip.nonEmpty) context.system.eventStream.publish(ModifiersProcessingResult(Seq(), modsToSkip))
+        if (modsToSkip.nonEmpty) {
+          // reset the status of the modifiers to Unknown, so that we try to fetch them again in the future
+          context.system.eventStream.publish(ModifiersProcessingResult(Seq(), modsToSkip))
+        }
       } else {
         mods.foreach(m => modifiersCache.put(m.id, m))
       }

--- a/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/AbstractSidechainNodeViewHolder.scala
@@ -19,6 +19,7 @@ import sparkz.core.transaction.state.TransactionValidation
 import sparkz.core.utils.NetworkTimeProvider
 import sparkz.core.{ModifiersCache, idToVersion}
 
+import java.util.concurrent.TimeUnit
 import scala.util.{Failure, Success, Try}
 
 abstract class AbstractSidechainNodeViewHolder[
@@ -163,12 +164,21 @@ abstract class AbstractSidechainNodeViewHolder[
   /**
    * Process new modifiers from remote.
    * Put all candidates to modifiersCache and then try to apply as much modifiers from cache as possible.
+   * If the cache is half full, do not include modifiers that are more than 24 hours away from the best block timestamp.
    * Clear cache if it's size exceeds size limit.
    * Publish `ModifiersProcessingResult` message with all just applied and removed from cache modifiers.
    */
   override def processRemoteModifiers: Receive = {
     case sparkz.core.NodeViewHolder.ReceivableMessages.ModifiersFromRemote(mods: Seq[PMOD]) =>
-      mods.foreach(m => modifiersCache.put(m.id, m))
+
+      if (modifiersCache.size + mods.size > sparksSettings.network.maxModifiersCacheSize / 2) {
+        val bestBlockTimestampPlus24H = history().bestBlock.timestamp + TimeUnit.HOURS.toSeconds(24)
+        val (modsToApply, modsToSkip) = mods.partition(m => m.timestamp <= bestBlockTimestampPlus24H)
+        modsToApply.foreach(m => modifiersCache.put(m.id, m))
+        if (modsToSkip.nonEmpty) context.system.eventStream.publish(ModifiersProcessingResult(Seq(), modsToSkip))
+      } else {
+        mods.foreach(m => modifiersCache.put(m.id, m))
+      }
 
       log.debug(s"Cache size before: ${modifiersCache.size}")
 

--- a/sdk/src/test/scala/io/horizen/ParentIdModifiersCacheSpecification.scala
+++ b/sdk/src/test/scala/io/horizen/ParentIdModifiersCacheSpecification.scala
@@ -81,31 +81,4 @@ class ParentIdModifiersCacheSpecification extends AnyPropSpec
     cache.size shouldBe 3
   }
 
-  property("cache should clear itself if overflowed") {
-    val limit = 3
-    val random = Random
-
-    val k0 = bytesToId(Blake2b256.hash(random.nextString(5)))
-    val k1 = bytesToId(Blake2b256.hash(random.nextString(5)))
-    val k2 = bytesToId(Blake2b256.hash(random.nextString(5)))
-    val k3 = bytesToId(Blake2b256.hash(random.nextString(5)))
-    val k4 = bytesToId(Blake2b256.hash(random.nextString(5)))
-    val k5 = bytesToId(Blake2b256.hash(random.nextString(5)))
-    val k6 = bytesToId(Blake2b256.hash(random.nextString(5)))
-    val k7 = bytesToId(Blake2b256.hash(random.nextString(5)))
-
-    val cache = new ParentIdModifiersCache[FakeModifier, HistoryReader[FakeModifier, FakeSyncInfo]](limit)
-
-    cache.put(k1, new FakeModifier(k1, k0))
-    cache.put(k2, new FakeModifier(k2, k1))
-    cache.put(k3, new FakeModifier(k3, k2))
-    cache.put(k4, new FakeModifier(k4, k3))
-    cache.put(k5, new FakeModifier(k5, k4))
-    cache.put(k6, new FakeModifier(k6, k5))
-    cache.size shouldBe 6
-
-    cache.put(k7, new FakeModifier(k7, k6))
-    cache.size shouldBe 3
-  }
-
 }

--- a/sdk/src/test/scala/io/horizen/ParentIdModifiersCacheSpecification.scala
+++ b/sdk/src/test/scala/io/horizen/ParentIdModifiersCacheSpecification.scala
@@ -81,4 +81,31 @@ class ParentIdModifiersCacheSpecification extends AnyPropSpec
     cache.size shouldBe 3
   }
 
+  property("cache should clear itself if overflowed") {
+    val limit = 3
+    val random = Random
+
+    val k0 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k1 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k2 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k3 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k4 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k5 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k6 = bytesToId(Blake2b256.hash(random.nextString(5)))
+    val k7 = bytesToId(Blake2b256.hash(random.nextString(5)))
+
+    val cache = new ParentIdModifiersCache[FakeModifier, HistoryReader[FakeModifier, FakeSyncInfo]](limit)
+
+    cache.put(k1, new FakeModifier(k1, k0))
+    cache.put(k2, new FakeModifier(k2, k1))
+    cache.put(k3, new FakeModifier(k3, k2))
+    cache.put(k4, new FakeModifier(k4, k3))
+    cache.put(k5, new FakeModifier(k5, k4))
+    cache.put(k6, new FakeModifier(k6, k5))
+    cache.size shouldBe 6
+
+    cache.put(k7, new FakeModifier(k7, k6))
+    cache.size shouldBe 3
+  }
+
 }

--- a/sdk/src/test/scala/io/horizen/account/fixtures/MockedAccountSidechainNodeViewHolderFixture.scala
+++ b/sdk/src/test/scala/io/horizen/account/fixtures/MockedAccountSidechainNodeViewHolderFixture.scala
@@ -37,7 +37,7 @@ class MockedAccountSidechainNodeViewHolder(sidechainSettings: SidechainSettings,
 
 
 trait MockedAccountSidechainNodeViewHolderFixture extends MockitoSugar {
-  val maxModifiersCacheSize = 10
+  val maxModifiersCacheSize = 100
 
   def getMockedAccountSidechainNodeViewHolderRef(
                                            history: AccountHistory,

--- a/sdk/src/test/scala/io/horizen/utxo/SidechainNodeViewHolderTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/SidechainNodeViewHolderTest.scala
@@ -9,7 +9,6 @@ import io.horizen.consensus.{ConsensusEpochInfo, FullConsensusEpochInfo, intToCo
 import io.horizen.fixtures._
 import io.horizen.params.{NetworkParams, RegTestParams}
 import io.horizen.SidechainTypes
-import io.horizen.account.block.AccountBlock
 import io.horizen.utils.{CountDownLatchController, MerkleTree, WithdrawalEpochInfo}
 import io.horizen.utxo.block.SidechainBlock
 import io.horizen.utxo.box.ZenBox

--- a/sdk/src/test/scala/io/horizen/utxo/SidechainNodeViewHolderTest.scala
+++ b/sdk/src/test/scala/io/horizen/utxo/SidechainNodeViewHolderTest.scala
@@ -9,6 +9,7 @@ import io.horizen.consensus.{ConsensusEpochInfo, FullConsensusEpochInfo, intToCo
 import io.horizen.fixtures._
 import io.horizen.params.{NetworkParams, RegTestParams}
 import io.horizen.SidechainTypes
+import io.horizen.account.block.AccountBlock
 import io.horizen.utils.{CountDownLatchController, MerkleTree, WithdrawalEpochInfo}
 import io.horizen.utxo.block.SidechainBlock
 import io.horizen.utxo.box.ZenBox
@@ -32,6 +33,7 @@ import sparkz.core.{VersionTag, idToVersion}
 import sparkz.util.{ModifierId, SparkzEncoding}
 
 import java.nio.charset.StandardCharsets
+import java.time.Instant
 import java.util
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success, Try}
@@ -428,6 +430,9 @@ class SidechainNodeViewHolderTest extends JUnitSuite
     })
 
     Mockito.when(history.openSurfaceIds()).thenReturn(Seq())
+    val blockMock = Mockito.mock(classOf[SidechainBlock])
+    Mockito.when(history.bestBlock).thenReturn(blockMock)
+    Mockito.when(blockMock.timestamp).thenReturn(Instant.now().toEpochMilli)
 
     Mockito.when(history.applicableTry(ArgumentMatchers.any[SidechainBlock])).thenAnswer(answer => {
       val block: SidechainBlock = answer.getArgument(0)
@@ -488,6 +493,9 @@ class SidechainNodeViewHolderTest extends JUnitSuite
     })
 
     Mockito.when(history.openSurfaceIds()).thenReturn(Seq())
+    val blockMock = Mockito.mock(classOf[SidechainBlock])
+    Mockito.when(history.bestBlock).thenReturn(blockMock)
+    Mockito.when(blockMock.timestamp).thenReturn(Instant.now().toEpochMilli)
 
     Mockito.when(history.applicableTry(ArgumentMatchers.any[SidechainBlock])).thenAnswer(answer => {
       val block: SidechainBlock = answer.getArgument(0)
@@ -619,6 +627,9 @@ class SidechainNodeViewHolderTest extends JUnitSuite
     })
 
     Mockito.when(history.openSurfaceIds()).thenReturn(Seq())
+    val blockMock = Mockito.mock(classOf[SidechainBlock])
+    Mockito.when(history.bestBlock).thenReturn(blockMock)
+    Mockito.when(blockMock.timestamp).thenReturn(Instant.now().toEpochMilli)
 
     Mockito.when(history.applicableTry(ArgumentMatchers.any[SidechainBlock])).thenAnswer(answer => {
       val block: SidechainBlock = answer.getArgument(0)


### PR DESCRIPTION
## Description
the overflow of the modifiers cache is not something we introduced in this release, the logic there allows cache to grow while there's a new block to apply to the current history in the cache

only when the cache does not contain any valid block, it will clear itself

and I believe that on previous version, due to other synchronization problems, we did not encounter this one

but now the sync process is working better and faster, so we hit this bottleneck

## Jira Ticket
https://horizenlabs.atlassian.net/browse/SDK-1513


