### PR TITLE
Fix min storage version for recovery

### DIFF
--- a/examples/utxo/simpleapp/src/main/java/io/horizen/examples/SimpleAppModule.java
+++ b/examples/utxo/simpleapp/src/main/java/io/horizen/examples/SimpleAppModule.java
@@ -116,7 +116,7 @@ public class SimpleAppModule extends SidechainAppModule
 
         bind(Storage.class)
                 .annotatedWith(Names.named("SecretStorage"))
-                .toInstance(new VersionedLevelDbStorageAdapter(secretStore, 1));
+                .toInstance(new VersionedLevelDbStorageAdapter(secretStore, 5));
         bind(Storage.class)
                 .annotatedWith(Names.named("WalletBoxStorage"))
                 .toInstance(new VersionedLevelDbStorageAdapter(walletBoxStore, maxHistoryRewritingLength));
@@ -140,10 +140,10 @@ public class SimpleAppModule extends SidechainAppModule
                 .toInstance(new VersionedLevelDbStorageAdapter(stateUtxoMerkleTreeStore, maxHistoryRewritingLength));
         bind(Storage.class)
                 .annotatedWith(Names.named("HistoryStorage"))
-                .toInstance(new VersionedLevelDbStorageAdapter(historyStore, 1));
+                .toInstance(new VersionedLevelDbStorageAdapter(historyStore, 5));
         bind(Storage.class)
                 .annotatedWith(Names.named("ConsensusStorage"))
-                .toInstance(new VersionedLevelDbStorageAdapter(consensusStore, 1));
+                .toInstance(new VersionedLevelDbStorageAdapter(consensusStore, 5));
         bind(Storage.class)
                 .annotatedWith(Names.named("BackupStorage"))
                 .toInstance(new VersionedLevelDbStorageAdapter(backupStore, maxHistoryRewritingLength));

--- a/sdk/src/main/scala/io/horizen/account/AccountSidechainApp.scala
+++ b/sdk/src/main/scala/io/horizen/account/AccountSidechainApp.scala
@@ -93,12 +93,12 @@ class AccountSidechainApp @Inject()
 
   // Init all storages
   protected val sidechainHistoryStorage = new AccountHistoryStorage(
-    registerClosableResource(new VersionedLevelDbStorageAdapter(historyStore, 1)),
+    registerClosableResource(new VersionedLevelDbStorageAdapter(historyStore, 5)),
     sidechainTransactionsCompanion,
     params)
 
   protected val sidechainSecretStorage = new SidechainSecretStorage(
-    registerClosableResource(new VersionedLevelDbStorageAdapter(secretStore, 1)),
+    registerClosableResource(new VersionedLevelDbStorageAdapter(secretStore, 5)),
     sidechainSecretsCompanion)
 
   protected val stateMetadataStorage = new AccountStateMetadataStorage(
@@ -107,7 +107,7 @@ class AccountSidechainApp @Inject()
   protected val stateDbStorage: LevelDBDatabase = registerClosableResource(new LevelDBDatabase(dataDirAbsolutePath + "/evm-state"))
 
   protected val consensusDataStorage = new ConsensusDataStorage(
-    registerClosableResource(new VersionedLevelDbStorageAdapter(consensusStore, 1)))
+    registerClosableResource(new VersionedLevelDbStorageAdapter(consensusStore, 5)))
 
   // Append genesis secrets if we start the node first time
   if(sidechainSecretStorage.isEmpty) {


### PR DESCRIPTION
## Description
Version 1.0.1 changed the storage versions to keep to 1 for some storages, but that was too much to support the storage recovery procedure in case of crash douring the node update.
This PR increases the minimum versions from 1 to 5.
Following tests were failing with 1 and now are ok:
sc_evm_storage_recovery.py
sc_storage_recovery_with_csw.py
sc_storage_recovery_without_csw.py

