### PR TITLE
SDK-953: wrapping log.debug statements in anonymous functions to lazy…

### DIFF
--- a/sdk/src/main/scala/io/horizen/account/AccountSidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/account/AccountSidechainNodeViewHolder.scala
@@ -77,11 +77,11 @@ class AccountSidechainNodeViewHolder(sidechainSettings: SidechainSettings,
 
         log.debug(s"history bestBlockId = $historyVersion, stateVersion = $checkedStateVersion")
 
-        log.debug("{}", (() => {
+        log.whenDebugEnabled {
           val height_h = restoredHistory.blockInfoById(restoredHistory.bestBlockId).height
           val height_s = restoredHistory.blockInfoById(checkedStateVersion).height
           s"history height = $height_h, state height = $height_s"
-        }).apply)
+        }
 
         if (historyVersion == checkedStateVersion) {
           log.info("state and history storages are consistent")

--- a/sdk/src/main/scala/io/horizen/account/AccountSidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/account/AccountSidechainNodeViewHolder.scala
@@ -77,9 +77,11 @@ class AccountSidechainNodeViewHolder(sidechainSettings: SidechainSettings,
 
         log.debug(s"history bestBlockId = $historyVersion, stateVersion = $checkedStateVersion")
 
-        val height_h = restoredHistory.blockInfoById(restoredHistory.bestBlockId).height
-        val height_s = restoredHistory.blockInfoById(checkedStateVersion).height
-        log.debug(s"history height = $height_h, state height = $height_s")
+        log.debug("{}", (() => {
+          val height_h = restoredHistory.blockInfoById(restoredHistory.bestBlockId).height
+          val height_s = restoredHistory.blockInfoById(checkedStateVersion).height
+          s"history height = $height_h, state height = $height_s"
+        }).apply)
 
         if (historyVersion == checkedStateVersion) {
           log.info("state and history storages are consistent")

--- a/sdk/src/main/scala/io/horizen/block/MainchainBlockReference.scala
+++ b/sdk/src/main/scala/io/horizen/block/MainchainBlockReference.scala
@@ -271,7 +271,7 @@ object MainchainBlockReference extends SparkzLogging {
           offset += certificatesCount.size()
 
           while (certificates.size < certificatesCount.value()) {
-            log.debug(s"Parse Mainchain certificate: ${BytesUtils.toHexString(util.Arrays.copyOfRange(mainchainBlockBytes, offset, mainchainBlockBytes.length))}")
+            log.debug("Parse Mainchain certificate: {}", (() => BytesUtils.toHexString(util.Arrays.copyOfRange(mainchainBlockBytes, offset, mainchainBlockBytes.length))).apply)
             val c: WithdrawalEpochCertificate = WithdrawalEpochCertificate.parse(mainchainBlockBytes, offset)
             certificates = certificates :+ c
             offset += c.size

--- a/sdk/src/main/scala/io/horizen/block/MainchainBlockReference.scala
+++ b/sdk/src/main/scala/io/horizen/block/MainchainBlockReference.scala
@@ -271,7 +271,9 @@ object MainchainBlockReference extends SparkzLogging {
           offset += certificatesCount.size()
 
           while (certificates.size < certificatesCount.value()) {
-            log.debug("Parse Mainchain certificate: {}", (() => BytesUtils.toHexString(util.Arrays.copyOfRange(mainchainBlockBytes, offset, mainchainBlockBytes.length))).apply)
+            log.whenDebugEnabled {
+              s"Parse Mainchain certificate: ${BytesUtils.toHexString(util.Arrays.copyOfRange(mainchainBlockBytes, offset, mainchainBlockBytes.length))}"
+            }
             val c: WithdrawalEpochCertificate = WithdrawalEpochCertificate.parse(mainchainBlockBytes, offset)
             certificates = certificates :+ c
             offset += c.size

--- a/sdk/src/main/scala/io/horizen/history/validation/ConsensusValidator.scala
+++ b/sdk/src/main/scala/io/horizen/history/validation/ConsensusValidator.scala
@@ -179,15 +179,15 @@ class ConsensusValidator[
 
   //Verify that forging stake info in block is correct (including stake), exist in history and had enough stake to be forger
   private[horizen] def verifyForgingStakeInfo(header: SidechainBlockHeaderBase, stakeConsensusEpochInfo: StakeConsensusEpochInfo, vrfOutput: VrfOutput, percentageForkApplied: Boolean, activeSlotCoefficient: Double): Unit = {
-    log.debug("{}", (() => {
+    log.whenDebugEnabled {
       s"Verify Forging stake info against root hash: ${BytesUtils.toHexString(stakeConsensusEpochInfo.rootHash)} by merkle path ${header.forgingStakeMerklePath.bytes().deep.mkString}"
-    }).apply)
+    }
 
     val forgingStakeIsCorrect = stakeConsensusEpochInfo.rootHash.sameElements(header.forgingStakeMerklePath.apply(header.forgingStakeInfo.hash))
     if (!forgingStakeIsCorrect) {
-      log.debug("{}", (() => {
+      log.whenDebugEnabled {
         s"Actual stakeInfo: rootHash: ${BytesUtils.toHexString(stakeConsensusEpochInfo.rootHash)}, totalStake: ${stakeConsensusEpochInfo.totalStake}"
-      }).apply)
+      }
       throw new IllegalStateException(s"Forging stake merkle path in block ${header.id} is inconsistent to stakes merkle root hash ${BytesUtils.toHexString(stakeConsensusEpochInfo.rootHash)}")
     }
 

--- a/sdk/src/main/scala/io/horizen/history/validation/ConsensusValidator.scala
+++ b/sdk/src/main/scala/io/horizen/history/validation/ConsensusValidator.scala
@@ -179,11 +179,15 @@ class ConsensusValidator[
 
   //Verify that forging stake info in block is correct (including stake), exist in history and had enough stake to be forger
   private[horizen] def verifyForgingStakeInfo(header: SidechainBlockHeaderBase, stakeConsensusEpochInfo: StakeConsensusEpochInfo, vrfOutput: VrfOutput, percentageForkApplied: Boolean, activeSlotCoefficient: Double): Unit = {
-    log.debug(s"Verify Forging stake info against root hash: ${BytesUtils.toHexString(stakeConsensusEpochInfo.rootHash)} by merkle path ${header.forgingStakeMerklePath.bytes().deep.mkString}")
+    log.debug("{}", (() => {
+      s"Verify Forging stake info against root hash: ${BytesUtils.toHexString(stakeConsensusEpochInfo.rootHash)} by merkle path ${header.forgingStakeMerklePath.bytes().deep.mkString}"
+    }).apply)
 
     val forgingStakeIsCorrect = stakeConsensusEpochInfo.rootHash.sameElements(header.forgingStakeMerklePath.apply(header.forgingStakeInfo.hash))
     if (!forgingStakeIsCorrect) {
-      log.debug(s"Actual stakeInfo: rootHash: ${BytesUtils.toHexString(stakeConsensusEpochInfo.rootHash)}, totalStake: ${stakeConsensusEpochInfo.totalStake}")
+      log.debug("{}", (() => {
+        s"Actual stakeInfo: rootHash: ${BytesUtils.toHexString(stakeConsensusEpochInfo.rootHash)}, totalStake: ${stakeConsensusEpochInfo.totalStake}"
+      }).apply)
       throw new IllegalStateException(s"Forging stake merkle path in block ${header.id} is inconsistent to stakes merkle root hash ${BytesUtils.toHexString(stakeConsensusEpochInfo.rootHash)}")
     }
 

--- a/sdk/src/main/scala/io/horizen/utxo/SidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/utxo/SidechainNodeViewHolder.scala
@@ -80,11 +80,12 @@ class SidechainNodeViewHolder(sidechainSettings: SidechainSettings,
           case Success(checkedState) => {
             val checkedStateVersion = checkedState.version
 
-            log.debug(s"history bestBlockId = ${historyVersion}, stateVersion = ${checkedStateVersion}")
-
-            val height_h = restoredHistory.blockInfoById(restoredHistory.bestBlockId).height
-            val height_s = restoredHistory.blockInfoById(versionToId(checkedStateVersion)).height
-            log.debug(s"history height = ${height_h}, state height = ${height_s}")
+            log.debug("{}", (() => s"history bestBlockId = $historyVersion, stateVersion = $checkedStateVersion").apply)
+            log.debug("{}", (() => {
+              val height_h = restoredHistory.blockInfoById(restoredHistory.bestBlockId).height
+              val height_s = restoredHistory.blockInfoById(versionToId(checkedStateVersion)).height
+              s"history height = $height_h, state height = $height_s"
+            }).apply)
 
             if (historyVersion == checkedStateVersion) {
               log.info("state and history storages are consistent")

--- a/sdk/src/main/scala/io/horizen/utxo/SidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/utxo/SidechainNodeViewHolder.scala
@@ -80,12 +80,14 @@ class SidechainNodeViewHolder(sidechainSettings: SidechainSettings,
           case Success(checkedState) => {
             val checkedStateVersion = checkedState.version
 
-            log.debug("{}", (() => s"history bestBlockId = $historyVersion, stateVersion = $checkedStateVersion").apply)
-            log.debug("{}", (() => {
+            log.whenDebugEnabled {
+              s"history bestBlockId = $historyVersion, stateVersion = $checkedStateVersion"
+            }
+            log.whenDebugEnabled {
               val height_h = restoredHistory.blockInfoById(restoredHistory.bestBlockId).height
               val height_s = restoredHistory.blockInfoById(versionToId(checkedStateVersion)).height
               s"history height = $height_h, state height = $height_s"
-            }).apply)
+            }
 
             if (historyVersion == checkedStateVersion) {
               log.info("state and history storages are consistent")


### PR DESCRIPTION
… evaluate them only if debug log level is on

## Description
Since log.debug statements are executed only when the debug level is set in the config, we don't want to waste any computational resources to evaluate complex functions if we're not going to log anything. Using the anonymous functions as arguments, we can move a code block inside it and it will only be evaluated if the debug level is on.

## Jira Ticket
[SDK-953](https://horizenlabs.atlassian.net/browse/SDK-953)

## Changes
log.debug statements

## Breaking Changes
/

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
 
## Additional information


[SDK-953]: https://horizenlabs.atlassian.net/browse/SDK-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ