### PR TITLE
Improved error message for fromHorizenMcTransparentAddress method

### DIFF
--- a/sdk/src/main/java/io/horizen/utils/BytesUtils.java
+++ b/sdk/src/main/java/io/horizen/utils/BytesUtils.java
@@ -224,6 +224,24 @@ public final class BytesUtils {
         return fromHorizenMcTransparentAddress(address, params, false);
     }
 
+    static String getPrefixDescription(byte[] prefix) {
+        if (Arrays.equals(prefix, PUBLIC_KEY_MAINNET_PREFIX) || Arrays.equals(prefix, PUBLIC_KEY_MAINNET_PREFIX_OLD)){
+            return "pubKey MainNet prefix";
+        }
+        else if (Arrays.equals(prefix, SCRIPT_MAINNET_PREFIX) || Arrays.equals(prefix, SCRIPT_MAINNET_PREFIX_OLD)){
+            return "script MainNet prefix";
+        }
+        else if (Arrays.equals(prefix, PUBLIC_KEY_TESTNET_PREFIX) || Arrays.equals(prefix, PUBLIC_KEY_TESTNET_PREFIX_OLD)){
+            return "pubKey TestNet prefix";
+        }
+        else if (Arrays.equals(prefix, SCRIPT_TESTNET_PREFIX) || Arrays.equals(prefix, SCRIPT_TESTNET_PREFIX_OLD)){
+            return "script TestNet prefix";
+        }
+        else {
+            return String.format("Unknown prefix %s", BytesUtils.toHexString(prefix));
+        }
+    }
+
     public static byte[] fromHorizenMcTransparentAddress(String address, NetworkParams params, boolean onlyPubKey) {
         if(address.length() != HORIZEN_MC_TRANSPARENT_ADDRESS_BASE_58_LENGTH)
             throw new IllegalArgumentException(String.format("Incorrect Horizen mc transparent address length %d", address.length()));
@@ -238,25 +256,25 @@ public final class BytesUtils {
                 if (onlyPubKey){
                     throw new IllegalArgumentException(String.format(
                             "Incorrect Horizen address format, pubKey MainNet prefix expected, got %s",
-                            BytesUtils.toHexString(prefix)));
+                            getPrefixDescription(prefix)));
                 }
                 else if (!Arrays.equals(prefix, SCRIPT_MAINNET_PREFIX) && !Arrays.equals(prefix, SCRIPT_MAINNET_PREFIX_OLD)){
                     throw new IllegalArgumentException(String.format(
                             "Incorrect Horizen address format, pubKey or script MainNet prefix expected, got %s",
-                            BytesUtils.toHexString(prefix)));
+                            getPrefixDescription(prefix)));
                 }
             }
         }
         else if(!Arrays.equals(prefix, PUBLIC_KEY_TESTNET_PREFIX) && !Arrays.equals(prefix, PUBLIC_KEY_TESTNET_PREFIX_OLD)){
             if (onlyPubKey) {
                 throw new IllegalArgumentException(String.format(
-                        "Incorrect Horizen address format,  pubKey TestNet prefix expected, got %s",
-                        BytesUtils.toHexString(prefix)));
+                        "Incorrect Horizen address format, pubKey TestNet prefix expected, got %s",
+                        getPrefixDescription(prefix)));
             }
             else if (!Arrays.equals(prefix, SCRIPT_TESTNET_PREFIX) && !Arrays.equals(prefix, SCRIPT_TESTNET_PREFIX_OLD)){
                 throw new IllegalArgumentException(String.format(
-                        "Incorrect Horizen address format,  pubKey or script TestNet prefix expected, got %s",
-                        BytesUtils.toHexString(prefix)));
+                        "Incorrect Horizen address format, pubKey or script TestNet prefix expected, got %s",
+                        getPrefixDescription(prefix)));
             }
         }
 

--- a/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
+++ b/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
@@ -9,10 +9,8 @@ import io.horizen.params.NetworkParams;
 import io.horizen.params.TestNetParams;
 import org.junit.Test;
 import scala.Option;
-import scala.concurrent.duration.FiniteDuration;
 
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 import static io.horizen.utils.BytesUtils.padWithZeroBytes;
 import static org.junit.Assert.*;
@@ -287,6 +285,7 @@ public class BytesUtilsTest {
             BytesUtils.fromHorizenMcTransparentAddress(invalidNetworkPubKeyAddress, mainNetParams);
         } catch (IllegalArgumentException e) {
             exceptionOccurred = true;
+            assertTrue("wrong error message", e.getMessage().contains("pubKey TestNet prefix"));
         }
         assertTrue("Invalid network Horizen base 58 check address expected to throw exception during parsing.", exceptionOccurred);
 
@@ -313,6 +312,7 @@ public class BytesUtilsTest {
             BytesUtils.fromHorizenMcTransparentAddress(invalidNetworkPubKeyAddress, testNetParams);
         } catch (IllegalArgumentException e) {
             exceptionOccurred = true;
+            assertTrue("wrong error message", e.getMessage().contains("pubKey MainNet prefix"));
         }
         assertTrue("Invalid network Horizen base 58 check address expected to throw exception during parsing.", exceptionOccurred);
 
@@ -342,6 +342,7 @@ public class BytesUtilsTest {
             BytesUtils.fromHorizenMcTransparentKeyAddress(scriptAddMainNet, mainNetParams);
             fail("should fail with a script address");
         } catch (IllegalArgumentException e) {
+            assertTrue("wrong error message", e.getMessage().contains("script MainNet prefix"));
         }
 
         // Test 3: valid TestNet addresses in TestNet network
@@ -362,11 +363,26 @@ public class BytesUtilsTest {
             BytesUtils.fromHorizenMcTransparentKeyAddress(scriptAddTestNet, testNetParams);
             fail("should fail with a script address");
         } catch (IllegalArgumentException e) {
+            assertTrue("wrong error message", e.getMessage().contains("script TestNet prefix"));
         }
     }
 
     @Test
+    public void getPrefixDescription() {
+        assertEquals("pubKey MainNet prefix", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("2089")));
+        assertEquals("pubKey MainNet prefix", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("1CB8")));
+        assertEquals("script MainNet prefix", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("2096")));
+        assertEquals("script MainNet prefix", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("1CBD")));
+        assertEquals("pubKey TestNet prefix", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("2098")));
+        assertEquals("pubKey TestNet prefix", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("1D25")));
+        assertEquals("script TestNet prefix", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("2092")));
+        assertEquals("script TestNet prefix", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("1CBA")));
+        assertEquals("Unknown prefix 1cb3", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("1CB3")));
+        assertEquals("Unknown prefix 2347", BytesUtils.getPrefixDescription(BytesUtils.fromHexString("2347")));
 
+    }
+
+    @Test
     public void toHorizenPublicKeyAddress() {
         // Test 1: valid MainNet addresses in MainNet network
         NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false, Option.empty());


### PR DESCRIPTION
## Description
Improved the error message in case of wrong MC address type.

## Jira Ticket
[SDK-1734](https://horizenlabs.atlassian.net/browse/SDK-1734?atlOrigin=eyJpIjoiOTg0ZWY5ZDQzMjVlNDY0NjlkM2JhZjQxNGYyMzVjNmIiLCJwIjoiaiJ9)



[SDK-1734]: https://horizenlabs.atlassian.net/browse/SDK-1734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ