### PR TITLE
MC multisig addresses in ZenDAO native smart contract

### DIFF
--- a/qa/SidechainTestFramework/account/ac_use_smart_contract.py
+++ b/qa/SidechainTestFramework/account/ac_use_smart_contract.py
@@ -52,7 +52,7 @@ class SmartContract:
             SmartContract.__load(
                 SmartContract.__find_contract_data_path(
                     SmartContract.__split_path(
-                        contract_path.removesuffix(".sol")))))
+                        contract_path.rstrip(".sol")))))
         self.Functions = dict()
         for obj in self.Abi:
             if obj['type'] == 'function':
@@ -385,7 +385,7 @@ class SmartContract:
 
     @staticmethod
     def __split_path(contr: str):
-        return contr.removesuffix('.sol').split('/')[-1].split('\\')[-1]
+        return contr.rstrip('.sol').split('/')[-1].split('\\')[-1]
 
     @staticmethod
     def __get_input_type(inp: dict):
@@ -412,7 +412,7 @@ class SmartContract:
         sol_files = []
         for root, __, files in os.walk(base):
             for file in files:
-                if file.endswith(".json") and not file.endswith(".dbg.json") and file.removesuffix(".json") == contr:
+                if file.endswith(".json") and not file.endswith(".dbg.json") and file.rstrip(".json") == contr:
                     sol_files.append(os.path.join(root, file))
         if len(sol_files) < 1:
             raise RuntimeError(

--- a/qa/SidechainTestFramework/account/ac_use_smart_contract.py
+++ b/qa/SidechainTestFramework/account/ac_use_smart_contract.py
@@ -52,7 +52,7 @@ class SmartContract:
             SmartContract.__load(
                 SmartContract.__find_contract_data_path(
                     SmartContract.__split_path(
-                        contract_path.rstrip(".sol")))))
+                        contract_path.removesuffix(".sol")))))
         self.Functions = dict()
         for obj in self.Abi:
             if obj['type'] == 'function':
@@ -385,7 +385,7 @@ class SmartContract:
 
     @staticmethod
     def __split_path(contr: str):
-        return contr.rstrip('.sol').split('/')[-1].split('\\')[-1]
+        return contr.removesuffix('.sol').split('/')[-1].split('\\')[-1]
 
     @staticmethod
     def __get_input_type(inp: dict):
@@ -412,7 +412,7 @@ class SmartContract:
         sol_files = []
         for root, __, files in os.walk(base):
             for file in files:
-                if file.endswith(".json") and not file.endswith(".dbg.json") and file.rstrip(".json") == contr:
+                if file.endswith(".json") and not file.endswith(".dbg.json") and file.removesuffix(".json") == contr:
                     sol_files.append(os.path.join(root, file))
         if len(sol_files) < 1:
             raise RuntimeError(

--- a/qa/SidechainTestFramework/account/httpCalls/transaction/sendMultisigKeysOwnership.py
+++ b/qa/SidechainTestFramework/account/httpCalls/transaction/sendMultisigKeysOwnership.py
@@ -1,0 +1,33 @@
+import json
+
+
+def sendMultisigKeysOwnership(sidechainNode, *, sc_address, mc_addr, mc_signatures, redeemScript,
+                      nonce=None, gas_limit=2300000, max_priority_fee_per_gas=900000000,
+                      max_fee_per_gas=900000000, api_key=None):
+    j = {
+        "ownershipInfo": {
+            "scAddress" : sc_address,
+            "mcMultisigAddress": mc_addr,
+            "mcSignatures": mc_signatures,
+            "redeemScript": redeemScript
+        },
+        "nonce": nonce,
+        "gasInfo": {
+            "gasLimit": gas_limit,
+            "maxFeePerGas": max_fee_per_gas,
+            "maxPriorityFeePerGas": max_priority_fee_per_gas
+        }
+    }
+
+    request = json.dumps(j)
+    if api_key is not None:
+        response = sidechainNode.transaction_sendMultisigKeysOwnership(request, api_key)
+    else:
+        response = sidechainNode.transaction_sendMultisigKeysOwnership(request)
+
+
+    if "result" in response:
+        return response["result"]
+
+    raise RuntimeError("Something went wrong, see {}".format(str(response)))
+

--- a/qa/run_sc_tests.sh
+++ b/qa/run_sc_tests.sh
@@ -123,6 +123,7 @@ testScriptsEvm=(
     'account_websocket_server_sync.py'
     'account_websocket_server_rpc.py'
     'sc_evm_mc_addr_ownership.py'
+    'sc_evm_mc_addr_ownership_multisig.py'
     'sc_evm_mc_addr_ownership_perf_test.py'
     'sc_evm_proxy_nsc.py'
     'sc_evm_seedernode.py'

--- a/qa/sc_evm_mc_addr_ownership_multisig.py
+++ b/qa/sc_evm_mc_addr_ownership_multisig.py
@@ -1,0 +1,573 @@
+#!/usr/bin/env python3
+import json
+import logging
+import pprint
+from decimal import Decimal
+
+from eth_abi import decode
+from eth_utils import add_0x_prefix, remove_0x_prefix, event_signature_to_log_topic, encode_hex, \
+    function_signature_to_4byte_selector, to_checksum_address
+
+from SidechainTestFramework.account.ac_chain_setup import AccountChainSetup
+from SidechainTestFramework.account.ac_use_smart_contract import SmartContract
+from SidechainTestFramework.account.ac_utils import format_evm, estimate_gas, format_eoa
+from SidechainTestFramework.account.httpCalls.transaction.getKeysOwnership import getKeysOwnership
+from SidechainTestFramework.account.httpCalls.transaction.removeKeysOwnership import removeKeysOwnership
+from SidechainTestFramework.account.httpCalls.transaction.sendKeysOwnership import sendKeysOwnership
+from SidechainTestFramework.account.httpCalls.transaction.sendMultisigKeysOwnership import sendMultisigKeysOwnership
+from SidechainTestFramework.account.simple_proxy_contract import SimpleProxyContract
+from SidechainTestFramework.account.utils import MC_ADDR_OWNERSHIP_SMART_CONTRACT_ADDRESS, \
+    INTEROPERABILITY_FORK_EPOCH, ZENDAO_FORK_EPOCH
+from SidechainTestFramework.scutil import generate_next_block, EVM_APP_SLOT_TIME
+from httpCalls.transaction.allTransactions import allTransactions
+from test_framework.util import (assert_equal, assert_true, fail, hex_str_to_bytes, assert_false,
+                                 forward_transfer_to_sidechain)
+
+"""
+Configuration: 
+    - 2 SC node
+    - 1 MC node
+
+Test:
+    Do some test for handling relations between owned SC/MC addresses via native smart contract call:
+    - Add ownership relation and check event
+    - Get the list of MC addresses associated to a SC address
+    - Remove an association and check event
+    - Interoperability test: same tests as before but using a proxy evm smart contract
+    Do some negative tests     
+"""
+
+
+def get_address_with_balance(input_list):
+    """
+    Assumes the list in input is obtained via the RPC cmd listaddressgroupings()
+    """
+    for group in input_list:
+        for record in group:
+            addr = record[0]
+            val = record[1]
+            if val > 0:
+                return addr, val
+    return None, 0
+
+
+def check_add_ownership_event(event, sc_addr, mc_addr, op="add"):
+    if op == "add":
+        sig = 'AddMcAddrOwnership(address,bytes3,bytes32)'
+    elif op == "remove":
+        sig = 'RemoveMcAddrOwnership(address,bytes3,bytes32)'
+    else:
+        sig = ""
+        assert_false("Invalid op = " + op)
+
+    assert_equal(2, len(event['topics']), "Wrong number of topics in event")
+    event_id = remove_0x_prefix(event['topics'][0])
+    event_signature = remove_0x_prefix(
+        encode_hex(event_signature_to_log_topic(sig)))
+    assert_equal(event_signature, event_id, "Wrong event signature in topics")
+
+    evt_sc_addr = decode(['address'], hex_str_to_bytes(event['topics'][1][2:]))[0][2:]
+    assert_equal(sc_addr, evt_sc_addr, "Wrong sc_addr address in topics")
+
+    (mca3, mca32) = decode(['bytes3', 'bytes32'], hex_str_to_bytes(event['data'][2:]))
+    evt_mc_addr = (mca3 + mca32).decode('utf-8')
+    assert_equal(mc_addr, evt_mc_addr, "Wrong mc_addr string in topics")
+
+
+def forge_and_check_receipt(self, sc_node, tx_hash, expected_receipt_status=1, sc_addr=None, mc_addr=None,
+                            evt_op="add"):
+    generate_next_block(sc_node, "first node")
+    self.sc_sync_all()
+
+    check_receipt(sc_node, tx_hash, expected_receipt_status, sc_addr, mc_addr, evt_op)
+
+
+def check_receipt(sc_node, tx_hash, expected_receipt_status=1, sc_addr=None, mc_addr=None, evt_op="add"):
+    # check receipt
+    receipt = sc_node.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_hash))
+    if 'result' not in receipt or receipt['result'] is None:
+        raise Exception('Rpc eth_getTransactionReceipt cmd failed:{}'.format(json.dumps(receipt, indent=2)))
+
+    status = int(receipt['result']['status'], 16)
+    assert_equal(expected_receipt_status, status)
+
+    # if we have a successful receipt and valid func parameters, check the event
+    if expected_receipt_status == 1:
+        if (sc_addr is not None) and (mc_addr is not None):
+            assert_equal(1, len(receipt['result']['logs']), "Wrong number of events in receipt")
+            event = receipt['result']['logs'][0]
+            check_add_ownership_event(event, sc_addr, mc_addr, evt_op)
+    else:
+        assert_equal(0, len(receipt['result']['logs']), "No events should be in receipt")
+
+
+def check_get_key_ownership(abi_return_value, exp_dict):
+    # the location of the data part of the first (the only one in this case) parameter (dynamic type), measured in bytes
+    # from the start of the return data block. In this case 32 (0x20)
+    abi_return_value_bytes = hex_str_to_bytes(abi_return_value)
+    sc_associations_dict = extract_sc_associations_list(abi_return_value_bytes)
+
+    pprint.pprint(sc_associations_dict)
+    res = json.dumps(sc_associations_dict)
+    assert_equal(res, json.dumps(dict(sorted(exp_dict.items()))))
+
+
+def extract_sc_associations_list(abi_return_value_bytes):
+    start_data_offset = decode(['uint32'], abi_return_value_bytes[0:32])[0]
+    assert_equal(start_data_offset, 32)
+    end_offset = start_data_offset + 32  # read 32 bytes
+    list_size = decode(['uint32'], abi_return_value_bytes[start_data_offset:end_offset])[0]
+    sc_associations_dict = {}
+    for i in range(list_size):
+        start_offset = end_offset
+        end_offset = start_offset + 96  # read (32 + 32 + 32) bytes
+        (address_pref, mca3, mca32) = decode(['address', 'bytes3', 'bytes32'],
+                                             abi_return_value_bytes[start_offset:end_offset])
+        sc_address_checksum_fmt = to_checksum_address(address_pref)
+        print("sc addr=" + sc_address_checksum_fmt)
+        if sc_address_checksum_fmt in sc_associations_dict:
+            mc_addr_list = sc_associations_dict.get(sc_address_checksum_fmt)
+        else:
+            sc_associations_dict[sc_address_checksum_fmt] = []
+            mc_addr_list = []
+        mc_addr = (mca3 + mca32).decode('utf-8')
+        mc_addr_list.append(mc_addr)
+        print("mc addr=" + mc_addr)
+        sc_associations_dict[sc_address_checksum_fmt] = mc_addr_list
+    return sc_associations_dict
+
+
+class SCEvmMcMultisigAddressOwnership(AccountChainSetup):
+    def __init__(self):
+        super().__init__(block_timestamp_rewind=1500 * EVM_APP_SLOT_TIME * INTEROPERABILITY_FORK_EPOCH,
+                         number_of_sidechain_nodes=2)
+
+    def run_test(self):
+        ft_amount_in_zen = Decimal('500.0')
+
+        self.sc_ac_setup(ft_amount_in_zen=ft_amount_in_zen)
+
+        sc_node = self.sc_nodes[0]
+        mc_node = self.nodes[0]
+
+        sc_address = remove_0x_prefix(self.evm_address)
+        sc_address_checksum_fmt = to_checksum_address(self.evm_address)
+
+        sc_node2 = self.sc_nodes[1]
+        sc_address2 = sc_node2.wallet_createPrivateKeySecp256k1()["result"]["proposition"]["address"]
+
+        # transfer some fund from MC to SC2
+        forward_transfer_to_sidechain(self.sc_nodes_bootstrap_info.sidechain_id,
+                                      self.nodes[0],
+                                      sc_address2,
+                                      ft_amount_in_zen,
+                                      self.mc_return_address)
+        self.sc_sync_all()
+
+        self.block_id = generate_next_block(sc_node, "first node", force_switch_to_next_epoch=True)
+        self.sc_sync_all()
+
+        # reach the ZenDao fork
+        current_best_epoch = sc_node.block_forgingInfo()["result"]["bestBlockEpochNumber"]
+
+        for i in range(0, ZENDAO_FORK_EPOCH - current_best_epoch):
+            generate_next_block(sc_node, "first node", force_switch_to_next_epoch=True)
+            self.sc_sync_all()
+
+        addresses = []
+        addr_objects = []
+        mc_signatures = []
+        rpc_array_param = []
+
+        NUM_OF_ADDR_IN_MULTISIG = 3
+        THRESHOLD_SIGNATURE_VALUE = 2
+        assert_true(THRESHOLD_SIGNATURE_VALUE <= NUM_OF_ADDR_IN_MULTISIG)
+
+        # Generate some new address and prepare rpc command input
+        for i in range(NUM_OF_ADDR_IN_MULTISIG):
+            addresses.append(mc_node.getnewaddress())
+            addr_objects.append(mc_node.validateaddress(addresses[i]))
+            rpc_array_param.append(addr_objects[i]['pubkey'])
+
+        # Create the multi-sig address as combination of the single addresses created above
+        m_sig_obj = mc_node.createmultisig(THRESHOLD_SIGNATURE_VALUE, rpc_array_param)
+        mc_multisig_address_1 = m_sig_obj["address"]
+        redeemScript_1 = m_sig_obj["redeemScript"]
+
+        print("  val mcMultiSigAddr1: String = \"{}\"".format(mc_multisig_address_1))
+        print("  val redeemScript1: String = \"{}\"".format(redeemScript_1))
+
+        for i in range(NUM_OF_ADDR_IN_MULTISIG):
+            if i <= THRESHOLD_SIGNATURE_VALUE:
+                mc_signatures.append(mc_node.signmessage(addresses[i], mc_multisig_address_1 + sc_address_checksum_fmt))
+                print("  val mcAddrStr: String = \"{}\"".format(addresses[i]))
+                print("  val mcSignatureStr: String = \"{}\"".format(mc_signatures[i]))
+
+        ret = sendMultisigKeysOwnership(sc_node,
+                                        sc_address=sc_address,
+                                        mc_addr=mc_multisig_address_1,
+                                        mc_signatures=mc_signatures,
+                                        redeemScript=redeemScript_1)
+
+
+        tx_hash = ret['transactionId']
+        self.sc_sync_all()
+
+        # check the tx adding an ownership is included in the block and the receipt is succesful
+        forge_and_check_receipt(self, sc_node, tx_hash, sc_addr=sc_address, mc_addr=mc_multisig_address_1)
+
+        # use an uncompressed pub key for generating a multisig address
+        addresses = []
+        mc_signatures = []
+        rpc_array_param = []
+
+        # a priv key with the corrisponding taddr and uncompressed pub key. Thos test vectors are used for creating a redeem script
+        # containing this pub key format
+        priv_key_unc = "cUHcJUdzjNceFfUhLQtrrbjPtHo5NBP9ZofNxdSFnQqXijao761c"
+        addr_unc = "ztTw2K532ewo9gynBJv7FFUgbD19Wpifv8G"
+        uncomp_pubkey = "049bff9c9b5d0976aed138669e050b6b202aba89d16b5d3dfe4952a87d1888418fcae1a517d1dca6c61a7326dcb2f76bd5ff713b2c30f11a68a818bb074a2d4023"
+
+        # import the key in wallet so that we can sign
+        mc_node.importprivkey(priv_key_unc)
+
+        addresses.append(addr_unc)
+        rpc_array_param.append(uncomp_pubkey)
+
+        # Generate some new address and prepare rpc command input
+        for i in range(NUM_OF_ADDR_IN_MULTISIG - 1):
+            addresses.append(mc_node.getnewaddress())
+            rpc_array_param.append(mc_node.validateaddress(addresses[i + 1])['pubkey'])
+
+        # Create the multi-sig address as combination of the single addresses created above
+        m_sig_obj = mc_node.createmultisig(THRESHOLD_SIGNATURE_VALUE, rpc_array_param)
+        mc_multisig_address_2 = m_sig_obj["address"]
+        redeemScript_2 = m_sig_obj["redeemScript"]
+
+
+        for i in range(NUM_OF_ADDR_IN_MULTISIG):
+            if i <= THRESHOLD_SIGNATURE_VALUE:
+                mc_signatures.append(mc_node.signmessage(addresses[i], mc_multisig_address_2 + sc_address_checksum_fmt))
+
+
+        print("  val mcMultiSigAddr2: String = \"{}\"".format(mc_multisig_address_2))
+        print("  val redeemScript2: String = \"{}\"".format(redeemScript_2))
+
+        for i in range(NUM_OF_ADDR_IN_MULTISIG):
+            if i <= THRESHOLD_SIGNATURE_VALUE:
+                mc_signatures.append(mc_node.signmessage(addresses[i], mc_multisig_address_2 + sc_address_checksum_fmt))
+                print("  val mcAddrStr: String = \"{}\"".format(addresses[i]))
+                print("  val mcSignatureStr: String = \"{}\"".format(mc_signatures[i]))
+
+        ret = sendMultisigKeysOwnership(sc_node,
+                                        sc_address=sc_address,
+                                        mc_addr=mc_multisig_address_2,
+                                        mc_signatures=mc_signatures,
+                                        redeemScript=redeemScript_2)
+
+        tx_hash = ret['transactionId']
+        self.sc_sync_all()
+
+        # check the tx adding an ownership is included in the block and the receipt is succesful
+        forge_and_check_receipt(self, sc_node, tx_hash, sc_addr=sc_address, mc_addr=mc_multisig_address_2)
+
+        # add an ordinary owned mc address linked to the same sc address, and use a different sc address format, we should
+        # support that
+        taddr_1 = mc_node.getnewaddress()
+        mc_signature_taddr_1 = mc_node.signmessage(taddr_1, sc_address_checksum_fmt)
+
+        ret = sendKeysOwnership(sc_node,
+                                sc_address=to_checksum_address(sc_address),
+                                mc_addr=taddr_1,
+                                mc_signature=mc_signature_taddr_1)
+
+        tx_hash = ret['transactionId']
+        forge_and_check_receipt(self, sc_node, tx_hash, sc_addr=sc_address, mc_addr=taddr_1)
+
+        # check we have both association and only them (and we support different sc address formats)
+        ret = getKeysOwnership(sc_node, sc_address=sc_address)
+        ret2 = getKeysOwnership(sc_node, sc_address=to_checksum_address(sc_address))
+        assert_equal(ret, ret2)
+
+        # check we have just one sc address association
+        assert_true(len(ret['keysOwnership']) == 1)
+        # check we have two mc address associated to sc address
+        assert_true(len(ret['keysOwnership'][sc_address_checksum_fmt]) == 3)
+        # check we have exactly the expected mc address
+        assert_true(mc_multisig_address_1 in ret['keysOwnership'][sc_address_checksum_fmt])
+        assert_true(mc_multisig_address_2 in ret['keysOwnership'][sc_address_checksum_fmt])
+        assert_true(taddr_1 in ret['keysOwnership'][sc_address_checksum_fmt])
+
+        ret = removeKeysOwnership(sc_node,
+                                  sc_address=sc_address,
+                                  mc_addr=taddr_1)
+
+        tx_hash = ret['transactionId']
+        forge_and_check_receipt(self, sc_node, tx_hash, sc_addr=sc_address, mc_addr=taddr_1, evt_op="remove")
+
+        ret = getKeysOwnership(sc_node, sc_address=sc_address)
+
+        # check we have just one sc address association
+        assert_true(len(ret['keysOwnership']) == 1)
+        # check we have only one mc address associated to sc address
+        assert_true(len(ret['keysOwnership'][sc_address_checksum_fmt]) == 2)
+        # check we have exactly that mc address
+        assert_true(mc_multisig_address_1 in ret['keysOwnership'][sc_address_checksum_fmt])
+        assert_true(mc_multisig_address_2 in ret['keysOwnership'][sc_address_checksum_fmt])
+        assert_true(taddr_1 not in ret['keysOwnership'][sc_address_checksum_fmt])
+
+        removeKeysOwnership(sc_node,
+                            sc_address=to_checksum_address(sc_address),
+                            mc_addr=mc_multisig_address_1)
+
+        generate_next_block(sc_node, "first node")
+        self.sc_sync_all()
+
+        list_associations_sc_address = getKeysOwnership(sc_node, sc_address=sc_address)
+
+        # check we have just one sc address association
+        assert_true(len(list_associations_sc_address['keysOwnership']) == 1)
+        # check we have the expected number
+        assert_true(len(list_associations_sc_address['keysOwnership'][sc_address_checksum_fmt]) == 1)
+        assert_true(mc_multisig_address_2 in list_associations_sc_address['keysOwnership'][sc_address_checksum_fmt])
+
+        # add an association for a different sc address
+        taddr_sc2_1 = mc_node.getnewaddress()
+        sc_address2_checksum_fmt = to_checksum_address(sc_address2)
+        mc_signature_sc2 = mc_node.signmessage(taddr_sc2_1, sc_address2_checksum_fmt)
+        print("scAddr: " + sc_address2_checksum_fmt)
+        print("mcAddr: " + taddr_sc2_1)
+        print("mcSignature: " + mc_signature_sc2)
+
+        ret = sendKeysOwnership(sc_node2,
+                                sc_address=sc_address2,
+                                mc_addr=taddr_sc2_1,
+                                mc_signature=mc_signature_sc2)
+        self.sc_sync_all()
+        tx_hash = ret['transactionId']
+        forge_and_check_receipt(self, sc_node, tx_hash, sc_addr=sc_address2, mc_addr=taddr_sc2_1)
+
+        list_all_associations = getKeysOwnership(sc_node)
+        pprint.pprint(list_all_associations)
+
+        # check we have two sc address associations
+        assert_equal(2, len(list_all_associations['keysOwnership']))
+        # check we have the expected numbers
+        assert_equal(1, len(list_all_associations['keysOwnership'][sc_address_checksum_fmt]))
+        assert_equal(1, len(list_all_associations['keysOwnership'][sc_address2_checksum_fmt]))
+        assert_true(taddr_sc2_1 in list_all_associations['keysOwnership'][sc_address2_checksum_fmt])
+
+        # negative cases
+        # 1. try to use invalid parameters
+        # 1.1 illegal sc address
+        invalid_sc_addr = "1234h"
+        try:
+            sendMultisigKeysOwnership(sc_node,
+                                      sc_address=invalid_sc_addr,
+                                      mc_addr=mc_multisig_address_2,
+                                      mc_signatures=mc_signatures,
+                                      redeemScript=m_sig_obj["redeemScript"])
+        except Exception as err:
+            print("Expected exception thrown: {}".format(str(err)))
+            assert_true("Account " + invalid_sc_addr + " is invalid " in str(err))
+        else:
+            fail("invalid sc address should not work")
+
+        # 1.2 illegal mc address
+        try:
+            sendMultisigKeysOwnership(sc_node,
+                                      sc_address=sc_address,
+                                      mc_addr="1LMcKyPmwebfygoeZP8E9jAMS2BcgH3Yip",
+                                      mc_signatures=mc_signatures,
+                                      redeemScript=m_sig_obj["redeemScript"])
+        except RuntimeError as err:
+            print("Expected exception thrown: {}".format(str(err)))
+            assert_true("Invalid input parameters" in str(err))
+        else:
+            fail("invalid mc address should not work")
+
+        # 1.3 illegal mc signature
+        mc_signatures.append("xyz")
+        try:
+            sendMultisigKeysOwnership(sc_node,
+                                      sc_address=sc_address,
+                                      mc_addr=mc_multisig_address_2,
+                                      mc_signatures=mc_signatures,
+                                      redeemScript=m_sig_obj["redeemScript"])
+        except RuntimeError as err:
+            print("Expected exception thrown: {}".format(str(err)))
+            assert_true("Invalid input parameters" in str(err))
+        else:
+            fail("invalid mc signature should not work")
+
+        # 2. Try to use a number of signatures minor that the threshold value
+        # Generate some new address and prepare rpc command input
+        addresses = []
+        addr_objects = []
+        mc_signatures_bad = []
+        rpc_array_param = []
+
+        for i in range(NUM_OF_ADDR_IN_MULTISIG):
+            addresses.append(mc_node.getnewaddress())
+            addr_objects.append(mc_node.validateaddress(addresses[i]))
+            rpc_array_param.append(addr_objects[i]['pubkey'])
+
+        # Create the multi-sig address as combination of the single addresses created above
+        m_sig_obj = mc_node.createmultisig(THRESHOLD_SIGNATURE_VALUE, rpc_array_param)
+        mc_multisig_address_3 = m_sig_obj["address"]
+        redeem_script_2 = m_sig_obj["redeemScript"]
+
+        mc_signatures_bad.append(mc_node.signmessage(addresses[0], mc_multisig_address_3 + sc_address_checksum_fmt))
+
+        ret = sendMultisigKeysOwnership(sc_node,
+                                        sc_address=sc_address,
+                                        mc_addr=mc_multisig_address_3,
+                                        mc_signatures=mc_signatures_bad,
+                                        redeemScript=redeem_script_2)
+
+        tx_hash = ret['transactionId']
+        self.sc_sync_all()
+
+        # check the tx adding an ownership is included in the block and the receipt is failed, since we have not reached
+        # the threashold signature value
+        forge_and_check_receipt(self, sc_node, tx_hash, expected_receipt_status=0, sc_addr=sc_address,
+                                mc_addr=mc_multisig_address_3)
+
+        # 3. Try using twice the same signature
+        mc_signatures_bad.append(mc_node.signmessage(addresses[0], mc_multisig_address_3 + sc_address_checksum_fmt))
+
+        ret = sendMultisigKeysOwnership(sc_node,
+                                        sc_address=sc_address,
+                                        mc_addr=mc_multisig_address_3,
+                                        mc_signatures=mc_signatures_bad,
+                                        redeemScript=redeem_script_2)
+
+        tx_hash = ret['transactionId']
+        self.sc_sync_all()
+
+        # check the tx adding an ownership is included in the block and the receipt is failed, since we have reached
+        # the threashold signature value with a repeated signature
+        forge_and_check_receipt(self, sc_node, tx_hash, expected_receipt_status=0, sc_addr=sc_address,
+                                mc_addr=mc_multisig_address_2)
+
+        native_contract_address = MC_ADDR_OWNERSHIP_SMART_CONTRACT_ADDRESS
+
+        # execute native smart contract for getting all associations
+        method = 'getAllKeyOwnerships()'
+        abi_str = function_signature_to_4byte_selector(method)
+        req = {
+            "from": format_evm(sc_address),
+            "to": format_evm(native_contract_address),
+            "nonce": 3,
+            "gasLimit": 2300000,
+            "gasPrice": 850000000,
+            "value": 0,
+            "data": encode_hex(abi_str)
+        }
+        response = sc_node2.rpc_eth_call(req, 'latest')
+        abi_return_value = remove_0x_prefix(response['result'])
+        print(abi_return_value)
+        result_string_length = len(abi_return_value)
+        # we have an offset of 64 bytes and 2 records with 3 chunks of 32 bytes
+        exp_len = 32 + 32 + 2 * (3 * 32)
+        assert_equal(result_string_length, 2 * exp_len)
+
+        check_get_key_ownership(abi_return_value, list_all_associations['keysOwnership'])
+
+        # execute native smart contract for getting sc address associations
+        method = 'getKeyOwnerships(address)'
+        abi_str = function_signature_to_4byte_selector(method)
+        addr_padded_str = "000000000000000000000000" + sc_address
+        req = {
+            "from": format_evm(sc_address),
+            "to": format_evm(native_contract_address),
+            "nonce": 3,
+            "gasLimit": 2300000,
+            "gasPrice": 850000000,
+            "value": 0,
+            "data": encode_hex(abi_str) + addr_padded_str
+        }
+        response = sc_node2.rpc_eth_call(req, 'latest')
+        abi_return_value = remove_0x_prefix(response['result'])
+        print(abi_return_value)
+        result_string_length = len(abi_return_value)
+        # we have an offset of 64 bytes and 1 records with 3 chunks of 32 bytes
+        exp_len = 32 + 32 + 1 * (3 * 32)
+        assert_equal(result_string_length, 2 * exp_len)
+
+        check_get_key_ownership(abi_return_value, list_associations_sc_address['keysOwnership'])
+
+        # add one more association and check gas estimation
+        taddr_sc2_2 = mc_node.getnewaddress()
+        mc_signature_sc2 = mc_node.signmessage(taddr_sc2_2, sc_address2_checksum_fmt)
+        print("scAddr: " + sc_address2_checksum_fmt)
+        print("mcAddr: " + taddr_sc2_2)
+        print("mcSignature: " + mc_signature_sc2)
+
+        ret = sendKeysOwnership(sc_node2,
+                                sc_address=sc_address2,
+                                mc_addr=taddr_sc2_2,
+                                mc_signature=mc_signature_sc2)
+        self.sc_sync_all()
+        tx_hash_check = ret['transactionId']
+
+        response = allTransactions(sc_node, True)
+        est_gas_nsc_data = response['transactions'][0]['data']
+
+        response = estimate_gas(sc_node2, sc_address2_checksum_fmt,
+                                to_address=to_checksum_address(native_contract_address),
+                                data="0x" + est_gas_nsc_data,
+                                gasPrice='0x35a4e900',
+                                nonce=0)
+
+        est_gas_used = response['result']
+
+        generate_next_block(sc_node, "first node")
+        self.sc_sync_all()
+
+        receipt = sc_node.rpc_eth_getTransactionReceipt(add_0x_prefix(tx_hash_check))
+        status = int(receipt['result']['status'], 16)
+        assert_true(status == 1)
+        gas_used = receipt['result']['gasUsed']
+        assert_equal(est_gas_used, gas_used)
+
+        # generate a multisig address with the max number of pub keys
+        addresses = []
+        addr_objects = []
+        mc_signatures = []
+        rpc_array_param = []
+
+        NUM_OF_ADDR_IN_MULTISIG = 15
+        THRESHOLD_SIGNATURE_VALUE = 15
+        assert_true(THRESHOLD_SIGNATURE_VALUE <= NUM_OF_ADDR_IN_MULTISIG)
+
+        # Generate some new address and prepare rpc command input
+        for i in range(NUM_OF_ADDR_IN_MULTISIG):
+            addresses.append(mc_node.getnewaddress())
+            addr_objects.append(mc_node.validateaddress(addresses[i]))
+            rpc_array_param.append(addr_objects[i]['pubkey'])
+
+        # Create the multi-sig address as combination of the single addresses created above
+        m_sig_obj = mc_node.createmultisig(THRESHOLD_SIGNATURE_VALUE, rpc_array_param)
+        mc_multisig_address_1 = m_sig_obj["address"]
+        redeemScript_1 = m_sig_obj["redeemScript"]
+
+        for i in range(NUM_OF_ADDR_IN_MULTISIG):
+            if i < THRESHOLD_SIGNATURE_VALUE:
+                mc_signatures.append(mc_node.signmessage(addresses[i], mc_multisig_address_1 + sc_address_checksum_fmt))
+
+        ret = sendMultisigKeysOwnership(sc_node,
+                                        sc_address=sc_address,
+                                        mc_addr=mc_multisig_address_1,
+                                        mc_signatures=mc_signatures,
+                                        redeemScript=redeemScript_1)
+
+
+        tx_hash = ret['transactionId']
+        self.sc_sync_all()
+
+        # check the tx adding an ownership is included in the block and the receipt is succesful
+        forge_and_check_receipt(self, sc_node, tx_hash, sc_addr=sc_address, mc_addr=mc_multisig_address_1)
+
+
+if __name__ == "__main__":
+    SCEvmMcMultisigAddressOwnership().main()

--- a/sdk/src/main/java/io/horizen/utils/BytesUtils.java
+++ b/sdk/src/main/java/io/horizen/utils/BytesUtils.java
@@ -195,41 +195,57 @@ public final class BytesUtils {
         return false;
     }
 
-    public static final int HORIZEN_PUBLIC_KEY_ADDRESS_HASH_LENGTH = 20;
+    public static final int HORIZEN_COMPRESSED_PUBLIC_KEY_LENGTH = 33;
+    public static final int HORIZEN_ADDRESS_HASH_LENGTH = 20;
     public static final int HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH = 35;
     public static final int HORIZEN_MC_SIGNATURE_BASE_64_LENGTH = 88;
 
-    private static final int HORIZEN_PUBLIC_KEY_ADDRESS_PREFIX_LENGTH = 2;
-    private static final int HORIZEN_PUBLIC_KEY_ADDRESS_CHECKSUM_LENGTH = 4;
+    private static final int HORIZEN_ADDRESS_PREFIX_LENGTH = 2;
+    private static final int HORIZEN_ADDRESS_CHECKSUM_LENGTH = 4;
 
     private static final byte[] PUBLIC_KEY_MAINNET_PREFIX = BytesUtils.fromHexString("2089"); // "zn"
     private static final byte[] PUBLIC_KEY_MAINNET_PREFIX_OLD = BytesUtils.fromHexString("1CB8"); // "t1"
+    private static final byte[] SCRIPT_MAINNET_PREFIX = BytesUtils.fromHexString("2096"); // "zs"
+    private static final byte[] SCRIPT_MAINNET_PREFIX_OLD = BytesUtils.fromHexString("1CBD"); // "t3"
 
     private static final byte[] PUBLIC_KEY_TESTNET_PREFIX = BytesUtils.fromHexString("2098"); // "zt"
     private static final byte[] PUBLIC_KEY_TESTNET_PREFIX_OLD = BytesUtils.fromHexString("1D25"); // "tm"
+    private static final byte[] SCRIPT_TESTNET_PREFIX = BytesUtils.fromHexString("2092"); // "zr"
+    private static final byte[] SCRIPT_TESTNET_PREFIX_OLD = BytesUtils.fromHexString("1CBA"); // "t2"
+
+    public static final byte OP_CHECKMULTISIG = (byte) 0xAE;
+    public static final byte OP_1 = (byte) 0x51;
+    public static final byte OP_16 = (byte) 0x60;
+    public static final byte OFFSET_FOR_OP_N = (byte) 0x50; // in MC it is computred as (OP_1 - -1) since 0x50 is a reserved OP
 
     public static byte[] fromHorizenMcTransparentAddress(String address, NetworkParams params) {
         if(address.length() != HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH)
             throw new IllegalArgumentException(String.format("Incorrect Horizen mc transparent address length %d", address.length()));
 
         byte[] addressBytesWithChecksum = Base58.decode(address).get();
-        byte[] addressBytes = Arrays.copyOfRange(addressBytesWithChecksum, 0, HORIZEN_PUBLIC_KEY_ADDRESS_PREFIX_LENGTH + HORIZEN_PUBLIC_KEY_ADDRESS_HASH_LENGTH);
+        byte[] addressBytes = Arrays.copyOfRange(addressBytesWithChecksum, 0, HORIZEN_ADDRESS_PREFIX_LENGTH + HORIZEN_ADDRESS_HASH_LENGTH);
 
 
         // Check version
-        byte[] prefix = Arrays.copyOfRange(addressBytes, 0, HORIZEN_PUBLIC_KEY_ADDRESS_PREFIX_LENGTH);
+        byte[] prefix = Arrays.copyOfRange(addressBytes, 0, HORIZEN_ADDRESS_PREFIX_LENGTH);
         if(params instanceof MainNetParams) {
-            if(!Arrays.equals(prefix, PUBLIC_KEY_MAINNET_PREFIX) && !Arrays.equals(prefix, PUBLIC_KEY_MAINNET_PREFIX_OLD))
-                throw new IllegalArgumentException("Incorrect Horizen public key address format, MainNet format expected.");
+            if(!Arrays.equals(prefix, PUBLIC_KEY_MAINNET_PREFIX) && !Arrays.equals(prefix, PUBLIC_KEY_MAINNET_PREFIX_OLD) &&
+                    !Arrays.equals(prefix, SCRIPT_MAINNET_PREFIX) && !Arrays.equals(prefix, SCRIPT_MAINNET_PREFIX_OLD))
+                throw new IllegalArgumentException(String.format(
+                        "Incorrect Horizen address format, pubKey or script MainNet prefix expected, got %s",
+                        BytesUtils.toHexString(prefix)));
         }
-        else if(!Arrays.equals(prefix, PUBLIC_KEY_TESTNET_PREFIX) && !Arrays.equals(prefix, PUBLIC_KEY_TESTNET_PREFIX_OLD))
-            throw new IllegalArgumentException("Incorrect Horizen public key address format, TestNet format expected.");
+        else if(!Arrays.equals(prefix, PUBLIC_KEY_TESTNET_PREFIX) && !Arrays.equals(prefix, PUBLIC_KEY_TESTNET_PREFIX_OLD) &&
+                !Arrays.equals(prefix, SCRIPT_TESTNET_PREFIX) && !Arrays.equals(prefix, SCRIPT_TESTNET_PREFIX_OLD))
+            throw new IllegalArgumentException(String.format(
+                    "Incorrect Horizen address format,  pubKey or script TestNet prefix expected, got %s",
+                    BytesUtils.toHexString(prefix)));
 
-        byte[] publicKeyHash = Arrays.copyOfRange(addressBytes, HORIZEN_PUBLIC_KEY_ADDRESS_PREFIX_LENGTH, HORIZEN_PUBLIC_KEY_ADDRESS_PREFIX_LENGTH + HORIZEN_PUBLIC_KEY_ADDRESS_HASH_LENGTH);
+        byte[] publicKeyHash = Arrays.copyOfRange(addressBytes, HORIZEN_ADDRESS_PREFIX_LENGTH, HORIZEN_ADDRESS_PREFIX_LENGTH + HORIZEN_ADDRESS_HASH_LENGTH);
 
         // Verify checksum
-        byte[] checksum = Arrays.copyOfRange(addressBytesWithChecksum, HORIZEN_PUBLIC_KEY_ADDRESS_PREFIX_LENGTH + HORIZEN_PUBLIC_KEY_ADDRESS_HASH_LENGTH, addressBytesWithChecksum.length);
-        byte[] calculatedChecksum = Arrays.copyOfRange(Utils.doubleSHA256Hash(addressBytes), 0, HORIZEN_PUBLIC_KEY_ADDRESS_CHECKSUM_LENGTH);
+        byte[] checksum = Arrays.copyOfRange(addressBytesWithChecksum, HORIZEN_ADDRESS_PREFIX_LENGTH + HORIZEN_ADDRESS_HASH_LENGTH, addressBytesWithChecksum.length);
+        byte[] calculatedChecksum = Arrays.copyOfRange(Utils.doubleSHA256Hash(addressBytes), 0, HORIZEN_ADDRESS_CHECKSUM_LENGTH);
         if(!Arrays.equals(calculatedChecksum, checksum))
             throw new IllegalArgumentException("Broken Horizen public key address: checksum is wrong.");
 
@@ -237,12 +253,22 @@ public final class BytesUtils {
     }
 
     public static String toHorizenPublicKeyAddress(byte[] publicKeyHashBytes, NetworkParams params) {
-        if(publicKeyHashBytes.length != HORIZEN_PUBLIC_KEY_ADDRESS_HASH_LENGTH)
-            throw new IllegalArgumentException("Incorrect Horizen public key address bytes length.");
+        if(publicKeyHashBytes.length != HORIZEN_ADDRESS_HASH_LENGTH)
+            throw new IllegalArgumentException("Incorrect Horizen public key hash bytes length.");
 
         byte[] prefix = params instanceof MainNetParams ? PUBLIC_KEY_MAINNET_PREFIX : PUBLIC_KEY_TESTNET_PREFIX;
         byte[] addressBytes = Bytes.concat(prefix, publicKeyHashBytes);
-        byte[] checksum = Arrays.copyOfRange(Utils.doubleSHA256Hash(addressBytes), 0, HORIZEN_PUBLIC_KEY_ADDRESS_CHECKSUM_LENGTH);
+        byte[] checksum = Arrays.copyOfRange(Utils.doubleSHA256Hash(addressBytes), 0, HORIZEN_ADDRESS_CHECKSUM_LENGTH);
+        return Base58.encode(Bytes.concat(addressBytes, checksum));
+    }
+
+    public static String toHorizenScriptAddress(byte[] scriptHashBytes, NetworkParams params) {
+        if(scriptHashBytes.length != HORIZEN_ADDRESS_HASH_LENGTH)
+            throw new IllegalArgumentException("Incorrect Horizen script hash length.");
+
+        byte[] prefix = params instanceof MainNetParams ? SCRIPT_MAINNET_PREFIX : SCRIPT_TESTNET_PREFIX;
+        byte[] addressBytes = Bytes.concat(prefix, scriptHashBytes);
+        byte[] checksum = Arrays.copyOfRange(Utils.doubleSHA256Hash(addressBytes), 0, HORIZEN_ADDRESS_CHECKSUM_LENGTH);
         return Base58.encode(Bytes.concat(addressBytes, checksum));
     }
 

--- a/sdk/src/main/java/io/horizen/utils/BytesUtils.java
+++ b/sdk/src/main/java/io/horizen/utils/BytesUtils.java
@@ -196,6 +196,7 @@ public final class BytesUtils {
     }
 
     public static final int HORIZEN_COMPRESSED_PUBLIC_KEY_LENGTH = 33;
+    public static final int HORIZEN_UNCOMPRESSED_PUBLIC_KEY_LENGTH = 65;
     public static final int HORIZEN_ADDRESS_HASH_LENGTH = 20;
     public static final int HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH = 35;
     public static final int HORIZEN_MC_SIGNATURE_BASE_64_LENGTH = 88;
@@ -216,7 +217,7 @@ public final class BytesUtils {
     public static final byte OP_CHECKMULTISIG = (byte) 0xAE;
     public static final byte OP_1 = (byte) 0x51;
     public static final byte OP_16 = (byte) 0x60;
-    public static final byte OFFSET_FOR_OP_N = (byte) 0x50; // in MC it is computred as (OP_1 - -1) since 0x50 is a reserved OP
+    public static final byte OFFSET_FOR_OP_N = (byte) 0x50; // in MC it is computred as (OP_1 -1) since 0x50 is a reserved OP
 
     public static byte[] fromHorizenMcTransparentAddress(String address, NetworkParams params) {
         if(address.length() != HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH)
@@ -224,7 +225,6 @@ public final class BytesUtils {
 
         byte[] addressBytesWithChecksum = Base58.decode(address).get();
         byte[] addressBytes = Arrays.copyOfRange(addressBytesWithChecksum, 0, HORIZEN_ADDRESS_PREFIX_LENGTH + HORIZEN_ADDRESS_HASH_LENGTH);
-
 
         // Check version
         byte[] prefix = Arrays.copyOfRange(addressBytes, 0, HORIZEN_ADDRESS_PREFIX_LENGTH);
@@ -241,7 +241,7 @@ public final class BytesUtils {
                     "Incorrect Horizen address format,  pubKey or script TestNet prefix expected, got %s",
                     BytesUtils.toHexString(prefix)));
 
-        byte[] publicKeyHash = Arrays.copyOfRange(addressBytes, HORIZEN_ADDRESS_PREFIX_LENGTH, HORIZEN_ADDRESS_PREFIX_LENGTH + HORIZEN_ADDRESS_HASH_LENGTH);
+        byte[] addressDataHash = Arrays.copyOfRange(addressBytes, HORIZEN_ADDRESS_PREFIX_LENGTH, HORIZEN_ADDRESS_PREFIX_LENGTH + HORIZEN_ADDRESS_HASH_LENGTH);
 
         // Verify checksum
         byte[] checksum = Arrays.copyOfRange(addressBytesWithChecksum, HORIZEN_ADDRESS_PREFIX_LENGTH + HORIZEN_ADDRESS_HASH_LENGTH, addressBytesWithChecksum.length);
@@ -249,7 +249,8 @@ public final class BytesUtils {
         if(!Arrays.equals(calculatedChecksum, checksum))
             throw new IllegalArgumentException("Broken Horizen public key address: checksum is wrong.");
 
-        return publicKeyHash;
+        // The returned data can be a pubKeyHash or a scriptHash, depending on the address type
+        return addressDataHash;
     }
 
     public static String toHorizenPublicKeyAddress(byte[] publicKeyHashBytes, NetworkParams params) {

--- a/sdk/src/main/java/io/horizen/utils/Utils.java
+++ b/sdk/src/main/java/io/horizen/utils/Utils.java
@@ -50,6 +50,17 @@ public final class Utils
         }
     }
 
+    public static byte[] Ripemd160Hash(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("RIPEMD160");
+            digest.update(bytes, 0, bytes.length);
+            byte[] result = digest.digest();
+            return result;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);  // Cannot happen.
+        }
+    }
+
     public static byte[] doubleSHA256HashOfConcatenation(byte[] bytes1, byte[] bytes2) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");

--- a/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorData.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorData.scala
@@ -2,19 +2,20 @@ package io.horizen.account.state
 
 import com.fasterxml.jackson.annotation.JsonView
 import io.horizen.account.abi.{ABIDecoder, ABIEncodable, ABIListEncoder, MsgProcessorInputDecoder}
-import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.state.McAddrOwnershipData.{decodeMcAddress, decodeMcSignature}
-import io.horizen.json.Views
 import io.horizen.evm.Address
+import io.horizen.json.Views
 import io.horizen.utils.BytesUtils
 import org.web3j.abi.TypeReference
 import org.web3j.abi.datatypes.generated.{Bytes24, Bytes3, Bytes32}
-import org.web3j.abi.datatypes.{StaticStruct, Type, Address => AbiAddress}
+import org.web3j.abi.datatypes.{DynamicArray, DynamicStruct, StaticStruct, Type, Utf8String, Address => AbiAddress}
 import sparkz.core.serialization.{BytesSerializable, SparkzSerializer}
 import sparkz.util.serialization.{Reader, Writer}
 
 import java.nio.charset.StandardCharsets
 import java.util
+import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters.asScalaBufferConverter
 
 
 case class AddNewOwnershipCmdInput(mcTransparentAddress: String, mcSignature: String)
@@ -74,6 +75,74 @@ object AddNewOwnershipCmdInputDecoder
       listOfParams.get(4).asInstanceOf[Bytes32])
 
     AddNewOwnershipCmdInput(mcTransparentAddrress, mcSignature)
+  }
+}
+
+case class AddNewMultisigOwnershipCmdInput(mcTransparentAddress: String, redeemScript: String, mcSignatures: Seq[String])
+  extends ABIEncodable[DynamicStruct] {
+
+  require(mcTransparentAddress.length == BytesUtils.HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH,
+    s"Invalid mc address length: ${mcTransparentAddress.length}")
+
+  require(mcSignatures.size <= 16)
+  mcSignatures.foreach { s =>
+    require(s.length == BytesUtils.HORIZEN_MC_SIGNATURE_BASE_64_LENGTH,
+      s"Invalid mc signature length: ${s.length}")
+  }
+
+  override def asABIType(): DynamicStruct = {
+
+    val listOfSignatures = JavaConverters.seqAsJavaList(mcSignatures.map(new Utf8String(_)))
+    val theType = classOf[Utf8String]
+
+    val listOfParams: util.List[Type[_]] = util.Arrays.asList(
+      new Utf8String(mcTransparentAddress),
+      new Utf8String(redeemScript),
+      new DynamicArray(theType, listOfSignatures))
+
+    new DynamicStruct(listOfParams)
+  }
+
+  override def toString: String = {
+    val str1 = "%s(mcAddress: %s, redeemScript: %s, signatures:["
+      .format(
+        this.getClass.toString,
+        mcTransparentAddress, redeemScript)
+    val str2 = mcSignatures.mkString(":")
+    str1 + str2 + "])"
+  }
+}
+
+
+object AddNewMultisigOwnershipCmdInputDecoder
+  extends ABIDecoder[AddNewMultisigOwnershipCmdInput]
+    with MsgProcessorInputDecoder[AddNewMultisigOwnershipCmdInput] {
+
+  /* We should not check this dynamic size
+  override def getABIDataParamsDynamicLengthInBytes: Int =
+    2*Type.MAX_BYTE_LENGTH + // offsets of the 2 dynamic utf8strings
+      Type.MAX_BYTE_LENGTH + // the 32 padded utf8String size
+      2 * Type.MAX_BYTE_LENGTH +  // two chunks for the 35 bytes mc address string
+      ...
+   */
+
+  override val getListOfABIParamTypes: util.List[TypeReference[Type[_]]] = {
+    org.web3j.abi.Utils.convert(util.Arrays.asList(
+      // mc transparent address
+      new TypeReference[Utf8String]() {},
+      // redeem script
+      new TypeReference[Utf8String]() {},
+      // signatures
+      new TypeReference[DynamicArray[Utf8String]]() {}))
+  }
+
+
+  override def createType(listOfParams: util.List[Type[_]]): AddNewMultisigOwnershipCmdInput = {
+    val mcTransparentAddress = listOfParams.get(0).asInstanceOf[Utf8String].getValue
+    val redeemScript = listOfParams.get(1).asInstanceOf[Utf8String].getValue
+    val mcSignatures = listOfParams.get(2).asInstanceOf[DynamicArray[Utf8String]].getValue
+
+    AddNewMultisigOwnershipCmdInput(mcTransparentAddress, redeemScript, mcSignatures.asScala.map(_.getValue))
   }
 }
 
@@ -251,7 +320,7 @@ object OwnerScAddressSerializer extends SparkzSerializer[OwnerScAddress] {
   }
 
   override def parse(r: Reader): OwnerScAddress = {
-    val scAddressBytes = r.getBytes(2*BytesUtils.HORIZEN_PUBLIC_KEY_ADDRESS_HASH_LENGTH)
+    val scAddressBytes = r.getBytes(2*BytesUtils.HORIZEN_ADDRESS_HASH_LENGTH)
 
     OwnerScAddress(
       new String(scAddressBytes, StandardCharsets.UTF_8)

--- a/sdk/src/test/java/io/horizen/account/secret/McSignatureTest.java
+++ b/sdk/src/test/java/io/horizen/account/secret/McSignatureTest.java
@@ -202,7 +202,9 @@ public class McSignatureTest {
         byte[] hashedMsg = getMcHashedMsg("0x00c8f107a09cd4f463afc2f1e6e5bf6022ad4600");
         System.out.println("hashed msg = " + BytesUtils.toHexString(hashedMsg));
 
-        // base64 encoded signature as it is returned by rpc cmd above
+        // base64 encoded signature as it is returned by rpc cmd above. Note that Base64 encoding requires 4 characters
+        // for every 3 bytes encoded, then the string's length is padded up to a multiple of 4.
+        // So, base64-encoding s signature, which is 65 bytes long, results in a base64-encoded string 88 characters long.
         String strMcSignature = "IOc348/la3bqCb31IQg0DEVOowg6f3cKll+SmZ6ip4KVR37qp0aG72iqZwdulDmj+1bid+IdIJJhoOm1kMqCX/s=";
 
         byte[] decodedMcSignature = Base64.decode(strMcSignature).get();

--- a/sdk/src/test/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorMultisigTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorMultisigTest.scala
@@ -1,0 +1,1101 @@
+package io.horizen.account.state
+
+import com.google.common.primitives.Bytes
+import io.horizen.account.fork.GasFeeFork.DefaultGasFeeFork
+import io.horizen.account.fork.ZenDAOFork
+import io.horizen.account.proof.SignatureSecp256k1
+import io.horizen.account.state.McAddrOwnershipMsgProcessor._
+import io.horizen.account.state.events.{AddMcAddrOwnership, RemoveMcAddrOwnership}
+import io.horizen.account.state.receipt.EthereumConsensusDataLog
+import io.horizen.account.utils.BigIntegerUInt256.getUnsignedByteArray
+import io.horizen.account.utils.Secp256k1.{PUBLIC_KEY_SIZE, SIGNATURE_RS_SIZE}
+import io.horizen.account.utils.ZenWeiConverter
+import io.horizen.consensus.intToConsensusEpochNumber
+import io.horizen.evm.Address
+import io.horizen.fixtures.StoreFixture
+import io.horizen.fork.{ForkConfigurator, ForkManagerUtil, OptionalSidechainFork, SidechainForkConsensusEpoch}
+import io.horizen.params.NetworkParams
+import io.horizen.utils.BytesUtils.{padWithZeroBytes, toHorizenPublicKeyAddress}
+import io.horizen.utils.Utils.Ripemd160Sha256Hash
+import io.horizen.utils.{BytesUtils, Pair}
+import org.junit.Assert._
+import org.junit._
+import org.mockito.Mockito
+import org.scalatestplus.junit.JUnitSuite
+import org.scalatestplus.mockito._
+import org.web3j.abi.datatypes.Type
+import org.web3j.abi.{FunctionReturnDecoder, TypeReference}
+import org.web3j.crypto.{Keys, Sign}
+import org.web3j.utils.Numeric
+import sparkz.core.bytesToVersion
+import sparkz.crypto.hash.Keccak256
+
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.Optional
+import scala.jdk.CollectionConverters.seqAsJavaListConverter
+
+class McAddrOwnershipMsgProcessorMultisigTest
+  extends JUnitSuite
+    with MockitoSugar
+    with MessageProcessorFixture
+    with StoreFixture {
+
+  val ZENDAO_MOCK_FORK_POINT: Int = 100
+
+  class TestOptionalForkConfigurator extends ForkConfigurator {
+    override val fork1activation: SidechainForkConsensusEpoch = SidechainForkConsensusEpoch(0, 0, 0)
+
+    override def getOptionalSidechainForks: util.List[Pair[SidechainForkConsensusEpoch, OptionalSidechainFork]] =
+      Seq[Pair[SidechainForkConsensusEpoch, OptionalSidechainFork]](
+        new Pair(SidechainForkConsensusEpoch(ZENDAO_MOCK_FORK_POINT, ZENDAO_MOCK_FORK_POINT, ZENDAO_MOCK_FORK_POINT), ZenDAOFork(true)),
+      ).asJava
+  }
+
+  override val defaultBlockContext = new BlockContext(
+    Address.ZERO,
+    0,
+    0,
+    DefaultGasFeeFork.blockGasLimit,
+    0,
+    /*consensusEpochNumber*/ ZENDAO_MOCK_FORK_POINT,
+    0,
+    1,
+    MockedHistoryBlockHashProvider,
+    new io.horizen.evm.Hash(new Array[Byte](32))
+  )
+
+  @Before
+  def init(): Unit = {
+    ForkManagerUtil.initializeForkManager(new TestOptionalForkConfigurator, "regtest")
+    // by default start with fork active
+    Mockito.when(metadataStorageView.getConsensusEpochNumber).thenReturn(Option(intToConsensusEpochNumber(ZENDAO_MOCK_FORK_POINT)))
+  }
+
+  val dummyBigInteger: BigInteger = BigInteger.ONE
+  val negativeAmount: BigInteger = BigInteger.valueOf(-1)
+
+  val invalidWeiAmount: BigInteger = new BigInteger("10000000001")
+  val validWeiAmount: BigInteger = new BigInteger("10000000000")
+
+  val mockNetworkParams: NetworkParams = mock[NetworkParams]
+  val messageProcessor: McAddrOwnershipMsgProcessor = McAddrOwnershipMsgProcessor(mockNetworkParams)
+  val contractAddress: Address = messageProcessor.contractAddress
+
+  val scAddrStr1: String = "00C8F107a09cd4f463AFc2f1E6E5bF6022Ad4600"
+  val scAddressObj1 = new Address("0x" + scAddrStr1)
+
+  //-------------------------------------------------------------------------------------------------------------------------------
+  val mcMultiSigAddr1: String = "zr5VjXGbJDnWW2K6JM88uuG8X83T6Cgq1iT"
+  val redeemScript1: String = "522102b1fb3c3b174b6a878e07f50c8057afe027d382c55b6ba9d91fa72e064479b6d32103db06cb236d4be6968deb8d829ca879ce254805f8dc9ea79586de428b7484b4cf21036509e8a548e4680d7e01fd32de53281054ee37022c622863d0a23c7258d4618b53ae"
+
+  val mcAddrStr_11: String = "ztZxhE8FLc5biXSffbNtvTUUw7sZ9dcp2Du"
+  val mcAddrStr_12: String = "ztbPhVg29w5Bjx3t4MjUmfeijUejUs5VEWR"
+  val mcAddrStr_13: String = "ztrPYtTwCrVcbHiW8NZmdZDhvEWremL7nbU"
+
+  val mcSignatureStr_11: String = "H19keJ3XHiMKgMBs1YPlB23a74fp82hsP/BgVbWuTnnofkNS6xuzDn/VtFpI0Tg1jZXDnTrCVUgMOuDUiTJUVkE="
+  val mcSignatureStr_12: String = "H8sSwd4E9/j0s9sOA/udo8v+IlmwBuhvJR5QEN5FjeyoKnodzbnMDR8yKIa7sFOZlltBmvqazc13Y4JZWSWM1TY="
+  val mcSignatureStr_13: String = "ILWR5DWahVgYcLV8bQuBeUsC6k5DVlrBLEpiVGmoY6LXUblD5EejUzT6paK3tpXdsBcfAWv/tP97xQAnZCwJDeg="
+
+  var listOfMcMultisigAddrSign_1: Seq[String] = Seq[String](mcSignatureStr_11, mcSignatureStr_12, mcSignatureStr_13)
+  //-------------------------------------------------------------------------------------------------------------------------------
+  val mcMultiSigAddr2: String = "zrDVBZrgyp7r4ripx7gAaf9AoFVZ8dktgSX"
+  val redeemScript2: String = "5241049bff9c9b5d0976aed138669e050b6b202aba89d16b5d3dfe4952a87d1888418fcae1a517d1dca6c61a7326dcb2f76bd5ff713b2c30f11a68a818bb074a2d40232103b881310ef3be9b8f42ad1705180d8eeed727fe47673a5119b6b1fe37309be9512102828b14acc47d4b7ba3f721b5eede0b85e4849cadb4bc59fc9aaaba75f579daea53ae"
+
+  val mcAddrStr_21: String = "ztTw2K532ewo9gynBJv7FFUgbD19Wpifv8G"
+  val mcAddrStr_22: String = "zthyXpQ2LMYrHLxwVC1R3yfpR6epqNrRDMz"
+  val mcAddrStr_23: String = "ztp4GJMoLSQhuunZPC7x67wZW1YeKkWqb6Q"
+
+  val mcSignatureStr_21: String = "H2ay43UtkU6vC+fA9mH41Y3aFnTaIeYYe/2jXycV5AkXeNTMOgs9PZtyAAP+1k7ln5v2PthgOzSV15P85WZVhlA="
+  val mcSignatureStr_22: String = "IAsfMcq4+8nCxGxYUVXCiMBEMxWhAGPR7+4e/zwKnanxF++H0OlbF/LxUH+NWKVdtP0z3OquOK4UEtCmN5cfV8k="
+  val mcSignatureStr_23: String = "H+Fn/va1Ct/BcyjokrrcSfzsvnk/19KKwNbWKrKWUPhvaGDy+uBsGPuQF39wIrds2mt9O62ZbOhh/T3jCSrd0a4="
+
+  var listOfMcMultisigAddrSign_2: Seq[String] = Seq[String](mcSignatureStr_21, mcSignatureStr_22, mcSignatureStr_23)
+  //-------------------------------------------------------------------------------------------------------------------------------
+  // A multisig address made of 3 identical pub keys.
+  val mcMultiSigAddrRep: String = "zr5Z3wKHPabDbr8vVXzW1JXdmZ55WRTcEN8"
+  val redeemScriptRep: String = "522103dc080dc6ddc4dfeed866cf09e2d883babc6cc32ff6796f6ceed9d5f714a9cf452103dc080dc6ddc4dfeed866cf09e2d883babc6cc32ff6796f6ceed9d5f714a9cf452103dc080dc6ddc4dfeed866cf09e2d883babc6cc32ff6796f6ceed9d5f714a9cf4553ae"
+  val mcSignatureStrRep: String = "Hw1T7OCaewGVgqjq+4FX+QczfYSwQJWzmb6D91qfnpmBGjO+WuuxYzcycspRaMChUzDJVEE7yLbd1SxeBxFP5Lk="
+  var listOfMcMultisigAddrSign_rep: Seq[String] = Seq[String](mcSignatureStrRep, mcSignatureStrRep)
+  //-------------------------------------------------------------------------------------------------------------------------------
+  val mcMultiSigAddrBig: String = "zrSNRgWtnXoeDKsgWBPPBs2rFJEDq1hGpU6"
+  val redeemScriptBig: String = "5f210240eb71c1faa869ef6fa575038e38185264874b2ab63bb5f8fb1b6bcc94d239a02102ede12c5f9c7990f40a2fd384223b970b7e210bfb97d57fc1824533100b89811a2102cb9986b088f164b739a1b007f7006ba627c539b597fc896355b75521df3cf7a021039056f14b5d7ec72686a8b3f0b9e43627f5b62056c79cde9fa361230c138bdc2721030cad99ba7cc045b9362dcff9f61b82edcc3bf45c5f376dd747881a8837495c432103baf9fdd1172c9049c612d2eece4b6fcd190cfd6f0c0c2073b9bf2090e83509e221034a2bad171d349cb10383ed0c3d39ce41add9715b670df80b9ee321bf88f4f01b2102f7cd52264a45ae5c84f47db6288b5ba0e5035abe529758550e56b5c4326351dd21027bdfe42fbb7abc80700892d095913509ede81dbb576959f10ce21a349332d2502102fc3841a7dd09470ed176e9bdbe0e778597888fed3b36514efdfa17bab359d89a2102d247302d65622b703203178fc57b5350ff24a05a523ecf9fdafe2eb6a2598d9821033ac3af609ba0a8522ed329d9dcb6250b7abacdac1c163aef232ab5a2bf4a00cf2102c4a59bde4fd83aad73fb3a423d24214facdc03dd93fc32e7ce664d6325c2de1b2102795a710a3a2bcc1be23578a84d127e801a458f831f504dccf256987ac17ce7562103d5d8ea992fbf8d8a66c376a18e824f880b5e809437c25bd7b9efe4c04724d9775fae"
+  var listOfMcMultisigAddrSign_big: Seq[String] = Seq[String](
+    "HwomseQg9FktQ3RIb+txbWpNpOFD2pTPwK5hhgt/CzW8Zq6na1bXFC18qpaOu2rdy/kDnLyQoZxL5aBF7XG0Exs=",
+    "H6sz+uZZR+O4kP4aOwTfhrERG9bpixwk/p2/LA0KsPlAGK5GWWgrOPRQO+x6C2EVi+UpEE0fIsilY919W1JufGA=",
+    "H5SG8jAxfWHELvoYM0NF5ROQYLjJGxdgJuXPsz5xtdfWQFj+U6mOV0sEk1SsJpDHNoHlpNCzPPGZi/PqgDOiNF4=",
+    "HwvmoXsact7tammb92V2mDcfTGIUxj6bAg8IqSwKioBQIBpvWNe3FE7t/sDV1tBWq6AzJXKN42PPd1iCjBsZ+xk=",
+    "IC+CPirr5/8Po5Ux/Zd2UdNEkVaXWIeqJVyK7FwZE4VHOHvNJuBAzb+96+2Z/HvX9sJ5hf0i4g35XbcUY/e4Aeo=",
+    "IGLUfViNWcFsksy06yjEqWN8n+5kBOX1aAj7DhbEuy2TDAqfSL2T/LgRLaGxuaYPB1T4iTncFbkWj5NLlXsuYtA=",
+    "HzVbp1yNFL+8giKiYNvZ/2g3DInWPg/p6WmBcu/c00ENAuYrH0vzg6HUG5P/m7OcMaaR1cww/y7DaEEDCsNPjmg=",
+    "IMiOspm2c73TuEEuEkq5vml1MPyM5UYofzUxMVvnYpg+dfmVSaXDeMNzdK1aY5RVKByYMD+VgzUc2kEuw3yn6Yc=",
+    "H2GSDj7UagXKxL5UCzRPDpEv79JoJGeUlJrjOacPXbaeVshEwZ6hOinElfBp8xsl4RUlgEuPYE1CuUknubboAHc=",
+    "H01n7AjJXQc+WddsHAWeHwHddS5EH2ZZI8lUrVtjZFSRT8P+ute57bNhyNaluA4H21qce6mwo7gGILfYXhqV/7Q=",
+    "IFgnnP7X7Xk7xzM+Y+OsVHe2t8JNMKHRVntWYulaltG6WRR1MfU6Ts0awPsnjfFNd7zEe+pRU8qJpJOdGPPoBmY=",
+    "IEnF042X9IVfUzmXOCmKDKHiLGPpIABCdSJ6fLCDGUp5Im47RRwwSBZrBT7OOtMxT6ykcmUvBl/YDlxi0C8lKV8=",
+    "IO8SecGtR/9CZVY8u2TjeXkNb+ZBNPNUhbXkLAsXIYuyC1hwfHW187SyyjxpYQIIrdv+p5+1MaBuodlaDeta2Zw=",
+    "IONBPlExDo9a6H9Xv0JRwXchvqzuU5BIgG9LrjEgBkS0J8IxWccmC2ZjgTyw37lbBUupZf+rvJhJdTJA+iUlHbA=",
+    "IJqxtg51fUNkpx/YtegEtv+BoGc6HvvHgMOqT+ZzhTJKBR4QoFAgR3adAbUN0yJLzaIBB/upCQwO9P2eu8vtxks=")
+
+
+
+
+  // signature 'i' is obtained signing the same scAddrStr1 string using the priv key corresponding to mc addr 'i'
+  val mcAddrStr1: String = "ztZzTK8meAb3Be1XXN36Zu9NEAMCkYdiXXi"
+  val mcSignatureStr1: String = "H3YWXUJbpgP1cwT4QuyAr9JSVehVPWpV841W0Zv/GTrffa1JfwHq34CjM1Y5TWWz82vtUyfdPh6K9jjJI2DKY8E="
+  val mcAddrStr2: String = "ztfK1cpQtKmpwA9ELCZuE4ufQjS5rNx33D6"
+  val mcSignatureStr2: String = "ILCkShV1GxwNeOr1p153T2ds38LtJVWtjEf5usCvfvEwWULUgpGbuikFoU/fC0wobG+2xVAHniQuxaxGjHn65cg="
+  val mcAddrStr3: String = "ztes7TG8zHm2C1GzkMstmd8c6j6Q3pr8y5M"
+  val mcSignatureStr3: String = "IKlZeexpu0l1uaa4y/Jv9okn93MsDZQQUcy97iuYZQN2f8vzgEV08SdfEcMUtoukERX72WSoDCBOSrp7d9fjQ68="
+  val mcAddrStr4: String = "ztpXBsnFD9Ni1jvBPhfwswRSCoKG7irodXt"
+  val mcSignatureStr4: String = "IG/74ayOEYDBsQLEFibVb1CbFFtWWKjCpwAFiVaaYb4wbPmimGytxJo0jf7d8UDQUf0TTdM+J5Qn1Mzm+k6WRNw="
+  val mcAddrStr5: String = "ztVQPCqt17N3MQD9w8s736t2m26LHmzsJqG"
+  val mcSignatureStr5: String = "IISbzxfiUUSDbp+KvQBrburAeF1QM4hEwJ0HLckL42QXTvEYLG0w3WnquyAiiNSUgv8kc+RAcShif+qbM8tXZ3g="
+
+  val listOfMcAddrSign1 = new util.ArrayList[(String, String)]()
+  listOfMcAddrSign1.add((mcAddrStr1, mcSignatureStr1))
+  listOfMcAddrSign1.add((mcAddrStr2, mcSignatureStr2))
+  listOfMcAddrSign1.add((mcAddrStr3, mcSignatureStr3))
+  listOfMcAddrSign1.add((mcAddrStr4, mcSignatureStr4))
+  listOfMcAddrSign1.add((mcAddrStr5, mcSignatureStr5))
+
+  // a second sc address and its data
+  val scAddrStr2: String = "cA12fcB886CBF73a39D87aAC9610f8a303536642"
+  val scAddressObj2 = new Address("0x" + scAddrStr2)
+  val mcAddrStr1_2: String = "ztkPjQddjaskk68LVvQTMxB6U5gGgsFCUzf"
+  val mcSignatureStr1_2: String = "IKZJhxQtYGVTondsX0FHU+N1QjlxResb6md/HaEpGUirTqXUR8N4Bmi7p9szHTwpDKftq7QBRep8LUN4J8N3hz0="
+  val mcAddrStr2_2: String = "ztVUwVnqCnWFANk9X6najvM1VBEJQcF4j8Y"
+  val mcSignatureStr2_2: String = "H4IqujR8Wdh/3h5Wuf9GAb6dchn/8EjsDGPvIVtQD4XSLjNkwOGLLGKnCR896ZmH6t0nlQP2U/mksQOJaAMEH3g="
+
+  val listOfMcAddrSign2 = new util.ArrayList[(String, String)]()
+  listOfMcAddrSign2.add((mcAddrStr1_2, mcSignatureStr1_2))
+  listOfMcAddrSign2.add((mcAddrStr2_2, mcSignatureStr2_2))
+
+  // and here is the signature of the mcAddrStr1 made using the second sc address as msg. It is useful for negative tests
+  val mcSignatureStr3_2: String = "IPkgJQzjSBdOKrlfOhihEm682GB8i+UmDTBMdLGaTCEkEK2cS1zOcPN+p9pdsTqSoiVXuprd+1kcuKHB2zvOlMI="
+
+  val AddNewEventSig: Array[Byte] = getEventSignature("AddMcAddrOwnership(address,bytes3,bytes32)")
+  val NumOfIndexedAddNewEvtParams = 1
+  val RemoveEventSig: Array[Byte] = getEventSignature("RemoveMcAddrOwnership(address,bytes3,bytes32)")
+  val NumOfIndexedRemoveEvtParams = 1
+
+  def getDefaultMessage(opCode: Array[Byte], arguments: Array[Byte], nonce: BigInteger, value: BigInteger = negativeAmount): Message = {
+    val data = Bytes.concat(opCode, arguments)
+    new Message(
+      origin,
+      Optional.of(contractAddress), // to
+      dummyBigInteger, // gasPrice
+      dummyBigInteger, // gasFeeCap
+      dummyBigInteger, // gasTipCap
+      dummyBigInteger, // gasLimit
+      value,
+      nonce,
+      data,
+      false)
+  }
+
+  def randomNonce: BigInteger = randomU256
+
+  @Test
+  def testMethodIds(): Unit = {
+    //The expected methodIds were calculated using this site: https://emn178.github.io/online-tools/keccak_256.html
+    assertEquals("Wrong MethodId for AddNewMultisigOwnershipCmd", "33c72ed1", McAddrOwnershipMsgProcessor.AddNewMultisigOwnershipCmd)
+  }
+
+
+  @Test
+  def testAddAndRemoveMultisigOwnership(): Unit = {
+
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = BigInteger.valueOf(100).multiply(validWeiAmount)
+
+      //Setting the context
+      val txHash1 = Keccak256.hash("first tx")
+      view.setupTxContext(txHash1, 10)
+
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      val cmdInput = AddNewMultisigOwnershipCmdInput(mcMultiSigAddr1, redeemScript1, listOfMcMultisigAddrSign_1)
+
+      val data: Array[Byte] = cmdInput.encode()
+      val msg = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      val expectedOwnershipId = Keccak256.hash(mcMultiSigAddr1.getBytes(StandardCharsets.UTF_8))
+
+      // positive case, verify we can add the data to view
+      val returnData = assertGas(514937, msg, view, messageProcessor, defaultBlockContext)
+      assertNotNull(returnData)
+
+      assertArrayEquals(expectedOwnershipId, returnData)
+
+      // Checking log
+      var listOfLogs = view.getLogs(txHash1)
+      assertEquals("Wrong number of logs", 1, listOfLogs.length)
+      var expectedAddEvt = AddMcAddrOwnership(scAddressObj1, mcMultiSigAddr1)
+      checkAddNewOwnershipEvent(expectedAddEvt, listOfLogs(0))
+
+      val txHash2 = Keccak256.hash("second tx")
+      view.setupTxContext(txHash2, 10)
+      // try processing a msg with the same data (same msg), should fail
+      assertThrows[ExecutionRevertedException](withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _)))
+
+      // Checking that log doesn't change
+      listOfLogs = view.getLogs(txHash2)
+      assertEquals("Wrong number of logs", 0, listOfLogs.length)
+
+      // add a second association
+      val cmdInput2 = AddNewMultisigOwnershipCmdInput(mcMultiSigAddr2, redeemScript2, listOfMcMultisigAddrSign_2)
+
+      val data2: Array[Byte] = cmdInput2.encode()
+      val msg2 = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data2,
+        randomNonce,
+        scAddressObj1)
+
+      val txHash3 = Keccak256.hash("third tx")
+      view.setupTxContext(txHash3, 10)
+
+      val returnData2 = assertGas(362037, msg2, view, messageProcessor, defaultBlockContext)
+      assertNotNull(returnData2)
+
+      // Checking log
+      listOfLogs = view.getLogs(txHash3)
+      assertEquals("Wrong number of logs", 1, listOfLogs.length)
+      expectedAddEvt = AddMcAddrOwnership(scAddressObj1, mcMultiSigAddr2)
+      checkAddNewOwnershipEvent(expectedAddEvt, listOfLogs(0))
+
+      // remove first ownership association
+      val removeCmdInput1 = RemoveOwnershipCmdInput(Some(mcMultiSigAddr1))
+      val msg3 = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(RemoveOwnershipCmd) ++ removeCmdInput1.encode(),
+        randomNonce, scAddressObj1
+      )
+
+      val txHash4 = Keccak256.hash("forth tx")
+      view.setupTxContext(txHash4, 10)
+
+      val returnData3 = assertGas(63437, msg3, view, messageProcessor, defaultBlockContext)
+      assertNotNull(returnData3)
+
+      // Checking log
+      listOfLogs = view.getLogs(txHash4)
+      assertEquals("Wrong number of logs", 1, listOfLogs.length)
+      val expectedRemoveEvt = RemoveMcAddrOwnership(scAddressObj1, mcMultiSigAddr1)
+      checkRemoveNewOwnershipEvent(expectedRemoveEvt, listOfLogs(0))
+
+      // get the list of ownerships via native smart contract interface, should return just the remaining one
+      val expectedOwnershipData = McAddrOwnershipData(scAddrStr1, mcMultiSigAddr2)
+      val listOfExpectedOwnerships = new util.ArrayList[McAddrOwnershipData]
+      listOfExpectedOwnerships.add(expectedOwnershipData)
+
+      val msg4 = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(GetListOfAllOwnershipsCmd),
+        randomNonce
+      )
+      val returnData4 = assertGas(19000, msg4, view, messageProcessor, defaultBlockContext)
+      assertNotNull(returnData4)
+
+      assertArrayEquals(McAddrOwnershipDataListEncoder.encode(listOfExpectedOwnerships), returnData4)
+
+      view.commit(bytesToVersion(getVersion.data()))
+    }
+  }
+
+  @Test
+  def testAddMultisigOwnershipRepetitionOfPubKeys(): Unit = {
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = BigInteger.valueOf(100).multiply(validWeiAmount)
+
+      //Setting the context
+      val txHash1 = Keccak256.hash("first tx")
+      view.setupTxContext(txHash1, 10)
+
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      val cmdInput = AddNewMultisigOwnershipCmdInput(mcMultiSigAddrRep, redeemScriptRep, listOfMcMultisigAddrSign_rep)
+
+      val data: Array[Byte] = cmdInput.encode()
+      val msg = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      val expectedOwnershipId = Keccak256.hash(mcMultiSigAddrRep.getBytes(StandardCharsets.UTF_8))
+
+      // positive case, verify we can add the data to view
+      val returnData = assertGas(514937, msg, view, messageProcessor, defaultBlockContext)
+      assertNotNull(returnData)
+
+      assertArrayEquals(expectedOwnershipId, returnData)
+
+      // Checking log
+      val listOfLogs = view.getLogs(txHash1)
+      assertEquals("Wrong number of logs", 1, listOfLogs.length)
+      val expectedAddEvt = AddMcAddrOwnership(scAddressObj1, mcMultiSigAddrRep)
+      checkAddNewOwnershipEvent(expectedAddEvt, listOfLogs(0))
+
+    }
+  }
+
+  @Test
+  def testAddMultisigOwnershipLongShuffledSignatureList(): Unit = {
+
+    // provide a large sequence of signatures, some of them are not verifying and the coorrect ones are shuffled so that the order of verification
+    // is not the same of the public keys represented on the redeem script
+    val shuffledSignatures = scala.util.Random.shuffle(listOfMcMultisigAddrSign_1++listOfMcMultisigAddrSign_2)
+
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = BigInteger.valueOf(100).multiply(validWeiAmount)
+
+      //Setting the context
+      val txHash1 = Keccak256.hash("first tx")
+      view.setupTxContext(txHash1, 10)
+
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      val cmdInput = AddNewMultisigOwnershipCmdInput(mcMultiSigAddr1, redeemScript1, shuffledSignatures)
+
+      val data: Array[Byte] = cmdInput.encode()
+      val msg = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      val expectedOwnershipId = Keccak256.hash(mcMultiSigAddr1.getBytes(StandardCharsets.UTF_8))
+
+      // positive case, verify we can add the data to view
+      val returnData = assertGas(514937, msg, view, messageProcessor, defaultBlockContext)
+      assertNotNull(returnData)
+
+      assertArrayEquals(expectedOwnershipId, returnData)
+
+      // Checking log
+      val listOfLogs = view.getLogs(txHash1)
+      assertEquals("Wrong number of logs", 1, listOfLogs.length)
+      val expectedAddEvt = AddMcAddrOwnership(scAddressObj1, mcMultiSigAddr1)
+      checkAddNewOwnershipEvent(expectedAddEvt, listOfLogs(0))
+
+    }
+  }
+
+  @Test
+  def testAddMultisigOwnershipMaxNumOfPubKeys(): Unit = {
+
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = BigInteger.valueOf(100).multiply(validWeiAmount)
+
+      //Setting the context
+      val txHash1 = Keccak256.hash("first tx")
+      view.setupTxContext(txHash1, 10)
+
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      val cmdInput = AddNewMultisigOwnershipCmdInput(mcMultiSigAddrBig, redeemScriptBig, listOfMcMultisigAddrSign_big)
+
+      val data: Array[Byte] = cmdInput.encode()
+      val msg = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      val expectedOwnershipId = Keccak256.hash(mcMultiSigAddrBig.getBytes(StandardCharsets.UTF_8))
+
+      // positive case, verify we can add the data to view
+      val returnData = assertGas(514937, msg, view, messageProcessor, defaultBlockContext)
+      assertNotNull(returnData)
+
+      assertArrayEquals(expectedOwnershipId, returnData)
+
+      // Checking log
+      val listOfLogs = view.getLogs(txHash1)
+      assertEquals("Wrong number of logs", 1, listOfLogs.length)
+      val expectedAddEvt = AddMcAddrOwnership(scAddressObj1, mcMultiSigAddrBig)
+      checkAddNewOwnershipEvent(expectedAddEvt, listOfLogs(0))
+
+    }
+  }
+
+
+  @Test
+  def testNegativeAddMultisigOwnership(): Unit = {
+
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = BigInteger.valueOf(100).multiply(validWeiAmount)
+
+      //Setting the context
+      val txHash1 = Keccak256.hash("first tx")
+      view.setupTxContext(txHash1, 10)
+
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      // Use a valid multisig address but not corresponding to redeem script
+      var cmdInput = AddNewMultisigOwnershipCmdInput(mcMultiSigAddr2, redeemScript1, listOfMcMultisigAddrSign_1)
+      var data: Array[Byte] = cmdInput.encode()
+      var msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      var ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Could not verify multisig address against redeemScript"))
+
+      // Use an ill formed mc addr
+      cmdInput = AddNewMultisigOwnershipCmdInput("_______ThisIsNotAnMcAddress________", redeemScript1, listOfMcMultisigAddrSign_2)
+      data = cmdInput.encode()
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Could not verify multisig address against redeemScript"))
+
+
+      // Use an ill formed redeem script
+      cmdInput = AddNewMultisigOwnershipCmdInput(mcMultiSigAddr1, "_______ThisIsNotARedeemScript______«", listOfMcMultisigAddrSign_2)
+      data = cmdInput.encode()
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Unexpected format of redeemScript"))
+
+      // Use a wrong list of signatures address
+      cmdInput = AddNewMultisigOwnershipCmdInput(mcMultiSigAddr1, redeemScript1, listOfMcMultisigAddrSign_2)
+      data = cmdInput.encode()
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Invalid number of verified signatures: 0"))
+
+      // Use too short a list of signatures address
+      val seqTest = listOfMcMultisigAddrSign_1.take(1)
+      cmdInput = AddNewMultisigOwnershipCmdInput(mcMultiSigAddr1, redeemScript1, seqTest)
+      data = cmdInput.encode()
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Invalid number of verified signatures: 1"))
+
+      // Use an illegal redeemScript
+      cmdInput = AddNewMultisigOwnershipCmdInput(mcMultiSigAddr1, redeemScript1.replace("ae", "dd"), listOfMcMultisigAddrSign_1)
+      data = cmdInput.encode()
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewMultisigOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Unexpected format of redeemScript"))
+    }
+  }
+
+  @Test
+  def testGetListOfOwnerships(): Unit = {
+
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = BigInteger.valueOf(10).multiply(validWeiAmount)
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      val listOfAllExpectedData = new util.ArrayList[McAddrOwnershipData]()
+      val listOfScAddress1ExpectedData = new util.ArrayList[McAddrOwnershipData]()
+
+      // add some mc address associations for sc address 1
+      for (i <- 0 until listOfMcAddrSign1.size()) {
+        val mcAddr = listOfMcAddrSign1.get(i)._1
+        val mcSignature = listOfMcAddrSign1.get(i)._2
+        val cmdInput = AddNewOwnershipCmdInput(mcAddr, mcSignature)
+
+        val data: Array[Byte] = cmdInput.encode()
+        val msg = getMessage(contractAddress, BigInteger.ZERO,
+          BytesUtils.fromHexString(AddNewOwnershipCmd) ++ data, randomNonce, scAddressObj1)
+
+        listOfAllExpectedData.add(McAddrOwnershipData(scAddrStr1.toLowerCase(), mcAddr))
+        listOfScAddress1ExpectedData.add(McAddrOwnershipData(scAddrStr1.toLowerCase(), mcAddr))
+
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        assertNotNull(returnData)
+      }
+
+      createSenderAccount(view, initialAmount, scAddressObj2)
+      val listOfScAddress2ExpectedData = new util.ArrayList[McAddrOwnershipData]()
+
+      // add some mc address associations for sc address 2
+      for (i <- 0 until listOfMcAddrSign2.size()) {
+        val mcAddr = listOfMcAddrSign2.get(i)._1
+        val mcSignature = listOfMcAddrSign2.get(i)._2
+        val cmdInput = AddNewOwnershipCmdInput(mcAddr, mcSignature)
+
+        val data: Array[Byte] = cmdInput.encode()
+        val msg = getMessage(contractAddress, BigInteger.ZERO,
+          BytesUtils.fromHexString(AddNewOwnershipCmd) ++ data, randomNonce, scAddressObj2)
+
+        listOfAllExpectedData.add(McAddrOwnershipData(scAddrStr2.toLowerCase(), mcAddr))
+        listOfScAddress2ExpectedData.add(McAddrOwnershipData(scAddrStr2.toLowerCase(), mcAddr))
+
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        assertNotNull(returnData)
+      }
+
+
+      // get associations of each sc address
+      val data1List = messageProcessor.getListOfMcAddrOwnerships(view, Some(scAddrStr1.toLowerCase()))
+      val data2List = messageProcessor.getListOfMcAddrOwnerships(view, Some(scAddrStr2.toLowerCase()))
+
+      // get all associations
+      val dataAllList = messageProcessor.getListOfMcAddrOwnerships(view)
+
+      assertEquals(listOfAllExpectedData, dataAllList.asJava)
+      assertEquals(listOfScAddress1ExpectedData, data1List.asJava)
+      assertEquals(listOfScAddress2ExpectedData, data2List.asJava)
+
+      // get the list of all ownerships via native smart contract interface
+      val returnData1 = getOwnershipList(view, scAddressObj1)
+      assertNotNull(returnData1)
+      assertArrayEquals(McAddrOwnershipDataListEncoder.encode(listOfScAddress1ExpectedData), returnData1)
+
+      val returnData2 = getOwnershipList(view, scAddressObj2)
+      assertNotNull(returnData2)
+      assertArrayEquals(McAddrOwnershipDataListEncoder.encode(listOfScAddress2ExpectedData), returnData2)
+
+      val returnAllData = getAllOwnershipList(view)
+      assertNotNull(returnAllData)
+      assertArrayEquals(McAddrOwnershipDataListEncoder.encode(listOfAllExpectedData), returnAllData)
+
+      view.commit(bytesToVersion(getVersion.data()))
+    }
+  }
+
+
+  @Test
+  def testOwnershipLinkedList(): Unit = {
+
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = ZenWeiConverter.MAX_MONEY_IN_WEI
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      val listOfExpectedData = new util.ArrayList[McAddrOwnershipData]()
+      val numOfOwnerships = listOfMcAddrSign1.size()
+      assertTrue("Test data list too short", numOfOwnerships > 3)
+
+      // add some mc sc address associations
+      for (i <- 0 until numOfOwnerships) {
+        val mcAddr = listOfMcAddrSign1.get(i)._1
+        val mcSignature = listOfMcAddrSign1.get(i)._2
+        val cmdInput = AddNewOwnershipCmdInput(mcAddr, mcSignature)
+
+        val data: Array[Byte] = cmdInput.encode()
+        val msg = getMessage(contractAddress, BigInteger.ZERO,
+          BytesUtils.fromHexString(AddNewOwnershipCmd) ++ data, randomNonce, scAddressObj1)
+
+        listOfExpectedData.add(McAddrOwnershipData(scAddrStr1, mcAddr))
+
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        assertNotNull(returnData)
+      }
+
+      val ownershipList = getAllOwnershipList(view)
+      val ownershipList2 = getOwnershipList(view, scAddressObj1)
+
+      //Check getListOfForgers
+      val expectedListData = McAddrOwnershipDataListEncoder.encode(listOfExpectedData)
+      assertArrayEquals(expectedListData, ownershipList)
+      assertArrayEquals(expectedListData, ownershipList2)
+
+      // remove in the middle of the list
+      checkRemoveItemFromList(view, listOfExpectedData, 2)
+
+      // remove at the beginning of the list (head)
+      checkRemoveItemFromList(view, listOfExpectedData, 0)
+
+      // remove at the end of the list
+      checkRemoveItemFromList(view, listOfExpectedData, listOfExpectedData.size()-1)
+
+      // remove the last element we have
+      checkRemoveItemFromList(view, listOfExpectedData, 0)
+
+      // call msg processor for removing a not existing association. In this casethe linked list is not even accessed
+      val ex = intercept[ExecutionRevertedException] {
+        removeOwnership(view, new Address("0x"+scAddrStr1), mcAddrStr1_2)
+      }
+      assertTrue(ex.getMessage.contains("does not exist"))
+
+      view.commit(bytesToVersion(getVersion.data()))
+    }
+  }
+
+  @Test
+  def testInvalidAddNewOwnershipCmd(): Unit = {
+
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = ZenWeiConverter.MAX_MONEY_IN_WEI
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      val cmdInput = AddNewOwnershipCmdInput(mcAddrStr1, mcSignatureStr1)
+      val data: Array[Byte] = cmdInput.encode()
+
+      val msg = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+
+      val returnData = assertGas(514937, msg, view, messageProcessor, defaultBlockContext)
+      assertNotNull(returnData)
+
+
+      // try adding with a value amount not null
+      var msgBad = getMessage(contractAddress, BigInteger.ONE.negate(),
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ cmdInput.encode(),
+        randomNonce, scAddressObj1
+      )
+      var ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Value must be zero"))
+
+      // try processing a msg with a trailing byte in the arguments, should fail
+      val badData = Bytes.concat(data, new Array[Byte](1))
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ badData,
+        randomNonce,
+        scAddressObj1)
+
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Wrong message data field length"))
+
+      // try processing a msg with different data (different nonce) but same ownership, should fail
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1)
+
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("already associated"))
+
+      // try using a wrong sender
+      createSenderAccount(view, initialAmount, origin)
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ data,
+        randomNonce,
+        origin)
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Invalid mc signature"))
+
+      // try using a wrong signature
+      var cmdInputBad = AddNewOwnershipCmdInput(mcAddrStr2, mcSignatureStr1)
+      var dataBad: Array[Byte] = cmdInputBad.encode()
+
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ dataBad,
+        randomNonce,
+        scAddressObj1)
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Invalid mc signature"))
+
+      // try using a wrong signature
+      cmdInputBad = AddNewOwnershipCmdInput(mcAddrStr2, mcSignatureStr1)
+      dataBad = cmdInputBad.encode()
+
+      msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ dataBad,
+        randomNonce,
+        scAddressObj1)
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Invalid mc signature"))
+
+      // try using an ill formed mc addr (we take a shorter BTC address)
+      val btcAddr = "1BNwxHGaFbeUBitpjy2AsKpJ29Ybxntqvb"
+      val ex2 = intercept[IllegalArgumentException] {
+
+        cmdInputBad = AddNewOwnershipCmdInput(btcAddr, mcSignatureStr1)
+
+        dataBad = cmdInputBad.encode()
+      }
+      assertTrue(ex2.getMessage.contains("Invalid mc address length"))
+
+      // try adding a new association using a mc address already associated to a sc address, should fail
+      createSenderAccount(view, initialAmount, scAddressObj2)
+
+      val cmdInput2 = AddNewOwnershipCmdInput(mcAddrStr1, mcSignatureStr3_2)
+      val data2: Array[Byte] = cmdInput2.encode()
+
+      val msg2 = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ data2,
+        randomNonce,
+        scAddressObj2
+      )
+
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msg2, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains(s"already associated to sc address ${scAddrStr1.toLowerCase()}"))
+    }
+  }
+
+  @Test
+  def testInvalidRemoveOwnershipCmd(): Unit = {
+
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = ZenWeiConverter.MAX_MONEY_IN_WEI
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      val cmdInput = AddNewOwnershipCmdInput(mcAddrStr1, mcSignatureStr1)
+
+      val data: Array[Byte] = cmdInput.encode()
+      val msg = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+
+      val returnData = assertGas(514937, msg, view, messageProcessor, defaultBlockContext)
+      assertNotNull(returnData)
+
+      val removeCmdInput = RemoveOwnershipCmdInput(Some(mcAddrStr1))
+
+      // try removing with a value amount not null (value 1)
+      var msgBad = getMessage(contractAddress, BigInteger.ONE,
+        BytesUtils.fromHexString(RemoveOwnershipCmd) ++ removeCmdInput.encode(),
+        randomNonce, scAddressObj1
+      )
+      var ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Value must be zero"))
+
+      // try removing with a value amount not null (value -1)
+      msgBad = getMessage(contractAddress, BigInteger.ONE.negate(),
+        BytesUtils.fromHexString(RemoveOwnershipCmd) ++ removeCmdInput.encode(),
+        randomNonce, scAddressObj1
+      )
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Value must be zero"))
+
+      // should fail because input data has a trailing byte
+      val badData = new Array[Byte](1)
+      msgBad = getMessage(contractAddress, BigInteger.ZERO,
+        BytesUtils.fromHexString(RemoveOwnershipCmd) ++ removeCmdInput.encode() ++ badData,
+        randomNonce, scAddressObj1
+      )
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("Wrong message data field length"))
+
+      // should fail because sender does not exist
+      msgBad = getMessage(contractAddress, BigInteger.ZERO,
+        BytesUtils.fromHexString(RemoveOwnershipCmd) ++ removeCmdInput.encode(),
+        randomNonce, origin
+      )
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("account does not exist"))
+
+      // should fail because sender is not the owner
+      createSenderAccount(view, initialAmount, origin)
+      msgBad = getMessage(contractAddress, BigInteger.ZERO,
+        BytesUtils.fromHexString(RemoveOwnershipCmd) ++ removeCmdInput.encode(),
+        randomNonce, origin
+      )
+      ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      assertTrue(ex.getMessage.contains("is not the owner"))
+
+      // should fail because mc address in not legal (we take a shorter BTC address)
+      val btcAddr = "1BNwxHGaFbeUBitpjy2AsKpJ29Ybxntqvb"
+      val removeCmdInputBad = RemoveOwnershipCmdInput(Some(btcAddr))
+      val ex2 = intercept[IllegalArgumentException] {
+        msgBad = getMessage(contractAddress, BigInteger.ZERO,
+          BytesUtils.fromHexString(RemoveOwnershipCmd) ++ removeCmdInputBad.encode(),
+          randomNonce, scAddressObj1
+        )
+      }
+      assertTrue(ex2.getMessage.contains("Invalid mc address length"))
+
+      view.commit(bytesToVersion(getVersion.data()))
+    }
+  }
+
+  def checkRemoveItemFromList(stateView: AccountStateView, inputList: java.util.List[McAddrOwnershipData],
+                              itemPosition: Int): Unit = {
+
+    // get the info related to the item to remove
+    val info = inputList.remove(itemPosition)
+
+    // call msg processor for removing the selected obj
+    removeOwnership(stateView, new Address("0x"+info.scAddress), info.mcTransparentAddress)
+
+    // call msg processor for retrieving the resulting list of forgers
+    val returnedList = getAllOwnershipList(stateView)
+
+    // check the results:
+    //  we removed just one element
+    val inputListData = McAddrOwnershipDataListEncoder.encode(inputList)
+    assertArrayEquals(inputListData, returnedList)
+  }
+
+  def checkAddNewOwnershipEvent(expectedEvent: AddMcAddrOwnership, actualEvent: EthereumConsensusDataLog): Unit = {
+    assertEquals("Wrong address", contractAddress, actualEvent.address)
+    assertEquals("Wrong number of topics", NumOfIndexedAddNewEvtParams + 1, actualEvent.topics.length) //The first topic is the hash of the signature of the event
+    assertArrayEquals("Wrong event signature", AddNewEventSig, actualEvent.topics(0).toBytes)
+    assertEquals("Wrong from address in topic", expectedEvent.scAddress, decodeEventTopic(actualEvent.topics(1), TypeReference.makeTypeReference(expectedEvent.scAddress.getTypeAsString)))
+
+    val listOfRefs = util.Arrays.asList(
+      TypeReference.makeTypeReference(expectedEvent.mcAddress_3.getTypeAsString),
+    TypeReference.makeTypeReference(expectedEvent.mcAddress_32.getTypeAsString))
+      .asInstanceOf[util.List[TypeReference[Type[_]]]]
+    val listOfDecodedData = FunctionReturnDecoder.decode(BytesUtils.toHexString(actualEvent.data), listOfRefs)
+    assertEquals("Wrong bytes in first part of mc address", expectedEvent.mcAddress_3, listOfDecodedData.get(0))
+    assertEquals("Wrong bytes in second part of mc address", expectedEvent.mcAddress_32, listOfDecodedData.get(1))
+  }
+
+  def checkRemoveNewOwnershipEvent(expectedEvent: RemoveMcAddrOwnership, actualEvent: EthereumConsensusDataLog) : Unit = {
+    assertEquals("Wrong address", contractAddress, actualEvent.address)
+    assertEquals("Wrong number of topics", NumOfIndexedRemoveEvtParams + 1, actualEvent.topics.length) //The first topic is the hash of the signature of the event
+    assertArrayEquals("Wrong event signature", RemoveEventSig, actualEvent.topics(0).toBytes)
+    assertEquals("Wrong from address in topic", expectedEvent.scAddress, decodeEventTopic(actualEvent.topics(1), TypeReference.makeTypeReference(expectedEvent.scAddress.getTypeAsString)))
+
+    val listOfRefs = util.Arrays.asList(
+      TypeReference.makeTypeReference(expectedEvent.mcAddress_3.getTypeAsString),
+      TypeReference.makeTypeReference(expectedEvent.mcAddress_32.getTypeAsString))
+      .asInstanceOf[util.List[TypeReference[Type[_]]]]
+    val listOfDecodedData = FunctionReturnDecoder.decode(BytesUtils.toHexString(actualEvent.data), listOfRefs)
+    assertEquals("Wrong bytes in first part of mc address", expectedEvent.mcAddress_3, listOfDecodedData.get(0))
+    assertEquals("Wrong bytes in second part of mc address", expectedEvent.mcAddress_32, listOfDecodedData.get(1))
+  }
+
+  def removeOwnership(stateView: AccountStateView, scAddress: Address, mcTransparentAddress: String): Unit = {
+    val nonce = randomNonce
+
+    // create command arguments
+    val removeCmdInput = RemoveOwnershipCmdInput(Some(mcTransparentAddress))
+    val data: Array[Byte] = removeCmdInput.encode()
+    val msg = getMessage(
+      contractAddress,
+      0,
+      BytesUtils.fromHexString(RemoveOwnershipCmd) ++ data,
+      nonce,
+      scAddress
+    )
+
+    // try processing the removal of ownership, should succeed
+    val returnData = withGas(TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, _))
+    assertNotNull(returnData)
+    assertArrayEquals(getOwnershipId(mcTransparentAddress), returnData)
+  }
+
+  def getAllOwnershipList(stateView: AccountStateView): Array[Byte] = {
+    val msg = getMessage(contractAddress, 0, BytesUtils.fromHexString(GetListOfAllOwnershipsCmd), randomNonce)
+    stateView.setupAccessList(msg)
+
+    val (returnData, usedGas) = withGas { gas =>
+      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas)
+      (result, gas.getUsedGas)
+    }
+    // gas consumption depends on the number of items in the list
+    assertTrue(usedGas.compareTo(0) > 0)
+    assertTrue(usedGas.compareTo(500000) < 0)
+
+    assertNotNull(returnData)
+    returnData
+  }
+
+  def getOwnershipList(stateView: AccountStateView, scAddress: Address): Array[Byte] = {
+    val getCmdInput = GetOwnershipsCmdInput(scAddress)
+    val data: Array[Byte] = getCmdInput.encode()
+
+    val msg = getMessage(
+      contractAddress, 0,
+      BytesUtils.fromHexString(GetListOfOwnershipsCmd) ++ data, randomNonce)
+    stateView.setupAccessList(msg)
+    val (returnData, usedGas) = withGas { gas =>
+      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas)
+      (result, gas.getUsedGas)
+    }
+    // gas consumption depends on the number of items in the list
+    assertTrue(usedGas.compareTo(0) > 0)
+    assertTrue(usedGas.compareTo(500000) < 0)
+
+    assertNotNull(returnData)
+    returnData
+  }
+
+  @Test
+  def testNegativeAddOwnershipWithMultisigSignature(): Unit = {
+
+    // verify we can not link the mc address with its signature applied on a multisig message (mcMultisigAddr+scAddress)
+    // which is different from the ordinary message (scAddress only)
+    usingView(messageProcessor) { view =>
+
+      messageProcessor.init(view, view.getConsensusEpochNumberAsInt)
+
+      // create sender account with some fund in it
+      val initialAmount = BigInteger.valueOf(100).multiply(validWeiAmount)
+
+      //Setting the context
+      val txHash1 = Keccak256.hash("first tx")
+      view.setupTxContext(txHash1, 10)
+
+      createSenderAccount(view, initialAmount, scAddressObj1)
+
+      // verify this is the address of one of the valid signers and the signature is valid if applied on the right message
+      val messageToSign = mcMultiSigAddr1 + Keys.toChecksumAddress(Numeric.toHexString(scAddressObj1.toBytes))
+      assertTrue(testIsValidOwnershipSignature(messageToSign, mcAddrStr_11, getMcSignature(mcSignatureStr_11)))
+
+      val cmdInput = AddNewOwnershipCmdInput(mcAddrStr_11, mcSignatureStr_11)
+      val data: Array[Byte] = cmdInput.encode()
+      val msgBad = getMessage(
+        contractAddress,
+        BigInteger.ZERO,
+        BytesUtils.fromHexString(AddNewOwnershipCmd) ++ data,
+        randomNonce,
+        scAddressObj1
+      )
+      val ex = intercept[ExecutionRevertedException] {
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+      }
+      // the signature has been applied on a different message
+      assertTrue(ex.getMessage.contains("Invalid mc signature"))
+    }
+  }
+
+  def testIsValidOwnershipSignature(message: String, mcTransparentAddress: String, mcSignature: SignatureSecp256k1): Boolean = {
+    // get a signature data obj for the verification
+    val v_barr = getUnsignedByteArray(mcSignature.getV)
+    val r_barr = padWithZeroBytes(getUnsignedByteArray(mcSignature.getR), SIGNATURE_RS_SIZE)
+    val s_barr = padWithZeroBytes(getUnsignedByteArray(mcSignature.getS), SIGNATURE_RS_SIZE)
+
+    val signatureData = new Sign.SignatureData(v_barr, r_barr, s_barr)
+
+    // the sc address hex string used in the message to sign must have a checksum format (EIP-55: Mixed-case checksum address encoding)
+    val hashedMsg = getMcHashedMsg(message)
+
+    // verify MC message signature
+    val recPubKey = Sign.signedMessageHashToKey(hashedMsg, signatureData)
+    val recUncompressedPubKeyBytes = Bytes.concat(Array[Byte](0x04), Numeric.toBytesPadded(recPubKey, PUBLIC_KEY_SIZE))
+    val ecpointRec = ecParameters.getCurve.decodePoint(recUncompressedPubKeyBytes)
+    val recCompressedPubKeyBytes = ecpointRec.getEncoded(true)
+    val mcPubkeyhash = Ripemd160Sha256Hash(recCompressedPubKeyBytes)
+    val computedTaddr = toHorizenPublicKeyAddress(mcPubkeyhash, mockNetworkParams)
+
+    computedTaddr.equals(mcTransparentAddress)
+  }
+
+}


### PR DESCRIPTION
Adding support for MC multisig addresses in ZenDAO native smart contract.
- new ABI interface for adding an ownership link between SC address and MC multisig address
- New HTTP API added
- Nwe UT and py tests  
