### PR TITLE
Limit number of block to traverse for eth_getLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 **0.10.0**
 1. Forger Stake native smart contract: OpenStakeForgerList function can be invoked using the ABI-compliant signature. The old signature is still valid for backward compatibility.
+2. Added limit for number of blocks to inspect for eth_getLogs
 
 **0.9.0**
 1. libevm dependency updated to 1.0.0.

--- a/sdk/src/main/scala/io/horizen/SidechainSettings.scala
+++ b/sdk/src/main/scala/io/horizen/SidechainSettings.scala
@@ -109,6 +109,11 @@ case class EthServiceSettings(
     getLogsSizeLimit: Int = 10000,
 
     /**
+     * Size limit of the number of blocks traversed by the RPC call eth_getLogs
+     */
+    getLogsBlockLimit: Int = 10000,
+
+    /**
      * Timeout limit for the RPC call eth_getLogs
      */
     getLogsQueryTimeout: FiniteDuration = 10.seconds

--- a/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
@@ -1116,7 +1116,7 @@ class EthService(
             val end = parseBlockTag(nodeView, query.toBlock)
             if (start > end || end - start > settings.getLogsBlockLimit) {
               throw new RpcException(RpcError.fromCode(RpcCode.InvalidParams,
-                "invalid block range. fromBlock should be before toBlock and range should be less than " + settings.getLogsBlockLimit))
+                "invalid block range. fromBlock should be before toBlock and range should be not over " + settings.getLogsBlockLimit))
             }
 
             var resultCount = 0

--- a/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/rpc/service/EthService.scala
@@ -1114,8 +1114,9 @@ class EthService(
           } else {
             val start = parseBlockTag(nodeView, query.fromBlock)
             val end = parseBlockTag(nodeView, query.toBlock)
-            if (start > end) {
-              throw new RpcException(RpcError.fromCode(RpcCode.InvalidParams, "invalid block range"))
+            if (start > end || end - start > settings.getLogsBlockLimit) {
+              throw new RpcException(RpcError.fromCode(RpcCode.InvalidParams,
+                "invalid block range. fromBlock should be before toBlock and range should be less than " + settings.getLogsBlockLimit))
             }
 
             var resultCount = 0

--- a/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/rpc/service/EthServiceTest.scala
@@ -1465,5 +1465,10 @@ class EthServiceTest extends JUnitSuite with MockitoSugar with ReceiptFixture wi
     }
   }
 
-
+  @Test
+  def eth_getLogs(): Unit = {
+    assertThrows[RpcException] {
+      rpc("eth_getLogs", Map("fromBlock" -> "1", "toBlock" -> "10002"))
+    }
+  }
 }


### PR DESCRIPTION
eth_getLogs with earliest and latest block tags timed out because it tried to inspect all the blocks. Failing EthService actor also failed all the other concurrent calls

## Jira Ticket
https://horizenlabs.atlassian.net/browse/SDK-1643

## Changes
Added a configurable limit of blocks that can be inspected. Limit set to 10000. Change error message to represent new condition.


## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
- [x] Breaking changes have been correctly tagged and notified

