### PR TITLE
Signature v field serialization

### DIFF
--- a/sdk/src/main/java/io/horizen/account/proof/SignatureSecp256k1.java
+++ b/sdk/src/main/java/io/horizen/account/proof/SignatureSecp256k1.java
@@ -8,6 +8,7 @@ import io.horizen.account.secret.PrivateKeySecp256k1;
 import io.horizen.account.utils.Secp256k1;
 import io.horizen.evm.Address;
 import io.horizen.json.serializer.HexNoPrefixBigIntegerSerializer;
+import io.horizen.json.serializer.SignatureVFieldSerializer;
 import io.horizen.proof.ProofOfKnowledge;
 import io.horizen.proof.ProofSerializer;
 import io.horizen.json.Views;
@@ -18,7 +19,7 @@ import java.math.BigInteger;
 public final class SignatureSecp256k1 implements ProofOfKnowledge<PrivateKeySecp256k1, AddressProposition> {
 
     @JsonProperty("v")
-    @JsonSerialize(using = HexNoPrefixBigIntegerSerializer.class)
+    @JsonSerialize(using = SignatureVFieldSerializer.class)
     private final BigInteger v;
 
     @JsonProperty("r")

--- a/sdk/src/main/java/io/horizen/json/serializer/SignatureVFieldSerializer.java
+++ b/sdk/src/main/java/io/horizen/json/serializer/SignatureVFieldSerializer.java
@@ -1,0 +1,22 @@
+package io.horizen.json.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.horizen.account.transaction.EthereumTransaction;
+import org.web3j.crypto.Sign;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+
+public class SignatureVFieldSerializer extends JsonSerializer<BigInteger> {
+    @Override
+    public void serialize(BigInteger val, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        Object pojo = jsonGenerator.getOutputContext().getParent().getCurrentValue();
+        if (pojo instanceof EthereumTransaction && ((EthereumTransaction) pojo).isLegacy())
+            jsonGenerator.writeString(val.toString(16));
+        else
+            jsonGenerator.writeString(val.subtract(BigInteger.valueOf(Sign.LOWER_REAL_V)).toString(16));
+    }
+}

--- a/sdk/src/main/java/io/horizen/json/serializer/SignatureVFieldSerializer.java
+++ b/sdk/src/main/java/io/horizen/json/serializer/SignatureVFieldSerializer.java
@@ -13,10 +13,15 @@ import java.math.BigInteger;
 public class SignatureVFieldSerializer extends JsonSerializer<BigInteger> {
     @Override
     public void serialize(BigInteger val, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
-        Object pojo = jsonGenerator.getOutputContext().getParent().getCurrentValue();
-        if (pojo instanceof EthereumTransaction && ((EthereumTransaction) pojo).isLegacy())
+        try {
+            Object pojo = jsonGenerator.getOutputContext().getParent().getCurrentValue();
+            if (pojo instanceof EthereumTransaction && ((EthereumTransaction) pojo).isLegacy())
+                jsonGenerator.writeString(val.toString(16));
+            else
+                jsonGenerator.writeString(val.subtract(BigInteger.valueOf(Sign.LOWER_REAL_V)).toString(16));
+        } catch (Exception e) {
+            // default serialization in case Signature is not a part of EthereumTransaction
             jsonGenerator.writeString(val.toString(16));
-        else
-            jsonGenerator.writeString(val.subtract(BigInteger.valueOf(Sign.LOWER_REAL_V)).toString(16));
+        }
     }
 }


### PR DESCRIPTION
## Description
Signature v field json representation was wrong - the value should be 0 or 1

## Jira Ticket
https://horizenlabs.atlassian.net/browse/SDK-1627

## Changes
Added a new JsonSerializer specifically for signature.v field - it checks the type of the transaction it is part of, and if the type is legacy - v field is 27 or 28. If the type if EIP1559 - v field is 0 or 1

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
- [x] Breaking changes have been correctly tagged and notified
 
## Additional information
