### PR TITLE
Fix for wrong signature of openStakeForgerList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 **0.10.0**
+1. Forger Stake native smart contract: OpenStakeForgerList function can be invoked using the ABI-compliant signature. The old signature is still valid for backward compatibility.
 
 **0.9.0**
 1. libevm dependency updated to 1.0.0.

--- a/doc/release/0.10.0.md
+++ b/doc/release/0.10.0.md
@@ -15,7 +15,7 @@ sparkz {
   }
 }
 ```
-The deafalut setting is = false, and is the correct configuration for standard behaviour.
+The default setting is = false, and is the correct configuration for standard behaviour.
 Setting it to 'true' will force the node to re-evaluate all the blocks received from other peers, even if they were previously marked as invalid/incorrect.
 This configuration can be used if a node was not updated on-time before a mandatory hard-fork, and after the fork is stuck in a separate chain. In such this case, updating the node with the correct version will not be enough to having it re-join the longest chain, because the modifiers status cache will still contain some blocks marked as invalid. 
 The suggested procedure in this situation is:
@@ -30,7 +30,7 @@ The suggested procedure in this situation is:
 
 ---
 ## Bug Fixes
-
+- Forger Stake native smart contract: OpenStakeForgerList function can be invoked using the ABI-compliant signature.
 ---
 
 ## Improvements

--- a/qa/run_sc_tests.sh
+++ b/qa/run_sc_tests.sh
@@ -140,7 +140,7 @@ testScriptsEvm=(
     'sc_evm_consensus_parameters_fork_with_sidechain_forks.py'
     'sc_evm_consensus_parameters_fork_with_mainchain_forks.py'
     'sc_evm_ft_to_smart_contract.py'
-    'sc_evm_forging_fee_payments_rollback.py
+    'sc_evm_forging_fee_payments_rollback.py'
 );
 
 testScriptsUtxo=(


### PR DESCRIPTION
## Description
Fix the signature of openStakeForgerList method, keeping retro-compatibility with old but wrong signature.

## Jira Ticket
[SDK-1606](https://horizenlabs.atlassian.net/browse/SDK-1606?atlOrigin=eyJpIjoiZTgzOGRmNWJkOWVkNDdmZThkNjdkOTIxZjE0MjNiNmMiLCJwIjoiaiJ9)

## Changes
Modified ForgerStakeMsgProcessor and its unit test.

## Breaking Changes


## Checks
- [ X] Project Builds
- [ X] Project passes tests and checks
- [X ] Updated documentation accordingly
- [ X] Breaking changes have been correctly tagged and notified
 
## Additional information


[SDK-1606]: https://horizenlabs.atlassian.net/browse/SDK-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ