### PR TITLE
Forger reward address

### DIFF
--- a/qa/SidechainTestFramework/account/smart_contract_resources/contracts/ReceivingEther.sol
+++ b/qa/SidechainTestFramework/account/smart_contract_resources/contracts/ReceivingEther.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract ReceivingEther {
+
+    // Helper function to check the balance of this contract
+    function getBalance() public view returns (uint) {
+        return address(this).balance;
+    }
+}

--- a/qa/SidechainTestFramework/sc_boostrap_info.py
+++ b/qa/SidechainTestFramework/sc_boostrap_info.py
@@ -98,9 +98,10 @@ Configuration that enables the possibility to restrict the forging phase
 
 
 class SCForgerConfiguration(object):
-    def __init__(self, restrict_forgers=False, allowed_forgers=[]):
+    def __init__(self, restrict_forgers=False, allowed_forgers=[], forger_reward_address=""):
         self.restrict_forgers = restrict_forgers
         self.allowed_forgers = []
+        self.forger_reward_address = forger_reward_address
         for forger in allowed_forgers:
             self.allowed_forgers.append(
                 '{ blockSignProposition = "' + forger[0] + '" NEW_LINE vrfPublicKey = "' + forger[1] + '" }')

--- a/qa/SidechainTestFramework/scutil.py
+++ b/qa/SidechainTestFramework/scutil.py
@@ -550,7 +550,8 @@ def initialize_sc_datadir(dirname, n, model, bootstrap_info=SCBootstrapInfo, sc_
         'MAX_MEMPOOL_SLOTS': sc_node_config.max_mempool_slots,
         'MAX_NONEXEC_SLOTS': sc_node_config.max_nonexec_pool_slots,
         'TX_LIFETIME': sc_node_config.tx_lifetime,
-        'HANDLING_TXS_ENABLED': ("true" if sc_node_config.handling_txs_enabled else "false")
+        'HANDLING_TXS_ENABLED': ("true" if sc_node_config.handling_txs_enabled else "false"),
+        'FORGER_REWARD_ADDRESS': sc_node_config.forger_options.forger_reward_address
 
     }
     config = config.replace("'", "")

--- a/qa/resources/template.conf
+++ b/qa/resources/template.conf
@@ -89,6 +89,7 @@ sparkz {
   forger {
     restrictForgers = %(RESTRICT_FORGERS)s
     allowedForgersList = %(ALLOWED_FORGERS_LIST)s
+    forgerRewardAddress = "%(FORGER_REWARD_ADDRESS)s"
   }
 
   remoteKeysManager {

--- a/qa/run_sc_tests.sh
+++ b/qa/run_sc_tests.sh
@@ -143,6 +143,7 @@ testScriptsEvm=(
     'sc_evm_ft_to_smart_contract.py'
     'sc_evm_forging_fee_payments_rollback.py'
     'sc_evm_shanghai.py'
+    'sc_evm_forger_reward_address.py'
 );
 
 testScriptsUtxo=(

--- a/qa/sc_evm_forger_reward_address.py
+++ b/qa/sc_evm_forger_reward_address.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+import json
+import logging
+import os
+import re
+
+from eth_utils import remove_0x_prefix
+
+from SidechainTestFramework.account.ac_chain_setup import AccountChainSetup
+from SidechainTestFramework.account.ac_use_smart_contract import SmartContract
+from SidechainTestFramework.account.ac_utils import ac_makeForgerStake, deploy_smart_contract
+from SidechainTestFramework.account.utils import convertZenToZennies, computeForgedTxFee
+from SidechainTestFramework.sc_forging_util import check_mcreference_presence
+from SidechainTestFramework.scutil import (
+    connect_sc_nodes, generate_next_block, SLOTS_IN_EPOCH, EVM_APP_SLOT_TIME,
+    start_sc_node, stop_sc_node, wait_for_sc_node_initialization,
+    EVM_APP_BINARY, )
+from httpCalls.block.getFeePayments import http_block_getFeePayments
+from test_framework.util import (
+    assert_equal, fail, forward_transfer_to_sidechain, assert_false, )
+
+"""
+Check Forger fee payments to a reward address that is a Smart Contract:
+1. Forge block to reach fee distribution epoch.
+Configuration:
+    Start 1 MC node and 2 SC node.
+    SC nodes are connected to the MC node.
+Test:
+    - Start 2 SC nodes
+    - deploy a smart contract on SC node 1
+    - restart sc node 2 with a new forger reward address
+    - create forger stake on sc node 2
+    - forge block to reach fee distribution epoch
+    - verify that smart contract balance is updated with the forging fee
+    
+    This test doesn't support --allforks.
+"""
+
+
+class ScEvmForgingFeePayments(AccountChainSetup):
+    FORGER_REWARD_ADDRESS = '0000000000000000000012341234123412341234'
+
+    def __init__(self):
+        super().__init__(number_of_sidechain_nodes=2, withdrawalEpochLength=20, forward_amount=20,
+                         block_timestamp_rewind=SLOTS_IN_EPOCH * EVM_APP_SLOT_TIME * 100)
+
+    def advance_to_epoch(self, epoch_number: int):
+        sc_node = self.sc_nodes[0]
+        forging_info = sc_node.block_forgingInfo()
+        current_epoch = forging_info["result"]["bestBlockEpochNumber"]
+        # make sure we are not already passed the desired epoch
+        assert_false(current_epoch > epoch_number, "unexpected epoch number")
+        while current_epoch < epoch_number:
+            generate_next_block(sc_node, "first node", force_switch_to_next_epoch=True)
+            self.sc_sync_all()
+            forging_info = sc_node.block_forgingInfo()
+            current_epoch = forging_info["result"]["bestBlockEpochNumber"]
+
+    def run_test(self):
+        self.sc_ac_setup()
+        if self.options.all_forks:
+            logging.info("This test cannot be executed with --allforks")
+            exit()
+
+        mc_node = self.nodes[0]
+        sc_node_1 = self.sc_nodes[0]
+        sc_node_2 = self.sc_nodes[1]
+        self.advance_to_epoch(35)
+
+        smart_contract_name = 'ReceivingEther'
+        smart_contract = SmartContract(smart_contract_name)
+        smart_contract_address = deploy_smart_contract(sc_node_1, smart_contract, self.evm_address)
+        FORGER_REWARD_ADDRESS = smart_contract_address
+
+        stop_sc_node(sc_node_2, 1)
+        datadir = os.path.join(self.options.tmpdir, "sc_node" + str(1))
+        cfgFileName = datadir + ('/node%s.conf' % 1)
+
+        with open(cfgFileName, "r") as config:
+            configLines = config.readlines()
+        with open(cfgFileName, "w") as sources:
+            for line in configLines:
+                sources.write(re.sub('forgerRewardAddress = ""',
+                                     "forgerRewardAddress = \"" + remove_0x_prefix(FORGER_REWARD_ADDRESS) + "\"", line))
+
+        sc_node_2 = start_sc_node(1, self.options.tmpdir, binary=EVM_APP_BINARY, auth_api_key='Horizen')
+        wait_for_sc_node_initialization(self.sc_nodes)
+        connect_sc_nodes(self.sc_nodes[0], 1)
+
+        # Do FT of some Zen to SC Node 2
+        evm_address_sc_node_2 = sc_node_2.wallet_createPrivateKeySecp256k1()["result"]["proposition"]["address"]
+        ft_amount_in_zen = 2.0
+        forward_transfer_to_sidechain(self.sc_nodes_bootstrap_info.sidechain_id,
+                                      mc_node,
+                                      evm_address_sc_node_2,
+                                      ft_amount_in_zen,
+                                      mc_return_address=mc_node.getnewaddress(),
+                                      generate_block=False)
+        self.sync_all()
+        assert_equal(1, mc_node.getmempoolinfo()["size"], "Forward Transfer expected to be added to mempool.")
+
+        # Generate MC block and SC block
+        mcblock_hash1 = mc_node.generate(1)[0]
+        scblock_id1 = generate_next_block(sc_node_1, "first node")
+        check_mcreference_presence(mcblock_hash1, scblock_id1, sc_node_1)
+        # Update block fees: node 1 generated block with 0 fees.
+        self.sc_sync_all()
+
+        # Create forger stake with some Zen for SC node 2
+        sc2_blockSignPubKey = sc_node_2.wallet_createPrivateKey25519()["result"]["proposition"]["publicKey"]
+        sc2_vrfPubKey = sc_node_2.wallet_createVrfSecret()["result"]["proposition"]["publicKey"]
+        forger_stake_amount = 1  # Zen
+        makeForgerStakeJsonRes = ac_makeForgerStake(sc_node_2, evm_address_sc_node_2, sc2_blockSignPubKey,
+                                                    sc2_vrfPubKey,
+                                                    convertZenToZennies(forger_stake_amount))
+        if "result" not in makeForgerStakeJsonRes:
+            fail("make forger stake failed: " + json.dumps(makeForgerStakeJsonRes))
+        tx_hash_0 = makeForgerStakeJsonRes['result']['transactionId']
+        generate_next_block(sc_node_1, "first node")
+        transactionFee_0, forgersPoolFee, forgerTip = computeForgedTxFee(sc_node_1, tx_hash_0)
+
+        generate_next_block(sc_node_1, "first node", force_switch_to_next_epoch=True)
+        self.sc_sync_all()
+        generate_next_block(sc_node_2, "second node", force_switch_to_next_epoch=True)
+        mc_node.generate(self.withdrawalEpochLength - 2)
+        last_block_id = generate_next_block(sc_node_2, "second node")
+        self.sc_sync_all()
+
+        expected_fee = http_block_getFeePayments(sc_node_1, last_block_id)['feePayments'][1]['value']
+        actual_fee = smart_contract.static_call(sc_node_1, "getBalance()", fromAddress=self.evm_address,
+                                                toAddress=smart_contract_address)[0]
+
+        assert_equal(expected_fee, actual_fee, "Smart Contract received wrong forger fee payment")
+
+
+if __name__ == "__main__":
+    ScEvmForgingFeePayments().main()

--- a/qa/sc_evm_forging_fee_payments.py
+++ b/qa/sc_evm_forging_fee_payments.py
@@ -13,13 +13,15 @@ from SidechainTestFramework.account.httpCalls.transaction.createLegacyTransactio
 from SidechainTestFramework.account.httpCalls.wallet.balance import http_wallet_balance
 from SidechainTestFramework.account.utils import convertZenToZennies, convertZenniesToWei, convertZenToWei, \
     computeForgedTxFee, FORGER_POOL_RECIPIENT_ADDRESS, VER_1_2_FORK_EPOCH
+from SidechainTestFramework.sc_boostrap_info import SCNodeConfiguration, MCConnectionInfo, SCNetworkConfiguration, \
+    SCCreationInfo, SC_CREATION_VERSION_2, SCForgerConfiguration
 from SidechainTestFramework.sc_forging_util import check_mcreference_presence
 from SidechainTestFramework.scutil import (
     connect_sc_nodes, generate_account_proposition, generate_next_block, SLOTS_IN_EPOCH, EVM_APP_SLOT_TIME,
-    generate_next_blocks, )
+    generate_next_blocks, bootstrap_sidechain_nodes, AccountModel, )
 from httpCalls.block.getFeePayments import http_block_getFeePayments
 from test_framework.util import (
-    assert_equal, fail, forward_transfer_to_sidechain, assert_false, )
+    assert_equal, fail, forward_transfer_to_sidechain, assert_false, websocket_port_by_mc_node_index, )
 
 """
 Info about forger account block fee payments
@@ -53,6 +55,8 @@ Test:
 
 
 class ScEvmForgingFeePayments(AccountChainSetup):
+    FORGER_REWARD_ADDRESS = '0000000000000000000012341234123412341234'
+
     def __init__(self):
         super().__init__(number_of_sidechain_nodes=2, withdrawalEpochLength=20, forward_amount=3,
                          block_timestamp_rewind=SLOTS_IN_EPOCH * EVM_APP_SLOT_TIME * 100)
@@ -68,6 +72,28 @@ class ScEvmForgingFeePayments(AccountChainSetup):
             self.sc_sync_all()
             forging_info = sc_node.block_forgingInfo()
             current_epoch = forging_info["result"]["bestBlockEpochNumber"]
+
+    def sc_setup_chain(self):
+        mc_node = self.nodes[0]
+        sc_node_configuration = [
+            SCNodeConfiguration(
+                MCConnectionInfo(address="ws://{0}:{1}".format(mc_node.hostname, websocket_port_by_mc_node_index(0))),
+                api_key='Horizen',
+                cert_submitter_enabled=True),
+
+            SCNodeConfiguration(
+                MCConnectionInfo(address="ws://{0}:{1}".format(mc_node.hostname, websocket_port_by_mc_node_index(0))),
+                forger_options=SCForgerConfiguration(forger_reward_address=self.FORGER_REWARD_ADDRESS),
+                api_key='Horizen',
+                cert_submitter_enabled=False
+            )
+        ]
+
+        network = SCNetworkConfiguration(SCCreationInfo(mc_node, 3, 20), *sc_node_configuration)
+        self.sc_nodes_bootstrap_info = \
+            bootstrap_sidechain_nodes(self.options, network,
+                                      block_timestamp_rewind=SLOTS_IN_EPOCH * EVM_APP_SLOT_TIME * 100,
+                                      model=AccountModel)
 
     def run_test(self):
         if self.options.all_forks:
@@ -290,7 +316,10 @@ class ScEvmForgingFeePayments(AccountChainSetup):
         # Check forger fee payments
         assert_equal(sc_node_1_balance_before_payments + node_1_fees, sc_node_1_balance_after_payments,
                      "Wrong fee payment amount for SC node 1")
-        assert_equal(sc_node_2_balance_before_payments + node_2_fees, sc_node_2_balance_after_payments,
+        # SC node 2 is configured to send rewards to some other address
+        reward_address_balance = http_wallet_balance(sc_node_2, self.FORGER_REWARD_ADDRESS)
+        assert_equal(sc_node_2_balance_before_payments + node_2_fees,
+                     sc_node_2_balance_after_payments + reward_address_balance,
                      "Wrong fee payment amount for SC node 2")
 
         # Check fee payments from API perspective
@@ -351,12 +380,15 @@ class ScEvmForgingFeePayments(AccountChainSetup):
         node_2_fees = per_block_fee * 3
 
         sc_node_1_balance_before_payments = sc_node_1_balance_after_payments
-        sc_node_2_balance_before_payments = sc_node_2_balance_after_payments
+        sc_node_2_balance_before_payments = sc_node_2_balance_after_payments + reward_address_balance
         sc_node_1_balance_after_payments = sc_node_1.wallet_getTotalBalance()['result']['balance']
         sc_node_2_balance_after_payments = sc_node_2.wallet_getTotalBalance()['result']['balance']
         assert_equal(sc_node_1_balance_before_payments + node_1_fees, sc_node_1_balance_after_payments,
                      "Wrong fee payment amount for SC node 1")
-        assert_equal(sc_node_2_balance_before_payments + node_2_fees, sc_node_2_balance_after_payments,
+        # SC node 2 is configured to send rewards to some other address
+        reward_address_balance = http_wallet_balance(sc_node_2, self.FORGER_REWARD_ADDRESS)
+        assert_equal(sc_node_2_balance_before_payments + node_2_fees,
+                     sc_node_2_balance_after_payments + reward_address_balance,
                      "Wrong fee payment amount for SC node 2")
 
         # assert forger pool balance is 0 now, as the fees are distributed

--- a/sdk/src/main/scala/io/horizen/AbstractSidechainApp.scala
+++ b/sdk/src/main/scala/io/horizen/AbstractSidechainApp.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler}
 import akka.stream.javadsl.Sink
+import io.horizen.account.proposition.AddressProposition
 import io.horizen.api.http._
 import io.horizen.api.http.client.SecureEnclaveApiClient
 import io.horizen.api.http.route.{DisableApiRoute, SidechainRejectionApiRoute}
@@ -138,6 +139,10 @@ abstract class AbstractSidechainApp
   val consensusParamsForkList = forkConfigurator.getOptionalSidechainForks.asScala.filter(fork => fork.getValue.isInstanceOf[ConsensusParamsFork])
   val defaultConsensusForks: ConsensusParamsFork = ConsensusParamsFork.DefaultConsensusParamsFork
 
+  private val forgerRewardAddress: Option[AddressProposition] = Option(sidechainSettings.forger.forgerRewardAddress)
+    .filter(_.nonEmpty)
+    .map(address => new AddressProposition(BytesUtils.fromHexString(address)))
+
   // Init proper NetworkParams depend on MC network
   lazy val params: NetworkParams = sidechainSettings.genesisData.mcNetwork match {
     case "regtest" =>
@@ -174,7 +179,8 @@ abstract class AbstractSidechainApp
         isNonCeasing = sidechainSettings.genesisData.isNonCeasing,
         isHandlingTransactionsEnabled = sidechainSettings.sparkzSettings.network.handlingTransactionsEnabled,
         mcBlockRefDelay = mcBlockReferenceDelay,
-        resetModifiersStatus = sidechainSettings.history.resetModifiersStatus
+        resetModifiersStatus = sidechainSettings.history.resetModifiersStatus,
+        rewardAddress = forgerRewardAddress
       )
 
 
@@ -212,7 +218,8 @@ abstract class AbstractSidechainApp
         isNonCeasing = sidechainSettings.genesisData.isNonCeasing,
         isHandlingTransactionsEnabled = sidechainSettings.sparkzSettings.network.handlingTransactionsEnabled,
         mcBlockRefDelay = mcBlockReferenceDelay,
-        resetModifiersStatus = sidechainSettings.history.resetModifiersStatus
+        resetModifiersStatus = sidechainSettings.history.resetModifiersStatus,
+        rewardAddress = forgerRewardAddress
       )
 
 
@@ -250,7 +257,8 @@ abstract class AbstractSidechainApp
         isNonCeasing = sidechainSettings.genesisData.isNonCeasing,
         isHandlingTransactionsEnabled = sidechainSettings.sparkzSettings.network.handlingTransactionsEnabled,
         mcBlockRefDelay = mcBlockReferenceDelay,
-        resetModifiersStatus = sidechainSettings.history.resetModifiersStatus
+        resetModifiersStatus = sidechainSettings.history.resetModifiersStatus,
+        rewardAddress = forgerRewardAddress
       )
 
 

--- a/sdk/src/main/scala/io/horizen/SidechainSettings.scala
+++ b/sdk/src/main/scala/io/horizen/SidechainSettings.scala
@@ -72,6 +72,7 @@ case class ForgerSettings(
     automaticForging: Boolean = false,
     restrictForgers: Boolean = false,
     allowedForgersList: Seq[ForgerKeysData] = Seq(),
+    forgerRewardAddress: String = null,
 ) extends SensitiveStringer
 
 case class MempoolSettings(

--- a/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
@@ -188,12 +188,12 @@ class AccountForgeMessageBuilder(
       isPending: Boolean = false
   ): Try[SidechainBlockBase[SidechainTypes#SCAT, AccountBlockHeader]] = {
 
-    // 1. As forger address take first address from the wallet
-    val addressList = nodeView.vault.secretsOfType(classOf[PrivateKeySecp256k1])
+    // 1. Forger address can be configured or take first address from the wallet
     val forgerAddress = params.rewardAddress.getOrElse {
+      val addressList = nodeView.vault.secretsOfType(classOf[PrivateKeySecp256k1])
       addressList.asScala.headOption.map(_.publicImage().asInstanceOf[AddressProposition]).getOrElse(
         if (isPending) new AddressProposition(Address.ZERO)
-        else throw new IllegalArgumentException("No addresses in wallet!")
+        else throw new IllegalArgumentException("No forger reward address configured and no addresses in wallet!")
       )
     }
 
@@ -263,10 +263,10 @@ class AccountForgeMessageBuilder(
               // get all previous payments for current ending epoch and append the one of the current block
               val feePayments = dummyView.getFeePaymentsInfo(withdrawalEpochNumber, consensusEpochNumber, Some(currentBlockPayments))
 
+              dummyView.resetForgerPoolAndBlockCounters(consensusEpochNumber)
+
               // add rewards to forgers balance
               feePayments.foreach(payment => dummyView.addBalance(payment.address.address(), payment.value))
-
-              dummyView.resetForgerPoolAndBlockCounters(consensusEpochNumber)
 
               feePayments
             } else {

--- a/sdk/src/main/scala/io/horizen/params/MainNetParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/MainNetParams.scala
@@ -4,6 +4,7 @@ import io.horizen.block.SidechainCreationVersions.{SidechainCreationVersion, Sid
 
 import java.math.BigInteger
 import com.horizen.commitmenttreenative.CustomBitvectorElementsConfig
+import io.horizen.account.proposition.AddressProposition
 import io.horizen.cryptolibprovider.CircuitTypes.{CircuitTypes, NaiveThresholdSignatureCircuit}
 import io.horizen.cryptolibprovider.utils.CumulativeHashFunctions
 import io.horizen.proposition.{PublicKey25519Proposition, SchnorrProposition, VrfPublicKey}
@@ -44,6 +45,7 @@ case class MainNetParams(
                           override val isHandlingTransactionsEnabled: Boolean = true,
                           override val mcBlockRefDelay: Int = 0,
                           override val resetModifiersStatus: Boolean = false,
+                          override val rewardAddress: Option[AddressProposition] = None,
                         ) extends NetworkParams {
   override val EquihashN: Int = 200
   override val EquihashK: Int = 9

--- a/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
@@ -6,6 +6,7 @@ import io.horizen.block.SidechainCreationVersions.SidechainCreationVersion
 
 import java.math.BigInteger
 import com.horizen.commitmenttreenative.CustomBitvectorElementsConfig
+import io.horizen.account.proposition.AddressProposition
 import io.horizen.cryptolibprovider.CircuitTypes.CircuitTypes
 import io.horizen.proposition.{PublicKey25519Proposition, SchnorrProposition, VrfPublicKey}
 import sparkz.core.block.Block
@@ -56,6 +57,7 @@ trait NetworkParams {
 
   // Fee payment params:
   final val forgerBlockFeeCoefficient: Double = 0.7 // forger portion of fees for the submitted Block
+  val rewardAddress: Option[AddressProposition] = None // Address to send fees to. If None - chosen from a local list.
 
   // Sidechain genesis params:
   val genesisMainchainBlockHash: Array[Byte] // hash of the block which include SidechainCreationTx for current SC

--- a/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
@@ -57,7 +57,7 @@ trait NetworkParams {
 
   // Fee payment params:
   final val forgerBlockFeeCoefficient: Double = 0.7 // forger portion of fees for the submitted Block
-  val rewardAddress: Option[AddressProposition] = None // Address to send fees to. If None - chosen from a local list.
+  val rewardAddress: Option[AddressProposition] = None // Address to send fees to. If None - chosen from the local wallet (first key found)
 
   // Sidechain genesis params:
   val genesisMainchainBlockHash: Array[Byte] // hash of the block which include SidechainCreationTx for current SC

--- a/sdk/src/main/scala/io/horizen/params/RegTestParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/RegTestParams.scala
@@ -4,6 +4,7 @@ import io.horizen.block.SidechainCreationVersions.{SidechainCreationVersion, Sid
 
 import java.math.BigInteger
 import com.horizen.commitmenttreenative.CustomBitvectorElementsConfig
+import io.horizen.account.proposition.AddressProposition
 import io.horizen.cryptolibprovider.CircuitTypes
 import io.horizen.cryptolibprovider.CircuitTypes.CircuitTypes
 import io.horizen.cryptolibprovider.utils.CumulativeHashFunctions
@@ -11,6 +12,7 @@ import io.horizen.proposition.{PublicKey25519Proposition, SchnorrProposition, Vr
 import sparkz.core.block.Block
 import sparkz.util.ModifierId
 import sparkz.util.bytesToId
+
 import scala.concurrent.duration._
 
 case class RegTestParams(
@@ -42,6 +44,7 @@ case class RegTestParams(
                           override val isHandlingTransactionsEnabled: Boolean = true,
                           override val mcBlockRefDelay: Int = 0,
                           override val resetModifiersStatus: Boolean = false,
+                          override val rewardAddress: Option[AddressProposition] = None,
                         ) extends NetworkParams {
   override val EquihashN: Int = 48
   override val EquihashK: Int = 5

--- a/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
@@ -4,12 +4,14 @@ import io.horizen.block.SidechainCreationVersions.{SidechainCreationVersion, Sid
 
 import java.math.BigInteger
 import com.horizen.commitmenttreenative.CustomBitvectorElementsConfig
+import io.horizen.account.proposition.AddressProposition
 import io.horizen.cryptolibprovider.CircuitTypes.{CircuitTypes, NaiveThresholdSignatureCircuit}
 import io.horizen.cryptolibprovider.utils.CumulativeHashFunctions
 import io.horizen.proposition.{PublicKey25519Proposition, SchnorrProposition, VrfPublicKey}
 import sparkz.core.block.Block
 import sparkz.util.ModifierId
 import sparkz.util.bytesToId
+
 import scala.concurrent.duration._
 
 case class TestNetParams(
@@ -41,6 +43,7 @@ case class TestNetParams(
                           override val isHandlingTransactionsEnabled: Boolean = true,
                           override val mcBlockRefDelay: Int = 0,
                           override val resetModifiersStatus: Boolean = false,
+                          override val rewardAddress: Option[AddressProposition] = None,
                         ) extends NetworkParams {
   override val EquihashN: Int = 200
   override val EquihashK: Int = 9

--- a/sdk/src/test/java/io/horizen/account/secret/McSignatureTest.java
+++ b/sdk/src/test/java/io/horizen/account/secret/McSignatureTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.web3j.crypto.ECKeyPair;
 import org.web3j.crypto.Sign;
 import org.web3j.utils.Numeric;
+import scala.Option;
 import scala.collection.Iterator;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -123,7 +124,7 @@ public class McSignatureTest {
                         null, null, null,
                         null, null, false, null,
                         null, 0, false, false,
-                        false, 0, false));
+                        false, 0, false, Option.empty()));
 
         System.out.println(computedTaddr);
         assertEquals("ztTw2K532ewo9gynBJv7FFUgbD19Wpifv8G", computedTaddr);
@@ -284,7 +285,7 @@ public class McSignatureTest {
                         null, null, null,
                         null, null, false, null,
                         null, 0,false, false,
-                        false, 0, false));
+                        false, 0, false, Option.empty()));
 
         assertEquals(taddr, computedTaddr);
 

--- a/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
+++ b/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
@@ -8,6 +8,7 @@ import io.horizen.params.MainNetParams;
 import io.horizen.params.NetworkParams;
 import io.horizen.params.TestNetParams;
 import org.junit.Test;
+import scala.Option;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.util.Arrays;
@@ -248,7 +249,7 @@ public class BytesUtilsTest {
     @Test
     public void fromHorizenPublicKeyAddress() {
         // Test 1: valid MainNet addresses in MainNet network
-        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false);
+        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false, Option.empty());
         String pubKeyAddressMainNet = "znc3p7CFNTsz1s6CceskrTxKevQLPoDK4cK";
         byte[] expectedPublicKeyHashBytesMainNet = BytesUtils.fromHexString("7843a3fcc6ab7d02d40946360c070b13cf7b9795");
 
@@ -297,7 +298,7 @@ public class BytesUtilsTest {
                 0,  null,null, null,
                 null, null, null,
                 null, false, null, null,
-                11111111, true, false, true, 0, false);
+                11111111, true, false, true, 0, false, Option.empty());
         String pubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";
         byte[] expectedPublicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         assertArrayEquals("Horizen base 58 check address expected to have different public key hash.",
@@ -319,7 +320,7 @@ public class BytesUtilsTest {
     @Test
     public void toHorizenPublicKeyAddress() {
         // Test 1: valid MainNet addresses in MainNet network
-        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false);
+        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false, Option.empty());
 
         byte[] publicKeyHashBytesMainNet = BytesUtils.fromHexString("7843a3fcc6ab7d02d40946360c070b13cf7b9795");
         String expectedPubKeyAddressMainNet = "znc3p7CFNTsz1s6CceskrTxKevQLPoDK4cK";
@@ -330,7 +331,7 @@ public class BytesUtilsTest {
 
 
         // Test 2: valid TestNet addresses in TestNet network
-        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false);
+        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false, Option.empty());
 
         byte[] publicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         String expectedPubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";

--- a/sdk/src/test/scala/io/horizen/account/forger/AccountForgeMessageBuilderTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/forger/AccountForgeMessageBuilderTest.scala
@@ -18,7 +18,7 @@ import io.horizen.consensus.{ConsensusParamsUtil, ForgingStakeInfo}
 import io.horizen.evm.{Address, Hash}
 import io.horizen.fixtures.{CompanionsFixture, SecretFixture, SidechainRelatedMainchainOutputFixture, VrfGenerator}
 import io.horizen.fork.{ConsensusParamsFork, ConsensusParamsForkInfo, CustomForkConfiguratorWithConsensusParamsFork, ForkManagerUtil}
-import io.horizen.params.TestNetParams
+import io.horizen.params.{NetworkParams, TestNetParams}
 import io.horizen.proof.{Signature25519, VrfProof}
 import io.horizen.proposition.VrfPublicKey
 import io.horizen.secret.{PrivateKey25519, PrivateKey25519Creator}
@@ -230,8 +230,10 @@ class AccountForgeMessageBuilderTest
     val companion = mock[DynamicTypedSerializer[SidechainTypes#SCAT, TransactionSerializer[SidechainTypes#SCAT]]]
     val inputBlockSize = 0
     val signatureOption = Some(mock[Signature25519])
+    val params = mock[NetworkParams]
+    when(params.rewardAddress).thenReturn(Option.empty)
 
-    val forger = new AccountForgeMessageBuilder(null, null, null, false)
+    val forger = new AccountForgeMessageBuilder(null, null, params, false)
 
     assertThrows[IllegalArgumentException](
       classOf[IllegalArgumentException],

--- a/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
+++ b/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
@@ -31,6 +31,7 @@ import io.horizen.transaction.mainchain.SidechainRelatedMainchainOutput;
 import io.horizen.utils.*;
 import io.horizen.vrf.VrfOutput;
 import scala.Enumeration;
+import scala.Option;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.BufferedReader;
@@ -938,11 +939,11 @@ public class ScBootstrappingToolCommandProcessor extends CommandProcessor {
 
         switch(network) {
             case 0: // mainnet
-                return new MainNetParams(scId, null, null, null, null, 1, 0,100, null, null, circuitType,0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, false);
+                return new MainNetParams(scId, null, null, null, null, 1, 0,100, null, null, circuitType,0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, false, Option.empty());
             case 1: // testnet
-                return new TestNetParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, false);
+                return new TestNetParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, false, Option.empty());
             case 2: // regtest
-                return new RegTestParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, false);
+                return new RegTestParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, false, Option.empty());
             default:
                 throw new IllegalStateException("Unexpected network type: " + network);
         }


### PR DESCRIPTION
## Description
Add a config property to specify forger reward address - forging tips and rewards will be sent to that address. Does not have to owned by a forger.

## Jira Ticket
https://horizenlabs.atlassian.net/browse/SDK-1635


## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [] Updated documentation accordingly
- [] Breaking changes have been correctly tagged and notified
