### PR TITLE
SDK-1527: clean old top certificate only if that certificate was alre…

### DIFF
--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageView.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageView.scala
@@ -345,8 +345,10 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
           case _ => false
         }
         if (isWithdrawalEpochSwitched) {
-          val certEpochNumberToRemove: Int = epochInfo.epoch - 4
-          removeList.add(getTopQualityCertificateKey(certEpochNumberToRemove))
+          getOldTopCertificatesToBeRemoved(epochInfo) match {
+            case Some(cert) => removeList.add(cert)
+            case _ =>
+          }
 
           val blockFeeInfoEpochToRemove: Int = epochInfo.epoch - 1
           for (counter <- 0 to getBlockFeeInfoCounter(blockFeeInfoEpochToRemove)) {
@@ -371,6 +373,16 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
 
   }
 
+  private[storage] def getOldTopCertificatesToBeRemoved(epochInfo: WithdrawalEpochInfo): Option[ByteArrayWrapper] = {
+    val certEpochNumberToRemove: Int = epochInfo.epoch - 4
+    // We only clean up the storage if the certEpochNumberToRemove has already been used as previous certificate hash
+    // in the certEpochNumberToRemove + 1 epoch certificate
+    if (storage.get(getTopQualityCertificateKey(certEpochNumberToRemove + 1)).isPresent) {
+      Some(getTopQualityCertificateKey(certEpochNumberToRemove))
+    } else {
+      None
+    }
+  }
 
   private def getBlockFeeInfoCounter(withdrawalEpochNumber: Int): Int = {
     storage.get(getBlockFeeInfoCounterKey(withdrawalEpochNumber)).asScala match {
@@ -388,6 +400,7 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
   }
 
   private[horizen] def getTopQualityCertificateKey(referencedWithdrawalEpoch: Int): ByteArrayWrapper = {
+    val x = calculateKey(Bytes.concat("topQualityCertificate".getBytes(StandardCharsets.UTF_8), Ints.toByteArray(referencedWithdrawalEpoch)))
     calculateKey(Bytes.concat("topQualityCertificate".getBytes(StandardCharsets.UTF_8), Ints.toByteArray(referencedWithdrawalEpoch)))
   }
 

--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageView.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageView.scala
@@ -400,7 +400,6 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
   }
 
   private[horizen] def getTopQualityCertificateKey(referencedWithdrawalEpoch: Int): ByteArrayWrapper = {
-    val x = calculateKey(Bytes.concat("topQualityCertificate".getBytes(StandardCharsets.UTF_8), Ints.toByteArray(referencedWithdrawalEpoch)))
     calculateKey(Bytes.concat("topQualityCertificate".getBytes(StandardCharsets.UTF_8), Ints.toByteArray(referencedWithdrawalEpoch)))
   }
 


### PR DESCRIPTION
…ady used as previous cert

## Description
We do not delete the top certificate if it has not yet been used as a previous certificate.

## Jira Ticket
[1527](https://horizenlabs.atlassian.net/browse/SDK-1527)

## Changes
AccountStateMetadataStorageView.scala: introduced a new method that returns an Option with any certificate to be erased

## Breaking Changes
No breaking changes

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
