### PR TITLE
Fix for json rpc compliancy

### DIFF
--- a/qa/sc_evm_rpc_eth.py
+++ b/qa/sc_evm_rpc_eth.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+import json
+import urllib
+import http.client
 from decimal import Decimal
 
 from SidechainTestFramework.account.ac_chain_setup import AccountChainSetup
@@ -18,8 +21,43 @@ Configuration:
 
 Test:
     - test eth_getTransactionByHash
+    - test some negative case for json rpc commands
 
 """
+
+REST_HEADERS = {
+    'accept': 'application/json',
+    'Content-Type': 'application/json',
+    'Authorization': 'Basic dXNlcjpIb3JpemVu'
+}
+
+# SOME JSON RPC ERROR CODE
+PARSE_ERROR_CODE = 32700
+INVALID_REQUEST_CODE = 32600
+METHOD_NOT_FOUND_CODE = 32601
+INVALID_PARAMS_CODE = 32602
+
+
+def do_rpc_call(node, payload, headers=None):
+    if headers is None:
+        headers = REST_HEADERS
+
+    port = str(urllib.parse.urlparse(node.url).port)
+    conn = http.client.HTTPConnection("127.0.0.1:" + port)
+    conn.request("POST", "/ethv1", payload, headers)
+    res = conn.getresponse()
+    code = res.getcode()
+    data = res.read()
+    return code, json.loads(data.decode("utf-8"))
+
+
+def check_result(code, result, expected_http_code, expected_string_in_result, expected_rpc_code=0):
+    print("RPC result = {}".format(result))
+    assert_equal(expected_http_code, code)
+    assert_true('error' in result)
+    assert_true((result['error']['code'] == -expected_rpc_code))
+    assert_true('message' in result['error'])
+    assert_true(expected_string_in_result in result['error']['message'])
 
 
 class SCEvmRPCEth(AccountChainSetup):
@@ -89,6 +127,128 @@ class SCEvmRPCEth(AccountChainSetup):
         assert_equal("0x" + block_id, res["result"]['blockHash'])
         assert_equal(res_block['result']['height'], int(res["result"]['blockNumber'][2:], 16))
         assert_equal("0x0", res["result"]['transactionIndex'])
+
+        # --------------------------------------------------
+
+        # missing request id
+        payload = json.dumps({
+            "jsonrpc": "2.0",
+            "method": "eth_chainId",
+            "params": []
+        })
+        code, result = do_rpc_call(sc_node, payload)
+        check_result(code, result, expected_http_code=400, expected_string_in_result='missing field: id',
+                     expected_rpc_code=INVALID_REQUEST_CODE)
+
+        # missing params string (allowed)
+        payload = json.dumps({
+            "jsonrpc": "2.0",
+            "method": "eth_chainId",
+            "id": 1
+        })
+        code, result = do_rpc_call(sc_node, payload)
+        assert_equal(200, code)
+        expected_result = {'jsonrpc': '2.0', 'id': 1, 'result': '0x3b9aca01'}
+        assert_equal(expected_result, result)
+
+        # wrong params string (this command has no parameters)
+        payload = json.dumps({
+            "jsonrpc": "2.0",
+            "method": "eth_chainId",
+            "id": 1,
+            "params": [{"qqq": 1}]
+        })
+        code, result = do_rpc_call(sc_node, payload)
+        check_result(code, result, expected_http_code=200, expected_string_in_result='Invalid params',
+                     expected_rpc_code=INVALID_PARAMS_CODE)
+
+        # missing jsonrpc string
+        payload = json.dumps({
+            "method": "eth_chainId",
+            "id": 1,
+            "params": []
+        })
+        code, result = do_rpc_call(sc_node, payload)
+        check_result(code, result, expected_http_code=400, expected_string_in_result='missing field: jsonrpc',
+                     expected_rpc_code=INVALID_REQUEST_CODE)
+
+        # wrong jsonrpc string version
+        payload = json.dumps({
+            "method": "eth_chainId",
+            "id": 1,
+            "params": [],
+            "jsonrpc": "1.0",
+        })
+        code, result = do_rpc_call(sc_node, payload)
+        check_result(code, result, expected_http_code=400, expected_string_in_result='jsonrpc value is not valid',
+                     expected_rpc_code=INVALID_REQUEST_CODE)
+
+        # wrong method specified (HTTP CODE 200)
+        payload = json.dumps({
+            "method": "eth_chainId_",
+            "id": 1,
+            "params": [],
+            "jsonrpc": "2.0",
+        })
+        code, result = do_rpc_call(sc_node, payload)
+        check_result(code, result, expected_http_code=200, expected_string_in_result='Method',
+                     expected_rpc_code=METHOD_NOT_FOUND_CODE)
+
+        # batch request with a failure, the expected output is a single error json (TODO check this behaviour)
+        payload = json.dumps([
+            {
+                "jsonrpc": "2.0",
+                "method": "net_version",
+                "params": [],
+                "id": 1
+            },
+            {
+                "jsonrpc": "2.0",
+                "method": "eth_chainId",
+                "params": []
+            }
+        ])
+        code, result = do_rpc_call(sc_node, payload)
+        check_result(code, result, expected_http_code=400, expected_string_in_result='Invalid request',
+                     expected_rpc_code=INVALID_REQUEST_CODE)
+        expected_result = {'error': {'code': -32600, 'message': 'Invalid request'}, 'jsonrpc': '2.0', 'id': None}
+        assert_equal(expected_result, result)
+
+        # empty batch request
+        payload = json.dumps([])
+        code, result = do_rpc_call(sc_node, payload)
+        check_result(code, result, expected_http_code=400, expected_string_in_result='Invalid request',
+                     expected_rpc_code=INVALID_REQUEST_CODE)
+
+        # batch request with just a failure, the expected output is a single error json
+        payload = json.dumps([1])
+        code, result = do_rpc_call(sc_node, payload)
+        assert_equal(400, code)
+        expected_result = {'error': {'code': -32600, 'message': 'Invalid request'}, 'jsonrpc': '2.0', 'id': None}
+        assert_equal(expected_result, result)
+
+        # batch with a single request, the response should be a json array with a single result (not just a result)
+        payload = json.dumps([
+            {
+                "jsonrpc": "2.0",
+                "method": "net_version",
+                "params": [],
+                "id": 1
+            }])
+
+        code, result = do_rpc_call(sc_node, payload)
+        assert_equal(200, code)
+        expected_result = [{'jsonrpc': '2.0', 'id': 1, 'result': '1000000001'}]
+        assert_equal(expected_result, result)
+
+        # batch with an invalid json format
+        payload = '[{"jsonrpc": "2.0", "method": "net_version", "params": [], "id": 1}, {"jsonrpc": "2.0", "method"]'
+
+        code, result = do_rpc_call(sc_node, payload)
+        check_result(code, result, expected_http_code=400, expected_string_in_result='Parse error',
+                     expected_rpc_code=PARSE_ERROR_CODE)
+        expected_result = "{'error': {'code': -32700, 'message': \"Parse error"
+        assert_true(str(result).startswith(expected_result))
 
 
 if __name__ == "__main__":

--- a/sdk/src/main/java/io/horizen/account/api/rpc/handler/RpcResponseException.java
+++ b/sdk/src/main/java/io/horizen/account/api/rpc/handler/RpcResponseException.java
@@ -1,0 +1,13 @@
+package io.horizen.account.api.rpc.handler;
+
+import io.horizen.account.api.rpc.request.RpcId;
+import io.horizen.account.api.rpc.utils.RpcError;
+
+public class RpcResponseException extends RpcException {
+    public final RpcId id;
+
+    public RpcResponseException(RpcError error, RpcId id) {
+        super(error);
+        this.id = id;
+    }
+}

--- a/sdk/src/main/java/io/horizen/account/api/rpc/request/RpcRequest.java
+++ b/sdk/src/main/java/io/horizen/account/api/rpc/request/RpcRequest.java
@@ -1,7 +1,7 @@
 package io.horizen.account.api.rpc.request;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.horizen.account.api.rpc.handler.RpcException;
+import io.horizen.account.api.rpc.handler.RpcResponseException;
 import io.horizen.account.api.rpc.utils.RpcCode;
 import io.horizen.account.api.rpc.utils.RpcError;
 
@@ -16,34 +16,46 @@ public class RpcRequest {
     public final String method;
     public final JsonNode params;
 
-    private static final List<String> mandatoryFields = List.of("jsonrpc", "id", "method");
+    private static final String mandatoryIdField = "id";
+    private static final List<String> otherMandatoryFields = List.of("jsonrpc", "method");
     private static final List<String> stringFields = List.of("jsonrpc", "method");
     private static final String JSON_RPC_VERSION = "2.0";
 
-    public RpcRequest(JsonNode json) throws RpcException {
-        for (var field : mandatoryFields) {
+    public RpcRequest(JsonNode json) throws RpcResponseException {
+
+        if (json.isArray() && json.isEmpty()) {
+            throw new RpcResponseException(RpcError.fromCode(RpcCode.InvalidRequest, "Empty array as input"), new RpcId());
+        }
+
+        // This should be the first to be checked, otherwise we fail to return the request id in other error conditions
+        if (!json.has(mandatoryIdField)) {
+            throw new RpcResponseException(RpcError.fromCode(RpcCode.InvalidRequest, String.format("missing field: %s", mandatoryIdField)), new RpcId());
+        }
+
+        try {
+            id = new RpcId(json.get(mandatoryIdField));
+        } catch (IllegalArgumentException e) {
+            throw new RpcResponseException(RpcError.fromCode(RpcCode.InvalidRequest, e.getMessage()), new RpcId());
+        }
+
+        for (var field : otherMandatoryFields) {
             if (!json.has(field)) {
-                throw new RpcException(
-                    RpcError.fromCode(RpcCode.InvalidRequest, String.format("missing field: %s", field)));
+                throw new RpcResponseException(
+                    RpcError.fromCode(RpcCode.InvalidRequest, String.format("missing field: %s", field)), id);
             }
         }
+
         for (var field : stringFields) {
             if (!json.get(field).isTextual()) {
-                throw new RpcException(
-                    RpcError.fromCode(RpcCode.InvalidRequest, String.format("field must be string: %s", field)));
+                throw new RpcResponseException(
+                    RpcError.fromCode(RpcCode.InvalidRequest, String.format("field must be string: %s", field)), id);
             }
-
-        }
-        try {
-            id = new RpcId(json.get("id"));
-        } catch (IllegalArgumentException e) {
-            throw new RpcException(RpcError.fromCode(RpcCode.InvalidRequest, e.getMessage()));
         }
 
         jsonrpc = json.get("jsonrpc").asText();
         // check if the jsonrpc value has the correct version
         if(!jsonrpc.equals(JSON_RPC_VERSION)) {
-            throw new RpcException(RpcError.fromCode(RpcCode.InvalidRequest, "jsonrpc value is not valid"));
+            throw new RpcResponseException(RpcError.fromCode(RpcCode.InvalidRequest, "jsonrpc value is not valid"), id);
         }
 
         method = json.get("method").asText();

--- a/sdk/src/main/scala/io/horizen/account/api/http/route/AccountEthRpcRejectionHandler.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/http/route/AccountEthRpcRejectionHandler.scala
@@ -19,7 +19,7 @@ object AccountEthRpcRejectionHandler {
                 new RpcId(),
                 RpcError.fromCode(RpcCode.ParseError, msg)
               )
-            )
+            ), hasError = true
           )
       }
       .result()

--- a/sdk/src/main/scala/io/horizen/account/api/http/route/AccountEthRpcRoute.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/http/route/AccountEthRpcRoute.scala
@@ -56,7 +56,10 @@ case class AccountEthRpcRoute(
         _ =>
         {
           entity(as[JsonNode]) { body =>
-            SidechainApiResponse(rpcProcessor.processEthRpc(body));
+            {
+              val (json_resp, hasError) = rpcProcessor.processEthRpc(body)
+                SidechainApiResponse(json_resp, hasError)
+            }
           }
         }
       }

--- a/sdk/src/main/scala/io/horizen/account/api/rpc/service/RpcProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/rpc/service/RpcProcessor.scala
@@ -1,7 +1,7 @@
 package io.horizen.account.api.rpc.service
 
 import com.fasterxml.jackson.databind.JsonNode
-import io.horizen.account.api.rpc.handler.{RpcException, RpcHandler}
+import io.horizen.account.api.rpc.handler.{RpcHandler, RpcResponseException}
 import io.horizen.account.api.rpc.request.{RpcId, RpcRequest}
 import io.horizen.account.api.rpc.response.RpcResponseError
 import io.horizen.account.api.rpc.utils.{RpcCode, RpcError}
@@ -12,35 +12,49 @@ import scala.jdk.CollectionConverters.asScalaIteratorConverter
 import scala.util.{Failure, Success, Try}
 
 
-case class RpcProcessor(val rpcHandler: RpcHandler) extends SparkzLogging {
+case class RpcProcessor(rpcHandler: RpcHandler) extends SparkzLogging {
 
-  def processEthRpc(body: JsonNode): String = {
+  def processEthRpc(body: JsonNode): (String, Boolean) = {
+
+    var jsonIsArray = false
+
     val requests = if (body.isArray && !body.isEmpty) {
       // if the input json is an array a batch rpc request will be handled
       // the single rpc request will retrieve from the input json and they will be processed by rpcHandler
       // the position of the elements in the output will reflect their position in the input request
+      jsonIsArray = true
       body.iterator().asScala.toArray
     } else {
       // if the input json is not an array a single rpc request will be handled
       Array(body)
     }
 
+    var hasError : Boolean = false
+
     val responses = requests.map(json => Try.apply(new RpcRequest(json)).map(rpcHandler.apply) match {
       case Success(value) => value
-      case Failure(exception: RpcException) => new RpcResponseError(new RpcId(), exception.error);
+      case Failure(exception: RpcResponseException) =>
+        hasError = true
+        new RpcResponseError(exception.id, exception.error);
       case Failure(exception) =>
         log.trace(s"internal error on RPC call: $exception")
+        hasError = true
         new RpcResponseError(new RpcId(), RpcError.fromCode(RpcCode.InvalidRequest));
     })
 
-    val json = if (responses.length > 1) {
-      EthJsonMapper.serialize(responses)
+    val json = if (jsonIsArray) {
+      if (hasError) {
+        // if any error has occurred, just reply with one single error message
+        EthJsonMapper.serialize(new RpcResponseError(new RpcId(), RpcError.fromCode(RpcCode.InvalidRequest)))
+      } else {
+        EthJsonMapper.serialize(responses)
+      }
     } else {
       EthJsonMapper.serialize(responses.head)
     }
 
     log.trace(s"RPC message response << $json")
-    json
+    (json, hasError)
   }
 
 }

--- a/sdk/src/main/scala/io/horizen/account/websocket/WebSocketAccountServerEndpoint.scala
+++ b/sdk/src/main/scala/io/horizen/account/websocket/WebSocketAccountServerEndpoint.scala
@@ -68,7 +68,7 @@ class WebSocketAccountServerEndpoint() extends SparkzLogging {
             }
           }
         case _ =>
-          val response = WebSocketAccountServerRef.rpcProcessor.processEthRpc(new ObjectMapper().readTree(message))
+          val (response, _) = WebSocketAccountServerRef.rpcProcessor.processEthRpc(new ObjectMapper().readTree(message))
           WebSocketAccountServerEndpoint.sendRpcResponse(response, session)
       }
     } catch {

--- a/sdk/src/main/scala/io/horizen/api/http/SidechainApiResponse.scala
+++ b/sdk/src/main/scala/io/horizen/api/http/SidechainApiResponse.scala
@@ -31,10 +31,15 @@ object SidechainApiResponse {
 
   def apply(result: String): Route = OK(result)
 
+  def apply(result: String, hasError: Boolean): Route =
+    if (hasError) BAD_REQ(result) else OK(result)
+
   def apply(result: Future[String]): Route = OK(result)
 
   def apply(result: Either[Throwable, String]): Route = result.fold(SidechainApiError.apply, OK.apply)
 
   object OK extends SidechainApiResponse(StatusCodes.OK)
+
+  object BAD_REQ extends SidechainApiResponse(StatusCodes.BadRequest)
 
 }


### PR DESCRIPTION
Fixes for json-rpc:

https://horizenlabs.atlassian.net/browse/SDK-1660 (compliance with geth)
https://horizenlabs.atlassian.net/browse/SDK-1706 (compliance with standard)

The desired behavior described in SDK-1660 must be verified to be real compliance with geth and in case the fix should be reverted. 