### PR TITLE
Removed a redundant check on nonce in native smart contract

### DIFF
--- a/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessor.scala
@@ -293,11 +293,6 @@ case class McAddrOwnershipMsgProcessor(networkParams: NetworkParams) extends Nat
   }
 
   def doRemoveOwnershipCmd(invocation: Invocation, view: BaseAccountStateView, msg: Message): Array[Byte] = {
-    // check that message contains a nonce, in the context of RPC calls the nonce might be missing
-    if (msg.getNonce == null) {
-      throw new ExecutionRevertedException("Call must include a nonce")
-    }
-
     // check that msg.value is zero
     if (invocation.value.signum() != 0) {
       throw new ExecutionRevertedException("Value must be zero")


### PR DESCRIPTION
Removed a redundant check on nonce in native smart contract.

Fix for issue [SDK-1575](https://horizenlabs.atlassian.net/browse/SDK-1575?atlOrigin=eyJpIjoiMDZmNWEzZjI5OTAyNGE4OWI1NjQzODNlN2M5ZTU0MjIiLCJwIjoiaiJ9)

[SDK-1575]: https://horizenlabs.atlassian.net/browse/SDK-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ