### PR TITLE
Fix for SDK_1532: eth_getTransactionByHash doesn't access the mempool

### DIFF
--- a/qa/run_sc_tests.sh
+++ b/qa/run_sc_tests.sh
@@ -126,6 +126,7 @@ testScriptsEvm=(
     'sc_evm_seedernode.py'
     'sc_evm_consensus_parameters_fork.py'
     'sc_evm_active_slot_coefficient.py'
+    'sc_evm_rpc_eth'
 );
 
 testScriptsUtxo=(

--- a/qa/sc_evm_rpc_eth.py
+++ b/qa/sc_evm_rpc_eth.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
-import logging
-import re
 from decimal import Decimal
 
 from SidechainTestFramework.account.ac_chain_setup import AccountChainSetup
-from SidechainTestFramework.account.ac_utils import eoa_transaction
 from SidechainTestFramework.account.httpCalls.transaction.createEIP1559Transaction import createEIP1559Transaction
-from SidechainTestFramework.account.utils import convertZenToWei
 from SidechainTestFramework.scutil import (
     assert_true, generate_next_block,
 )
@@ -58,23 +54,21 @@ class SCEvmRPCEth(AccountChainSetup):
 
         # Test with a transaction still in the mempool
 
-        tx_id = createEIP1559Transaction(sc_node,
-                                         fromAddress=evm_address_sc1,
-                                         toAddress=evm_address_sc2,
-                                         value=1,
-                                         nonce=0
-                                         )
+        tx_id = "0x" + createEIP1559Transaction(sc_node,
+                                                fromAddress=evm_address_sc1,
+                                                toAddress=evm_address_sc2,
+                                                value=1,
+                                                nonce=0
+                                                )
 
-        res = sc_node.rpc_eth_getTransactionByHash("0x" + tx_id)
-        logging.info(res)
+        res = sc_node.rpc_eth_getTransactionByHash(tx_id)
         assert_false("error" in res)
         assert_true("result" in res)
-        assert_false(res["result"] is None)
 
+        assert_equal(tx_id, res["result"]['hash'])
         assert_true(res["result"]['blockHash'] is None)
         assert_true(res["result"]['blockNumber'] is None)
         assert_true(res["result"]['transactionIndex'] is None)
-        assert_equal("0x" + tx_id, res["result"]['hash'])
 
         # Test with a transaction in the blockchain
 
@@ -84,17 +78,17 @@ class SCEvmRPCEth(AccountChainSetup):
         response = allTransactions(sc_node, False)
         assert_equal(0, len(response['transactionIds']))
 
-        res = sc_node.rpc_eth_getTransactionByHash("0x" + tx_id)
+        res = sc_node.rpc_eth_getTransactionByHash(tx_id)
         assert_false("error" in res)
         assert_true("result" in res)
-        assert_false(res["result"] is None)
+
+        assert_equal(tx_id, res["result"]['hash'])
 
         res_block = sc_node.block_findById(blockId=block_id)
 
         assert_equal("0x" + block_id, res["result"]['blockHash'])
         assert_equal(res_block['result']['height'], int(res["result"]['blockNumber'][2:], 16))
         assert_equal("0x0", res["result"]['transactionIndex'])
-        assert_equal("0x" + tx_id, res["result"]['hash'])
 
 
 if __name__ == "__main__":

--- a/qa/sc_evm_rpc_eth.py
+++ b/qa/sc_evm_rpc_eth.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+import logging
+import re
+from decimal import Decimal
+
+from SidechainTestFramework.account.ac_chain_setup import AccountChainSetup
+from SidechainTestFramework.account.ac_utils import eoa_transaction
+from SidechainTestFramework.account.httpCalls.transaction.createEIP1559Transaction import createEIP1559Transaction
+from SidechainTestFramework.account.utils import convertZenToWei
+from SidechainTestFramework.scutil import (
+    assert_true, generate_next_block,
+)
+from httpCalls.transaction.allTransactions import allTransactions
+from test_framework.util import assert_false, assert_equal
+
+"""
+Tests for eth namespace rpc methods.
+
+Configuration:
+    - 1 SC node
+    - 1 MC node
+
+Test:
+    - test eth_getTransactionByHash
+
+"""
+
+
+class SCEvmRPCEth(AccountChainSetup):
+    def __init__(self):
+        super().__init__(withdrawalEpochLength=20)
+
+    def run_test(self):
+        sc_node = self.sc_nodes[0]
+
+        ft_amount_in_zen = Decimal('3000.0')
+        self.sc_ac_setup(ft_amount_in_zen=ft_amount_in_zen)
+
+        evm_address_sc1 = self.evm_address[2:]
+        evm_address_sc2 = sc_node.wallet_createPrivateKeySecp256k1()["result"]["proposition"]["address"]
+
+        #######################################################################################
+        # eth_getTransactionByHash tests
+        #######################################################################################
+
+        # Test with invalid input transaction id
+
+        res = sc_node.rpc_eth_getTransactionByHash("0xcccbbb")
+        assert_true("error" in res)
+        assert_false("result" in res)
+        assert_equal("Invalid params", res['error']['message'])
+
+        # Test with valid input transaction id but not existing tx
+        res = sc_node.rpc_eth_getTransactionByHash("0xcccbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        assert_false("error" in res)
+        assert_true("result" in res)
+        assert_true(res["result"] is None)
+
+        # Test with a transaction still in the mempool
+
+        tx_id = createEIP1559Transaction(sc_node,
+                                         fromAddress=evm_address_sc1,
+                                         toAddress=evm_address_sc2,
+                                         value=1,
+                                         nonce=0
+                                         )
+
+        res = sc_node.rpc_eth_getTransactionByHash("0x" + tx_id)
+        logging.info(res)
+        assert_false("error" in res)
+        assert_true("result" in res)
+        assert_false(res["result"] is None)
+
+        assert_true(res["result"]['blockHash'] is None)
+        assert_true(res["result"]['blockNumber'] is None)
+        assert_true(res["result"]['transactionIndex'] is None)
+        assert_equal("0x" + tx_id, res["result"]['hash'])
+
+        # Test with a transaction in the blockchain
+
+        block_id = generate_next_block(sc_node, "first node")
+
+        # Verify that the mempool is empty
+        response = allTransactions(sc_node, False)
+        assert_equal(0, len(response['transactionIds']))
+
+        res = sc_node.rpc_eth_getTransactionByHash("0x" + tx_id)
+        assert_false("error" in res)
+        assert_true("result" in res)
+        assert_false(res["result"] is None)
+
+        res_block = sc_node.block_findById(blockId=block_id)
+
+        assert_equal("0x" + block_id, res["result"]['blockHash'])
+        assert_equal(res_block['result']['height'], int(res["result"]['blockNumber'][2:], 16))
+        assert_equal("0x0", res["result"]['transactionIndex'])
+        assert_equal("0x" + tx_id, res["result"]['hash'])
+
+
+if __name__ == "__main__":
+    SCEvmRPCEth().main()

--- a/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
@@ -51,6 +51,7 @@ import java.nio.charset.StandardCharsets
 import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import scala.collection.mutable.ListBuffer
+import scala.compat.java8.OptionConverters.RichOptionalGeneric
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, Future, TimeoutException}
 import scala.language.postfixOps
@@ -620,10 +621,36 @@ class EthService(
     }
   }
 
+  // This method looks for the transaction first in the history and then, if not found, in the memory pool.
+  private def getTransaction(transactionHash: Hash)
+  : Option[(Option[AccountBlock], EthereumTransaction, EthereumReceipt)] = {
+    applyOnAccountView { nodeView =>
+      using(nodeView.state.getView) { stateView =>
+        stateView
+          .getTransactionReceipt(transactionHash.toBytes)
+          .flatMap(receipt => {
+            nodeView.history
+              .blockIdByHeight(receipt.blockNumber)
+              .map(ModifierId(_))
+              .flatMap(nodeView.history.getStorageBlockById)
+              .map(block => {
+                val tx = block.transactions(receipt.transactionIndex).asInstanceOf[EthereumTransaction]
+                (Some(block), tx, receipt)
+              })
+          }).orElse (
+            nodeView.pool.getTransactionById(transactionHash.toStringNoPrefix).asScala.map(tx =>
+              (None, tx.asInstanceOf[EthereumTransaction], null))
+          )
+      }
+    }
+  }
+
+
   @RpcMethod("eth_getTransactionByHash")
   def getTransactionByHash(transactionHash: Hash): EthereumTransactionView = {
-    getTransactionAndReceipt(transactionHash).map { case (block, tx, receipt) =>
-      new EthereumTransactionView(tx, receipt, block.header.baseFee)
+    getTransaction(transactionHash).map { case (blockOpt, tx, receipt) =>
+      val baseFee = blockOpt.map(_.header.baseFee).orNull
+      new EthereumTransactionView(tx, receipt, baseFee)
     }.orNull
   }
 

--- a/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
@@ -221,30 +221,35 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
       }
     }"""
 
-  private val txPoolContentFromOutput =
+
+  private val expectedPendingTx =
     """{
+         "blockHash":null,
+         "blockNumber":null,
+         "transactionIndex":null,
+         "hash":"0x68366d9034c74adb5d6e584116bc20838aedc15218a1d49eea43e04f31072044",
+         "type":"0x2",
+         "nonce":"0x10",
+         "from":"0x5b19616a7277d58ea1040a5f44c54d41853ccde3",
+         "to":"0x15532e34426cd5c37371ff455a5ba07501c0f522",
+         "value":"0xe4e1c0",
+         "input":"0xbd54d1f34e34a90f7dc5efe0b3d65fa4",
+         "gas":"0xec0564",
+         "gasPrice":"0x3b9aca64",
+         "maxPriorityFeePerGas":"0x6ef91",
+         "maxFeePerGas":"0x3b9aca64",
+         "chainId":"0x7cd",
+         "v":"0x1c",
+         "r":"0x805c658ac084be6da079d96bd4799bef3aa4578c8e57b97c3c6df9f581551023",
+         "s":"0x568277f09a64771f5b4588ff07f75725a8e40d2c641946eb645152dcd4c93f0d",
+         "accessList":[]
+      }
+      """
+
+  private val txPoolContentFromOutput =
+    s"""{
        "pending":{
-          "16":{
-             "blockHash":null,
-             "blockNumber":null,
-             "transactionIndex":null,
-             "hash":"0x68366d9034c74adb5d6e584116bc20838aedc15218a1d49eea43e04f31072044",
-             "type":"0x2",
-             "nonce":"0x10",
-             "from":"0x5b19616a7277d58ea1040a5f44c54d41853ccde3",
-             "to":"0x15532e34426cd5c37371ff455a5ba07501c0f522",
-             "value":"0xe4e1c0",
-             "input":"0xbd54d1f34e34a90f7dc5efe0b3d65fa4",
-             "gas":"0xec0564",
-             "gasPrice":"0x3b9aca64",
-             "maxPriorityFeePerGas":"0x6ef91",
-             "maxFeePerGas":"0x3b9aca64",
-             "chainId":"0x7cd",
-             "v":"0x1c",
-             "r":"0x805c658ac084be6da079d96bd4799bef3aa4578c8e57b97c3c6df9f581551023",
-             "s":"0x568277f09a64771f5b4588ff07f75725a8e40d2c641946eb645152dcd4c93f0d",
-             "accessList":[]
-          },
+          "16":$expectedPendingTx,
           "24":{
              "blockHash":null,
              "blockNumber":null,
@@ -524,7 +529,8 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
     val validCases = Table(
       ("Transaction hash", "Expected output"),
       ("0x6411db6b0b891abd9bd970562f71d4bd69b1ee3359d627c98856f024dec16253", expectedTxView),
-      ("0x123cfae639e9fcab216904adf931d55cc2cc54668dab04365437927b9cb2c7ba", "null")
+      ("0x123cfae639e9fcab216904adf931d55cc2cc54668dab04365437927b9cb2c7ba", "null"),
+      ("0x68366d9034c74adb5d6e584116bc20838aedc15218a1d49eea43e04f31072044", expectedPendingTx)
     )
 
     forAll(validCases) { (input, expectedOutput) =>

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountMockDataHelper.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountMockDataHelper.scala
@@ -211,6 +211,17 @@ case class AccountMockDataHelper(genesis: Boolean)
     // mock getNonExecutableTransactionsMapInspect method call
     Mockito.when(memoryPool.getNonExecutableTransactionsMapInspect).thenReturn(nonExecutableTxsMapInspect)
 
+    // mock getTransactionById
+    Mockito.when(memoryPool.getTransactionById(ArgumentMatchers.anyString())).thenAnswer { answer =>
+      val input: String = answer.getArgument(0)
+      input match {
+        case v if (v == executableTx1.id) => Optional.of(executableTx1.asInstanceOf[SidechainTypes#SCAT])
+        case v if (v == executableTx2.id) => Optional.of(executableTx2.asInstanceOf[SidechainTypes#SCAT])
+        case v if (v == executableTx3.id) => Optional.of(executableTx3.asInstanceOf[SidechainTypes#SCAT])
+        case _ => Optional.empty()
+      }
+    }
+
     // return the mocked memory pool
     memoryPool
   }


### PR DESCRIPTION
## Description
eth_getTransactionByHash rpc method was changed in order to retrieve also transactions still in the mempool, as it should  according to our internal documentation available on postman.

## Jira Ticket
[SDK_1532](https://horizenlabs.atlassian.net/browse/SDK-1532?atlOrigin=eyJpIjoiM2Q0N2JmZDFjMGY3NDJlMmEyNDYxMDNhYTZlYTlkMWIiLCJwIjoiaiJ9)

## Changes
In EthService.scala added a new method that looks for a transaction first in the History and, if not found, in the mempool.

## Breaking Changes

## Checks
- [ X] Project Builds
- [ X] Project passes tests and checks
- [ ] Updated documentation accordingly
- [ ] Breaking changes have been correctly tagged and notified
 
## Additional information
