### PR TITLE
Reward from mainchain (ZenIP 42206) - additional constraint (max cap)

### DIFF
--- a/examples/account/evmapp/src/main/java/io/horizen/examples/AppForkConfigurator.java
+++ b/examples/account/evmapp/src/main/java/io/horizen/examples/AppForkConfigurator.java
@@ -73,6 +73,10 @@ public class AppForkConfigurator extends ForkConfigurator {
             new Pair<>(
                     new SidechainForkConsensusEpoch(70, 70, 70),
                     new Version1_3_0Fork(true)
+            ),
+            new Pair<>(
+                    new SidechainForkConsensusEpoch(80, 80, 80),
+                    new Version1_4_0Fork(true)
             )
         );
     }

--- a/examples/account/evmapp/src/main/java/io/horizen/examples/AppForkConfiguratorAllEnabledFromEpoch2.java
+++ b/examples/account/evmapp/src/main/java/io/horizen/examples/AppForkConfiguratorAllEnabledFromEpoch2.java
@@ -55,6 +55,10 @@ public class AppForkConfiguratorAllEnabledFromEpoch2 extends ForkConfigurator {
             new Pair<>(
                     new SidechainForkConsensusEpoch(2, 2, 2),
                     new Version1_3_0Fork(true)
+            ),
+            new Pair<>(
+                    new SidechainForkConsensusEpoch(2, 2, 2),
+                    new Version1_4_0Fork(true)
             )
         );
     }

--- a/qa/SidechainTestFramework/account/utils.py
+++ b/qa/SidechainTestFramework/account/utils.py
@@ -53,6 +53,8 @@ INTEROPERABILITY_FORK_EPOCH = 50
 VERSION_1_2_FORK_EPOCH = 60
 # The activation epoch for features released in v1.3 (e.g. SHANGHAI EVM), as coded in the sdk
 VERSION_1_3_FORK_EPOCH = 70
+# The activation epoch for features released in v1.4
+VERSION_1_4_FORK_EPOCH = 80
 
 # Block gas limit
 BLOCK_GAS_LIMIT = 30000000

--- a/qa/sc_evm_forging_fee_payments.py
+++ b/qa/sc_evm_forging_fee_payments.py
@@ -238,7 +238,7 @@ class ScEvmForgingFeePayments(AccountChainSetup):
 
         # let assume a portion of the MC coinbase is sent to the SC as a contribution to the forger pool
         # this funds should not be distributed until fork happens at epoch 60
-        ft_pool_amount = 0.5
+        ft_pool_amount = 100
         ft_pool_amount_wei = convertZenToWei(ft_pool_amount)
         forward_transfer_to_sidechain(self.sc_nodes_bootstrap_info.sidechain_id,
                                       mc_node,
@@ -379,7 +379,13 @@ class ScEvmForgingFeePayments(AccountChainSetup):
         self.sc_sync_all()
         last_block_id = generate_next_block(sc_node_2, "second node")
         self.sc_sync_all()
-        distribution_cap = 2500000000
+
+        # 2500000000 = 12.5 * 10^8 * 20 * 0.1, where
+        # 12.5 * 10^8 - base mainchain coinbase reward
+        # 20 - withdrawal epoch length
+        # 0.1 - divider/coefficient (10% of sum of mainchain coinbase reward for last epoch)
+        mc_withdrawal_epoch_distribution_cap = 2500000000
+        distribution_cap = convertZenniesToWei(mc_withdrawal_epoch_distribution_cap)
         per_block_fee = distribution_cap // 25
         ft_pool_remaining = ft_pool_amount_wei - distribution_cap
         node_1_fees = per_block_fee * 22

--- a/sdk/src/main/scala/io/horizen/account/AccountSidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/account/AccountSidechainNodeViewHolder.scala
@@ -161,7 +161,7 @@ class AccountSidechainNodeViewHolder(sidechainSettings: SidechainSettings,
   override def getFeePaymentsInfo(state: MS, withdrawalEpochNumber: Int) : FPI = {
     val consensusEpochNumber: ConsensusEpochNumber = state.getCurrentConsensusEpochInfo._2.epoch
     val feePayments = state.getFeePaymentsInfo(withdrawalEpochNumber, consensusEpochNumber)
-    AccountFeePaymentsInfo(feePayments)
+    AccountFeePaymentsInfo(feePayments._1)
   }
 
   override def getScanPersistentWallet(modToApply: AccountBlock, stateOp: Option[MS], epochNumber: Int, wallet: VL) : VL = {

--- a/sdk/src/main/scala/io/horizen/account/AccountSidechainNodeViewHolder.scala
+++ b/sdk/src/main/scala/io/horizen/account/AccountSidechainNodeViewHolder.scala
@@ -160,8 +160,8 @@ class AccountSidechainNodeViewHolder(sidechainSettings: SidechainSettings,
 
   override def getFeePaymentsInfo(state: MS, withdrawalEpochNumber: Int) : FPI = {
     val consensusEpochNumber: ConsensusEpochNumber = state.getCurrentConsensusEpochInfo._2.epoch
-    val feePayments = state.getFeePaymentsInfo(withdrawalEpochNumber, consensusEpochNumber)
-    AccountFeePaymentsInfo(feePayments._1)
+    val (feePayments, _) = state.getFeePaymentsInfo(withdrawalEpochNumber, consensusEpochNumber)
+    AccountFeePaymentsInfo(feePayments)
   }
 
   override def getScanPersistentWallet(modToApply: AccountBlock, stateOp: Option[MS], epochNumber: Int, wallet: VL) : VL = {

--- a/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
@@ -6,7 +6,7 @@ import io.horizen.account.block.AccountBlock.calculateReceiptRoot
 import io.horizen.account.block.{AccountBlock, AccountBlockHeader}
 import io.horizen.account.chain.AccountFeePaymentsInfo
 import io.horizen.account.companion.SidechainAccountTransactionsCompanion
-import io.horizen.account.fork.{Version1_2_0Fork, GasFeeFork}
+import io.horizen.account.fork.{GasFeeFork, Version1_2_0Fork, Version1_4_0Fork}
 import io.horizen.account.history.AccountHistory
 import io.horizen.account.mempool.{AccountMemoryPool, MempoolMap, TransactionsByPriceAndNonceIter}
 import io.horizen.account.proposition.AddressProposition
@@ -259,11 +259,14 @@ class AccountForgeMessageBuilder(
               require(ommers.isEmpty, "No Ommers allowed for the last block of the withdrawal epoch.")
 
               val withdrawalEpochNumber: Int = WithdrawalEpochUtils.getWithdrawalEpochInfo(mainchainBlockReferencesData.size, dummyView.getWithdrawalEpochInfo, params).epoch
-
+              val distributionCap = if (Version1_4_0Fork.get(consensusEpochNumber).active) {
+                val mcLastBlockHeight = params.mainchainCreationBlockHeight + ((withdrawalEpochNumber + 1) * params.withdrawalEpochLength) - 1
+                AccountFeePaymentsUtils.getMainchainWithdrawalEpochDistributionCap(mcLastBlockHeight, params.withdrawalEpochLength)
+              } else BigInteger.valueOf(Long.MaxValue)
               // get all previous payments for current ending epoch and append the one of the current block
-              val feePayments = dummyView.getFeePaymentsInfo(withdrawalEpochNumber, consensusEpochNumber, Some(currentBlockPayments))
+              val (feePayments, poolBalanceDistributed) = dummyView.getFeePaymentsInfo(withdrawalEpochNumber, consensusEpochNumber, distributionCap, Some(currentBlockPayments))
 
-              dummyView.resetForgerPoolAndBlockCounters(consensusEpochNumber)
+              dummyView.subtractForgerPoolBalanceAndResetBlockCounters(consensusEpochNumber, poolBalanceDistributed)
 
               // add rewards to forgers balance
               feePayments.foreach(payment => dummyView.addBalance(payment.address.address(), payment.value))

--- a/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
@@ -261,7 +261,7 @@ class AccountForgeMessageBuilder(
               val withdrawalEpochNumber: Int = WithdrawalEpochUtils.getWithdrawalEpochInfo(mainchainBlockReferencesData.size, dummyView.getWithdrawalEpochInfo, params).epoch
               val distributionCap = if (Version1_4_0Fork.get(consensusEpochNumber).active) {
                 val mcLastBlockHeight = params.mainchainCreationBlockHeight + ((withdrawalEpochNumber + 1) * params.withdrawalEpochLength) - 1
-                AccountFeePaymentsUtils.getMainchainWithdrawalEpochDistributionCap(mcLastBlockHeight, params.withdrawalEpochLength)
+                AccountFeePaymentsUtils.getMainchainWithdrawalEpochDistributionCap(mcLastBlockHeight, params)
               } else BigInteger.valueOf(Long.MaxValue)
               // get all previous payments for current ending epoch and append the one of the current block
               val (feePayments, poolBalanceDistributed) = dummyView.getFeePaymentsInfo(withdrawalEpochNumber, consensusEpochNumber, distributionCap, Some(currentBlockPayments))

--- a/sdk/src/main/scala/io/horizen/account/fork/Version1_4_0Fork.scala
+++ b/sdk/src/main/scala/io/horizen/account/fork/Version1_4_0Fork.scala
@@ -1,0 +1,19 @@
+package io.horizen.account.fork
+
+import io.horizen.fork.{ForkManager, OptionalSidechainFork}
+
+case class Version1_4_0Fork(active: Boolean = false) extends OptionalSidechainFork
+
+/**
+ * <p>This fork introduces the following major changes:</p>
+ * <ul>
+ *  <li>1. It enables max cap for mainchain forger reward distribution based on mainchain coinbase. </li>
+ * </ul>
+ */
+object Version1_4_0Fork {
+  def get(epochNumber: Int): Version1_4_0Fork = {
+    ForkManager.getOptionalSidechainFork[Version1_4_0Fork](epochNumber).getOrElse(DefaultFork)
+  }
+
+  private val DefaultFork: Version1_4_0Fork = Version1_4_0Fork()
+}

--- a/sdk/src/main/scala/io/horizen/account/state/AccountState.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/AccountState.scala
@@ -3,7 +3,7 @@ package io.horizen.account.state
 import com.horizen.certnative.BackwardTransfer
 import io.horizen.SidechainTypes
 import io.horizen.account.block.AccountBlock
-import io.horizen.account.fork.{GasFeeFork, Version1_2_0Fork}
+import io.horizen.account.fork.{GasFeeFork, Version1_2_0Fork, Version1_4_0Fork}
 import io.horizen.account.history.validation.InvalidTransactionChainIdException
 import io.horizen.account.node.NodeAccountState
 import io.horizen.account.state.receipt.{EthereumConsensusDataLog, EthereumReceipt}
@@ -210,7 +210,11 @@ class AccountState(
       stateView.updateForgerBlockCounter(mod.forgerPublicKey, consensusEpochNumber)
 
       // If SC block has reached the end of the withdrawal epoch reward the forgers.
-      evalForgersReward(mod, modWithdrawalEpochInfo, consensusEpochNumber, stateView)
+      val distributionCap = if (Version1_4_0Fork.get(consensusEpochNumber).active) {
+        val mcLastBlockHeight = params.mainchainCreationBlockHeight + ((currentWithdrawalEpochInfo.epoch + 1) * params.withdrawalEpochLength) - 1
+        AccountFeePaymentsUtils.getMainchainWithdrawalEpochDistributionCap(mcLastBlockHeight, params.withdrawalEpochLength)
+      } else BigInteger.valueOf(Long.MaxValue)
+      evalForgersReward(mod, modWithdrawalEpochInfo, consensusEpochNumber, distributionCap, stateView)
 
       // check logs bloom consistency with block header
       mod.verifyLogsBloomConsistency(receiptList)
@@ -246,13 +250,13 @@ class AccountState(
   }
 
 
-  private def evalForgersReward(mod: AccountBlock, modWithdrawalEpochInfo: WithdrawalEpochInfo, consensusEpochNumber: ConsensusEpochNumber, stateView: AccountStateView): Unit = {
+  private def evalForgersReward(mod: AccountBlock, modWithdrawalEpochInfo: WithdrawalEpochInfo, consensusEpochNumber: ConsensusEpochNumber, distributionCap: BigInteger, stateView: AccountStateView): Unit = {
     // If SC block has reached the end of the withdrawal epoch -> fee payments expected to be produced.
     // If SC block is in the middle of the withdrawal epoch -> no fee payments hash expected to be defined.
     val isWithdrawalEpochFinished: Boolean = WithdrawalEpochUtils.isEpochLastIndex(modWithdrawalEpochInfo, params)
     if (isWithdrawalEpochFinished) {
       // current block fee info is already in the view therefore we pass None as third param
-      val feePayments = stateView.getFeePaymentsInfo(modWithdrawalEpochInfo.epoch, consensusEpochNumber, None)
+      val (feePayments, poolBalanceDistributed) = stateView.getFeePaymentsInfo(modWithdrawalEpochInfo.epoch, consensusEpochNumber, distributionCap, None)
 
       log.info(s"End of Withdrawal Epoch ${modWithdrawalEpochInfo.epoch} reached, added ${feePayments.length} rewards with block ${mod.header.id}")
 
@@ -266,7 +270,7 @@ class AccountState(
       }
 
       // reset forger pool balance and block counters
-      stateView.resetForgerPoolAndBlockCounters(consensusEpochNumber)
+      stateView.subtractForgerPoolBalanceAndResetBlockCounters(consensusEpochNumber, poolBalanceDistributed)
 
       // add rewards to forgers balance
       feePayments.foreach(
@@ -386,11 +390,17 @@ class AccountState(
 
   override def hasCeased: Boolean = stateMetadataStorage.hasCeased
 
-  override def getFeePaymentsInfo(withdrawalEpoch: Int, consensusEpochNumber: ConsensusEpochNumber, blockToAppendFeeInfo: Option[AccountBlockFeeInfo] = None): Seq[AccountPayment] = {
+  override def getFeePaymentsInfo(
+    withdrawalEpoch: Int,
+    consensusEpochNumber: ConsensusEpochNumber,
+    distributionCap: BigInteger = BigInteger.valueOf(Long.MaxValue),
+    blockToAppendFeeInfo: Option[AccountBlockFeeInfo] = None): (Seq[AccountPayment], BigInteger) =
+  {
     val feePaymentInfoSeq = stateMetadataStorage.getFeePayments(withdrawalEpoch)
     val mcForgerPoolRewards = stateMetadataStorage.getMcForgerPoolRewards
+    val poolBalanceDistributed = mcForgerPoolRewards.values.foldLeft(BigInteger.ZERO)((a, b) => a.add(b))
 
-    AccountFeePaymentsUtils.getForgersRewards(feePaymentInfoSeq, mcForgerPoolRewards)
+    (AccountFeePaymentsUtils.getForgersRewards(feePaymentInfoSeq, mcForgerPoolRewards), poolBalanceDistributed)
   }
 
   override def getWithdrawalEpochInfo: WithdrawalEpochInfo = stateMetadataStorage.getWithdrawalEpochInfo

--- a/sdk/src/main/scala/io/horizen/account/state/AccountStateView.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/AccountStateView.scala
@@ -137,6 +137,11 @@ class AccountStateView(
   def subtractForgerPoolBalanceAndResetBlockCounters(consensusEpochNumber: ConsensusEpochNumber, poolBalanceDistributed: BigInteger): Unit = {
     if (Version1_2_0Fork.get(consensusEpochNumber).active) {
       val forgerPoolBalance = getBalance(WellKnownAddresses.FORGER_POOL_RECIPIENT_ADDRESS)
+      if (poolBalanceDistributed.compareTo(forgerPoolBalance) > 0) {
+        val errMsg = s"Trying to subtract more($poolBalanceDistributed) from the forger pool balance than available($forgerPoolBalance)"
+        log.error(errMsg)
+        throw new IllegalArgumentException(errMsg)
+      }
       if (forgerPoolBalance.signum() == 1) {
         subBalance(WellKnownAddresses.FORGER_POOL_RECIPIENT_ADDRESS, poolBalanceDistributed)
         metadataStorageView.resetForgerBlockCounters()

--- a/sdk/src/main/scala/io/horizen/account/state/AccountStateView.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/AccountStateView.scala
@@ -88,35 +88,38 @@ class AccountStateView(
   override def getFeePaymentsInfo(
       withdrawalEpoch: Int,
       consensusEpochNumber: ConsensusEpochNumber,
+      distributionCap: BigInteger,
       blockToAppendFeeInfo: Option[AccountBlockFeeInfo] = None
-  ): Seq[AccountPayment] = {
+  ): (Seq[AccountPayment], BigInteger) = {
     var blockFeeInfoSeq = metadataStorageView.getFeePayments(withdrawalEpoch)
     blockToAppendFeeInfo.foreach(blockFeeInfo => blockFeeInfoSeq = blockFeeInfoSeq :+ blockFeeInfo)
-    val mcForgerPoolRewards = getMcForgerPoolRewards(consensusEpochNumber)
+    val mcForgerPoolRewards = getMcForgerPoolRewards(consensusEpochNumber, distributionCap)
+    val poolBalanceDistributed = mcForgerPoolRewards.values.foldLeft(BigInteger.ZERO)((a, b) => a.add(b))
     metadataStorageView.updateMcForgerPoolRewards(mcForgerPoolRewards)
-    AccountFeePaymentsUtils.getForgersRewards(blockFeeInfoSeq, mcForgerPoolRewards)
+    (AccountFeePaymentsUtils.getForgersRewards(blockFeeInfoSeq, mcForgerPoolRewards), poolBalanceDistributed)
   }
 
   override def getAccountStateRoot: Array[Byte] = metadataStorageView.getAccountStateRoot
 
-  def getMcForgerPoolRewards(consensusEpochNumber: ConsensusEpochNumber): Map[AddressProposition, BigInteger] = {
+  def getMcForgerPoolRewards(consensusEpochNumber: ConsensusEpochNumber, distributionCap: BigInteger): Map[AddressProposition, BigInteger] = {
     if (Version1_2_0Fork.get(consensusEpochNumber).active) {
       val extraForgerReward = getBalance(WellKnownAddresses.FORGER_POOL_RECIPIENT_ADDRESS)
       if (extraForgerReward.signum() == 1) {
-          val counters: Map[AddressProposition, Long] = getForgerBlockCounters
-          val perBlockFee_remainder = extraForgerReward.divideAndRemainder(BigInteger.valueOf(counters.values.sum))
-          val perBlockFee = perBlockFee_remainder(0)
-          var remainder = perBlockFee_remainder(1)
-          //sort and add remainder based by block count
-          val forgerPoolRewards = counters.toSeq.sortBy(_._2)
-            .map { address_blocks =>
-              val blocks = BigInteger.valueOf(address_blocks._2)
-              val usedRemainder = remainder.min(blocks)
-              val reward = perBlockFee.multiply(blocks).add(usedRemainder)
-              remainder = remainder.subtract(usedRemainder)
-              (address_blocks._1, reward)
-            }
-          forgerPoolRewards.toMap
+        val availableReward = extraForgerReward.min(distributionCap)
+        val counters: Map[AddressProposition, Long] = getForgerBlockCounters
+        val perBlockFee_remainder = availableReward.divideAndRemainder(BigInteger.valueOf(counters.values.sum))
+        val perBlockFee = perBlockFee_remainder(0)
+        var remainder = perBlockFee_remainder(1)
+        //sort and add remainder based by block count
+        val forgerPoolRewards = counters.toSeq.sortBy(_._2)
+          .map { address_blocks =>
+            val blocks = BigInteger.valueOf(address_blocks._2)
+            val usedRemainder = remainder.min(blocks)
+            val reward = perBlockFee.multiply(blocks).add(usedRemainder)
+            remainder = remainder.subtract(usedRemainder)
+            (address_blocks._1, reward)
+          }
+        forgerPoolRewards.toMap
       } else Map.empty
     } else Map.empty
   }
@@ -131,11 +134,11 @@ class AccountStateView(
     metadataStorageView.getForgerBlockCounters
   }
 
-  def resetForgerPoolAndBlockCounters(consensusEpochNumber: ConsensusEpochNumber): Unit = {
+  def subtractForgerPoolBalanceAndResetBlockCounters(consensusEpochNumber: ConsensusEpochNumber, poolBalanceDistributed: BigInteger): Unit = {
     if (Version1_2_0Fork.get(consensusEpochNumber).active) {
       val forgerPoolBalance = getBalance(WellKnownAddresses.FORGER_POOL_RECIPIENT_ADDRESS)
       if (forgerPoolBalance.signum() == 1) {
-        subBalance(WellKnownAddresses.FORGER_POOL_RECIPIENT_ADDRESS, forgerPoolBalance)
+        subBalance(WellKnownAddresses.FORGER_POOL_RECIPIENT_ADDRESS, poolBalanceDistributed)
         metadataStorageView.resetForgerBlockCounters()
       }
     }

--- a/sdk/src/main/scala/io/horizen/account/utils/AccountFeePaymentsUtils.scala
+++ b/sdk/src/main/scala/io/horizen/account/utils/AccountFeePaymentsUtils.scala
@@ -2,11 +2,13 @@ package io.horizen.account.utils
 
 import io.horizen.account.proposition.AddressProposition
 import io.horizen.evm.{StateDB, TrieHasher}
+import io.horizen.params.NetworkParams
 
 import java.math.BigInteger
 
 object AccountFeePaymentsUtils {
   val DEFAULT_ACCOUNT_FEE_PAYMENTS_HASH: Array[Byte] = StateDB.EMPTY_ROOT_HASH.toBytes
+  val MC_DISTRIBUTION_CAP_DIVIDER: BigInteger = BigInteger.valueOf(10)
 
   def calculateFeePaymentsHash(feePayments: Seq[AccountPayment]): Array[Byte] = {
     if(feePayments.isEmpty) {
@@ -58,20 +60,24 @@ object AccountFeePaymentsUtils {
     }
   }
 
-  def getMainchainWithdrawalEpochDistributionCap(epochMaxHeight: Long, epochLength: Long): BigInteger = {
+  def getMainchainWithdrawalEpochDistributionCap(epochMaxHeight: Long, params: NetworkParams): BigInteger = {
     val baseReward = 12.5 * 1e8
-    val halvingInterval = 840000
+    val halvingInterval = params.mcHalvingInterval
+    val epochLength = params.withdrawalEpochLength
 
-    var result = 0L
+    var mcEpochRewardZennies = 0L
     for (height <- epochMaxHeight - epochLength until epochMaxHeight) {
       var reward = baseReward.longValue()
       val halvings = height / halvingInterval
       for (_ <- 1L to halvings) {
         reward = reward >> 1
       }
-      result = result + reward
+      mcEpochRewardZennies = mcEpochRewardZennies + reward
     }
 
-    BigInteger.valueOf(result).divide(BigInteger.valueOf(10))
+    val mcEpochRewardWei = ZenWeiConverter.convertZenniesToWei(mcEpochRewardZennies)
+    mcEpochRewardWei.divide(getMcDistributionCapDivider)
   }
+
+  private def getMcDistributionCapDivider: BigInteger = MC_DISTRIBUTION_CAP_DIVIDER
 }

--- a/sdk/src/main/scala/io/horizen/account/utils/AccountFeePaymentsUtils.scala
+++ b/sdk/src/main/scala/io/horizen/account/utils/AccountFeePaymentsUtils.scala
@@ -57,4 +57,21 @@ object AccountFeePaymentsUtils {
       }
     }
   }
+
+  def getMainchainWithdrawalEpochDistributionCap(epochMaxHeight: Long, epochLength: Long): BigInteger = {
+    val baseReward = 12.5 * 1e8
+    val halvingInterval = 840000
+
+    var result = 0L
+    for (height <- epochMaxHeight - epochLength until epochMaxHeight) {
+      var reward = baseReward.longValue()
+      val halvings = height / halvingInterval
+      for (_ <- 1L to halvings) {
+        reward = reward >> 1
+      }
+      result = result + reward
+    }
+
+    BigInteger.valueOf(result).divide(BigInteger.valueOf(10))
+  }
 }

--- a/sdk/src/main/scala/io/horizen/params/MainNetParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/MainNetParams.scala
@@ -44,6 +44,7 @@ case class MainNetParams(
                           override val isNonCeasing: Boolean = false,
                           override val isHandlingTransactionsEnabled: Boolean = true,
                           override val mcBlockRefDelay: Int = 0,
+                          override val mcHalvingInterval: Int = 840000,
                           override val resetModifiersStatus: Boolean = false,
                           override val rewardAddress: Option[AddressProposition] = None,
                         ) extends NetworkParams {

--- a/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/NetworkParams.scala
@@ -53,6 +53,7 @@ trait NetworkParams {
   val isCSWEnabled: Boolean
   val isHandlingTransactionsEnabled: Boolean = true
   val mcBlockRefDelay:Int
+  val mcHalvingInterval:Int
 
   // it is overridden only by regtest class for testing purposes
   val maxHistoryRewritingLength: Int = AbstractHistory.MAX_HISTORY_REWRITING_LENGTH

--- a/sdk/src/main/scala/io/horizen/params/RegTestParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/RegTestParams.scala
@@ -41,6 +41,7 @@ case class RegTestParams(
                           override val isNonCeasing: Boolean = false,
                           override val isHandlingTransactionsEnabled: Boolean = true,
                           override val mcBlockRefDelay: Int = 0,
+                          override val mcHalvingInterval: Int = 2000,
                           override val resetModifiersStatus: Boolean = false,
                           override val maxHistoryRewritingLength: Int = MAX_HISTORY_REWRITING_LENGTH,
                           override val rewardAddress: Option[AddressProposition] = None,

--- a/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
@@ -42,6 +42,7 @@ case class TestNetParams(
                           override val isNonCeasing: Boolean = false,
                           override val isHandlingTransactionsEnabled: Boolean = true,
                           override val mcBlockRefDelay: Int = 0,
+                          override val mcHalvingInterval: Int = 2000,
                           override val resetModifiersStatus: Boolean = false,
                           override val rewardAddress: Option[AddressProposition] = None,
                         ) extends NetworkParams {

--- a/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
+++ b/sdk/src/main/scala/io/horizen/params/TestNetParams.scala
@@ -42,7 +42,7 @@ case class TestNetParams(
                           override val isNonCeasing: Boolean = false,
                           override val isHandlingTransactionsEnabled: Boolean = true,
                           override val mcBlockRefDelay: Int = 0,
-                          override val mcHalvingInterval: Int = 2000,
+                          override val mcHalvingInterval: Int = 840000,
                           override val resetModifiersStatus: Boolean = false,
                           override val rewardAddress: Option[AddressProposition] = None,
                         ) extends NetworkParams {

--- a/sdk/src/main/scala/io/horizen/state/BaseStateReader.scala
+++ b/sdk/src/main/scala/io/horizen/state/BaseStateReader.scala
@@ -11,7 +11,7 @@ import java.math.BigInteger
 trait BaseStateReader {
   def getWithdrawalEpochInfo: WithdrawalEpochInfo
   def getTopQualityCertificate(referencedWithdrawalEpoch: Int): Option[WithdrawalEpochCertificate]
-  def getFeePaymentsInfo(withdrawalEpoch: Int, consensusEpochNumber: ConsensusEpochNumber, blockToAppendFeeInfo: Option[AccountBlockFeeInfo] = None): Seq[AccountPayment]
+  def getFeePaymentsInfo(withdrawalEpoch: Int, consensusEpochNumber: ConsensusEpochNumber, distributionCap: BigInteger = BigInteger.valueOf(Long.MaxValue), blockToAppendFeeInfo: Option[AccountBlockFeeInfo] = None): (Seq[AccountPayment], BigInteger)
   def getConsensusEpochNumber: Option[ConsensusEpochNumber]
   def getTransactionReceipt(txHash: Array[Byte]): Option[EthereumReceipt]
   def getNextBaseFee: BigInteger //Contains the base fee to be used when forging the next block

--- a/sdk/src/test/java/io/horizen/account/secret/McSignatureTest.java
+++ b/sdk/src/test/java/io/horizen/account/secret/McSignatureTest.java
@@ -124,7 +124,7 @@ public class McSignatureTest {
                         null, null, null,
                         null, null, false, null,
                         null, 0, false, false,
-                        false, 0, false, 0, Option.empty()));
+                        false, 0, 2000, false, 0, Option.empty()));
 
 
         System.out.println(computedTaddr);
@@ -286,7 +286,7 @@ public class McSignatureTest {
                         null, null, null,
                         null, null, false, null,
                         null, 0,false, false,
-                        false, 0, false, 0, Option.empty()));
+                        false, 0, 2000,  false, 0, Option.empty()));
 
 
         assertEquals(taddr, computedTaddr);

--- a/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
+++ b/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
@@ -247,7 +247,7 @@ public class BytesUtilsTest {
     @Test
     public void fromHorizenMcTransparentAddress() {
         // Test 1: valid MainNet addresses in MainNet network
-        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false, Option.empty());
+        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, 840000, false, Option.empty());
         String pubKeyAddressMainNet = "znc3p7CFNTsz1s6CceskrTxKevQLPoDK4cK";
         byte[] expectedPublicKeyHashBytesMainNet = BytesUtils.fromHexString("7843a3fcc6ab7d02d40946360c070b13cf7b9795");
 
@@ -297,7 +297,7 @@ public class BytesUtilsTest {
                 0,  null,null, null,
                 null, null, null,
                 null, false, null, null,
-                11111111, true, false, true, 0, false, Option.empty());
+                11111111, true, false, true, 0, 2000, false, Option.empty());
         String pubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";
         byte[] expectedPublicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         assertArrayEquals("Horizen base 58 check address expected to have different public key hash.",
@@ -324,7 +324,7 @@ public class BytesUtilsTest {
         byte[] expectedPublicKeyHashBytes = BytesUtils.fromHexString("7843a3fcc6ab7d02d40946360c070b13cf7b9795");
 
         // Test 1: valid MainNet addresses in MainNet network
-        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false, null);
+        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, 840000, false, null);
         String pubKeyAddressMainNet = BytesUtils.toHorizenPublicKeyAddress(expectedPublicKeyHashBytes, mainNetParams);
 
         assertArrayEquals("Horizen base 58 check address expected to have different public key hash.",
@@ -346,7 +346,7 @@ public class BytesUtilsTest {
         }
 
         // Test 3: valid TestNet addresses in TestNet network
-        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false, null);
+        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, 2000, false, null);
         String pubKeyAddressTestNet = BytesUtils.toHorizenPublicKeyAddress(expectedPublicKeyHashBytes, testNetParams);
         assertArrayEquals("Horizen base 58 check address expected to have different public key hash.",
                 expectedPublicKeyHashBytes,
@@ -385,7 +385,7 @@ public class BytesUtilsTest {
     @Test
     public void toHorizenPublicKeyAddress() {
         // Test 1: valid MainNet addresses in MainNet network
-        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false, Option.empty());
+        NetworkParams mainNetParams = new MainNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, 840000, false, Option.empty());
 
         byte[] publicKeyHashBytesMainNet = BytesUtils.fromHexString("7843a3fcc6ab7d02d40946360c070b13cf7b9795");
         String expectedPubKeyAddressMainNet = "znc3p7CFNTsz1s6CceskrTxKevQLPoDK4cK";
@@ -396,7 +396,7 @@ public class BytesUtilsTest {
 
 
         // Test 2: valid TestNet addresses in TestNet network
-        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, false, Option.empty());
+        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, 2000, false, Option.empty());
 
         byte[] publicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         String expectedPubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";

--- a/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
+++ b/sdk/src/test/java/io/horizen/utils/BytesUtilsTest.java
@@ -297,7 +297,7 @@ public class BytesUtilsTest {
                 0,  null,null, null,
                 null, null, null,
                 null, false, null, null,
-                11111111, true, false, true, 0, 2000, false, Option.empty());
+                11111111, true, false, true, 0, 840000, false, Option.empty());
         String pubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";
         byte[] expectedPublicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         assertArrayEquals("Horizen base 58 check address expected to have different public key hash.",
@@ -346,7 +346,7 @@ public class BytesUtilsTest {
         }
 
         // Test 3: valid TestNet addresses in TestNet network
-        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, 2000, false, null);
+        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, 840000, false, null);
         String pubKeyAddressTestNet = BytesUtils.toHorizenPublicKeyAddress(expectedPublicKeyHashBytes, testNetParams);
         assertArrayEquals("Horizen base 58 check address expected to have different public key hash.",
                 expectedPublicKeyHashBytes,
@@ -396,7 +396,7 @@ public class BytesUtilsTest {
 
 
         // Test 2: valid TestNet addresses in TestNet network
-        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, 2000, false, Option.empty());
+        NetworkParams testNetParams = new TestNetParams(null, null, null, null, null, 1, 0,100, null, null, CircuitTypes.NaiveThresholdSignatureCircuit(),0, null, null, null, null, null, null, null, false, null, null, 11111111, true, false, true, 0, 840000, false, Option.empty());
 
         byte[] publicKeyHashBytesTestNet = BytesUtils.fromHexString("c34e9f61c39bf4fa6225fcf715b59c195c12a6d7");
         String expectedPubKeyAddressTestNet = "ztkxeiFhYTS5sueyWSMDa8UiNr5so6aDdYi";

--- a/sdk/src/test/scala/io/horizen/account/AccountSidechainNodeViewHolderTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/AccountSidechainNodeViewHolderTest.scala
@@ -32,6 +32,7 @@ import sparkz.core.validation.RecoverableModifierError
 import sparkz.core.{VersionTag, idToVersion}
 import sparkz.util.{ModifierId, SparkzEncoding}
 
+import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util
@@ -307,8 +308,8 @@ class AccountSidechainNodeViewHolderTest extends JUnitSuite
     Mockito.when(state.isWithdrawalEpochLastIndex).thenReturn(false)
 
     // Mock state fee payments with checks
-    Mockito.when(state.getFeePaymentsInfo(ArgumentMatchers.any[Int](), any(), ArgumentMatchers.any[Option[AccountBlockFeeInfo]])).thenAnswer(_ => {
-      Seq()
+    Mockito.when(state.getFeePaymentsInfo(ArgumentMatchers.any[Int](), any(), any(),ArgumentMatchers.any[Option[AccountBlockFeeInfo]])).thenAnswer(_ => {
+      (Seq(), BigInteger.valueOf(Long.MaxValue))
     })
 
     // Mock wallet scanPersistent with checks
@@ -332,7 +333,7 @@ class AccountSidechainNodeViewHolderTest extends JUnitSuite
     Thread.sleep(100)
 
     // Verify that all the checks passed
-    Mockito.verify(state, times(0)).getFeePaymentsInfo(ArgumentMatchers.any[Int](), any(), ArgumentMatchers.any[Option[AccountBlockFeeInfo]])
+    Mockito.verify(state, times(0)).getFeePaymentsInfo(ArgumentMatchers.any[Int](), any(), any(),ArgumentMatchers.any[Option[AccountBlockFeeInfo]])
   }
 
   @Test
@@ -360,10 +361,10 @@ class AccountSidechainNodeViewHolderTest extends JUnitSuite
 
     // Mock state fee payments with checks
     val expectedFeePayments: Seq[AccountPayment] = Seq(ForgerAccountFixture.getAccountPayment(0L), ForgerAccountFixture.getAccountPayment(1L))
-    Mockito.when(state.getFeePaymentsInfo(ArgumentMatchers.any[Int](), any(), ArgumentMatchers.any[Option[AccountBlockFeeInfo]]())).thenAnswer(args => {
+    Mockito.when(state.getFeePaymentsInfo(ArgumentMatchers.any[Int](), any(), any(), ArgumentMatchers.any[Option[AccountBlockFeeInfo]]())).thenAnswer(args => {
       val epochNumber: Int = args.getArgument(0)
       assertEquals("Different withdrawal epoch number expected.", withdrawalEpochInfo.epoch, epochNumber)
-      expectedFeePayments
+      (expectedFeePayments, BigInteger.valueOf(Long.MaxValue))
     })
 
     // Mock wallet scanPersistent with checks
@@ -385,7 +386,7 @@ class AccountSidechainNodeViewHolderTest extends JUnitSuite
     Thread.sleep(100)
 
     // Verify that all the checks passed
-    Mockito.verify(state, times(1)).getFeePaymentsInfo(ArgumentMatchers.any[Int](), any(), ArgumentMatchers.any[Option[AccountBlockFeeInfo]])
+    Mockito.verify(state, times(1)).getFeePaymentsInfo(ArgumentMatchers.any[Int](), any(), any(), ArgumentMatchers.any[Option[AccountBlockFeeInfo]])
   }
 
   @Test

--- a/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
@@ -81,7 +81,7 @@ class AccountStateTest
     // Test 1: No block fee info record in the storage
     Mockito.when(metadataStorage.getFeePayments(ArgumentMatchers.any[Int]())).thenReturn(Seq())
     Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Some(ConsensusEpochNumber @@ 1))
-    var feePayments: Seq[AccountPayment] = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))
+    var feePayments: Seq[AccountPayment] = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))._1
     assertEquals(s"Fee payments size expected to be different.", 0, feePayments.size)
 
     // Test 2: with single block fee info record in the storage
@@ -93,7 +93,7 @@ class AccountStateTest
     Mockito.when(metadataStorage.getFeePayments(ArgumentMatchers.any[Int]())).thenReturn(Seq(blockFeeInfo1))
     Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Some(ConsensusEpochNumber @@ 1))
 
-    feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))
+    feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))._1
     assertEquals(s"Fee payments size expected to be different.", 1, feePayments.size)
     assertEquals(
       s"Fee value for baseFee ${feePayments.head.value} is wrong",
@@ -120,7 +120,7 @@ class AccountStateTest
       .thenReturn(Seq(blockFeeInfo1, blockFeeInfo2, blockFeeInfo3))
     Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Some(ConsensusEpochNumber @@ 1))
 
-    feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))
+    feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))._1
     assertEquals(s"Fee payments size expected to be different.", 3, feePayments.size)
 
     var forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))
@@ -147,7 +147,7 @@ class AccountStateTest
       .thenReturn(Seq(blockFeeInfo1, blockFeeInfo2, blockFeeInfo3, blockFeeInfo4))
     Mockito.when(metadataStorage.getConsensusEpochNumber).thenReturn(Some(ConsensusEpochNumber @@ 1))
 
-    feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))
+    feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))._1
     assertEquals(s"Fee payments size expected to be different.", 3, feePayments.size)
 
     forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))
@@ -172,7 +172,7 @@ class AccountStateTest
 
     totalFee = sumFeeInfos(bfi1, bfi2, bfi3, bfi4, bfi5)
 
-    feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))
+    feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))._1
     assertEquals(s"Fee payments size expected to be different.", 2, feePayments.size)
 
     forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))
@@ -204,7 +204,7 @@ class AccountStateTest
       .thenReturn(Seq(blockFeeInfo1, blockFeeInfo2, blockFeeInfo3, blockFeeInfo4))
     Mockito.when(metadataStorage.getMcForgerPoolRewards).thenAnswer(_ => Map(addr1 -> perBlockFee, addr2 -> perBlockFee, addr3 -> perBlockFee.add(perBlockFee)))
 
-    val feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))
+    val feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))._1
     assertEquals(s"Fee payments size expected to be different.", 3, feePayments.size)
 
     val forgerTotalFee = feePayments.foldLeft(BigInteger.ZERO)((sum, payment) => sum.add(payment.value))

--- a/sdk/src/test/scala/io/horizen/account/state/AccountStateViewTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/AccountStateViewTest.scala
@@ -172,11 +172,11 @@ class AccountStateViewTest extends JUnitSuite with MockitoSugar with MessageProc
 
     when(stateDb.getBalance(FORGER_POOL_RECIPIENT_ADDRESS)).thenReturn(BigInteger.valueOf(1000L))
     when(metadataStorageView.getForgerBlockCounters).thenAnswer(_ => blockCounters)
-    val rewardsBeforeFork = stateView.getMcForgerPoolRewards(intToConsensusEpochNumber(0))
+    val rewardsBeforeFork = stateView.getMcForgerPoolRewards(intToConsensusEpochNumber(0),BigInteger.valueOf(Long.MaxValue))
     assertTrue(rewardsBeforeFork.isEmpty)
 
     when(metadataStorageView.getConsensusEpochNumber).thenAnswer(_ => Some(36))
-    val rewardsAfterFork = stateView.getMcForgerPoolRewards(intToConsensusEpochNumber(36))
+    val rewardsAfterFork = stateView.getMcForgerPoolRewards(intToConsensusEpochNumber(36), BigInteger.valueOf(Long.MaxValue))
     assertEquals(3, rewardsAfterFork.size)
     assertEquals(BigInteger.valueOf(200L), rewardsAfterFork(addr1))
     assertEquals(BigInteger.valueOf(300L), rewardsAfterFork(addr2))

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
@@ -3,7 +3,7 @@ package io.horizen.account.utils
 import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.utils.AccountFeePaymentsUtils.{getForgersRewards, getMainchainWithdrawalEpochDistributionCap}
 import io.horizen.fixtures._
-import io.horizen.params.{MainNetParams, TestNetParams}
+import io.horizen.params.MainNetParams
 import io.horizen.utils.BytesUtils
 import org.junit.Assert._
 import org.junit._

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
@@ -3,6 +3,7 @@ package io.horizen.account.utils
 import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.utils.AccountFeePaymentsUtils.{getForgersRewards, getMainchainWithdrawalEpochDistributionCap}
 import io.horizen.fixtures._
+import io.horizen.params.{MainNetParams, TestNetParams}
 import io.horizen.utils.BytesUtils
 import org.junit.Assert._
 import org.junit._
@@ -209,21 +210,27 @@ class AccountFeePaymentsUtilsTest
 
   @Test
   def getMainchainWithdrawalEpochDistributionCapTest(): Unit = {
+    val params = MainNetParams()
+    val baseReward = 1250000000L
+    val rewardAfterFirstHalving = baseReward / 2
+    val rewardAfterSecondHalving = rewardAfterFirstHalving / 2
+    val divider = 10
+
     // test 1 - before first halving
-    var actual: Long = getMainchainWithdrawalEpochDistributionCap(500, 20).longValue()
-    var expected: Long = (12.5 * 1e8 * 20 * 0.1).longValue()
+    var actual: BigInteger = getMainchainWithdrawalEpochDistributionCap(500, params)
+    var expected: BigInteger = ZenWeiConverter.convertZenniesToWei(baseReward * params.withdrawalEpochLength / divider)
     assertEquals(expected, actual)
     // test 2 - at first halving
-    actual = getMainchainWithdrawalEpochDistributionCap(840010, 20).longValue()
-    expected = ((12.5 * 1e8 * 10 * 0.1) + (6.25 * 1e8 * 10 * 0.1)).longValue()
+    actual = getMainchainWithdrawalEpochDistributionCap(840010, params)
+    expected = ZenWeiConverter.convertZenniesToWei((baseReward * (params.withdrawalEpochLength - 10) / divider) + (rewardAfterFirstHalving * 10 / divider))
     assertEquals(expected, actual)
     // test 3 - after first halving
-    actual = getMainchainWithdrawalEpochDistributionCap(1000010, 20).longValue()
-    expected = (6.25 * 1e8 * 20 * 0.1).longValue()
+    actual = getMainchainWithdrawalEpochDistributionCap(1000010, params)
+    expected = ZenWeiConverter.convertZenniesToWei(rewardAfterFirstHalving * params.withdrawalEpochLength / divider)
     assertEquals(expected, actual)
     // test 4 - at second halving
-    actual = getMainchainWithdrawalEpochDistributionCap(1680010, 20).longValue()
-    expected = ((6.25 * 1e8 * 10 * 0.1) + (3.125 * 1e8 * 10 * 0.1)).longValue()
+    actual = getMainchainWithdrawalEpochDistributionCap(1680010, params)
+    expected = ZenWeiConverter.convertZenniesToWei((rewardAfterFirstHalving * (params.withdrawalEpochLength - 10) / divider) + (rewardAfterSecondHalving * 10 / divider))
     assertEquals(expected, actual)
   }
 }

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
@@ -1,13 +1,14 @@
 package io.horizen.account.utils
 
 import io.horizen.account.proposition.AddressProposition
-import io.horizen.account.utils.AccountFeePaymentsUtils.getForgersRewards
+import io.horizen.account.utils.AccountFeePaymentsUtils.{getForgersRewards, getMainchainWithdrawalEpochDistributionCap}
 import io.horizen.fixtures._
 import io.horizen.utils.BytesUtils
 import org.junit.Assert._
 import org.junit._
 import org.scalatestplus.junit.JUnitSuite
 import org.scalatestplus.mockito._
+
 import java.math.BigInteger
 
 
@@ -204,5 +205,25 @@ class AccountFeePaymentsUtilsTest
           assertEquals(BigInteger.valueOf(120), payment.value)
       }
     )
+  }
+
+  @Test
+  def getMainchainWithdrawalEpochDistributionCapTest(): Unit = {
+    // test 1 - before first halving
+    var actual: Long = getMainchainWithdrawalEpochDistributionCap(500, 20).longValue()
+    var expected: Long = (12.5 * 1e8 * 20 * 0.1).longValue()
+    assertEquals(expected, actual)
+    // test 2 - at first halving
+    actual = getMainchainWithdrawalEpochDistributionCap(840010, 20).longValue()
+    expected = ((12.5 * 1e8 * 10 * 0.1) + (6.25 * 1e8 * 10 * 0.1)).longValue()
+    assertEquals(expected, actual)
+    // test 3 - after first halving
+    actual = getMainchainWithdrawalEpochDistributionCap(1000010, 20).longValue()
+    expected = (6.25 * 1e8 * 20 * 0.1).longValue()
+    assertEquals(expected, actual)
+    // test 4 - at second halving
+    actual = getMainchainWithdrawalEpochDistributionCap(1680010, 20).longValue()
+    expected = ((6.25 * 1e8 * 10 * 0.1) + (3.125 * 1e8 * 10 * 0.1)).longValue()
+    assertEquals(expected, actual)
   }
 }

--- a/sdk/src/test/scala/io/horizen/fixtures/sidechainblock/generation/SidechainBlocksGenerator.scala
+++ b/sdk/src/test/scala/io/horizen/fixtures/sidechainblock/generation/SidechainBlocksGenerator.scala
@@ -551,6 +551,7 @@ object SidechainBlocksGenerator extends CompanionsFixture {
       override val isNonCeasing: Boolean = params.isNonCeasing
       override val minVirtualWithdrawalEpochLength: Int = 10
       override val mcBlockRefDelay : Int = 0
+      override val mcHalvingInterval: Int = 840000
     }
   }
 

--- a/sdk/src/test/scala/io/horizen/utils/TimeToEpochUtilsTest.scala
+++ b/sdk/src/test/scala/io/horizen/utils/TimeToEpochUtilsTest.scala
@@ -52,6 +52,7 @@ class TimeToEpochUtilsTest extends JUnitSuite {
     override val isNonCeasing: Boolean = false
     override val minVirtualWithdrawalEpochLength: Int = 10
     override val mcBlockRefDelay : Int = 0
+    override val mcHalvingInterval: Int = 840000
   }
 
   val defaultConsensusFork = ConsensusParamsFork.DefaultConsensusParamsFork

--- a/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
+++ b/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
@@ -937,11 +937,11 @@ public class ScBootstrappingToolCommandProcessor extends CommandProcessor {
 
         switch(network) {
             case 0: // mainnet
-                return new MainNetParams(scId, null, null, null, null, 1, 0,100, null, null, circuitType,0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, false, Option.empty());
+                return new MainNetParams(scId, null, null, null, null, 1, 0,100, null, null, circuitType,0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, 840000,  false, Option.empty());
             case 1: // testnet
-                return new TestNetParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, false, Option.empty());
+                return new TestNetParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, 2000, false, Option.empty());
             case 2: // regtest
-                return new RegTestParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, false, 0, Option.empty());
+                return new RegTestParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, 2000, false, 0, Option.empty());
 
             default:
                 throw new IllegalStateException("Unexpected network type: " + network);

--- a/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
+++ b/tools/sctool/src/main/java/io/horizen/ScBootstrappingToolCommandProcessor.java
@@ -939,7 +939,7 @@ public class ScBootstrappingToolCommandProcessor extends CommandProcessor {
             case 0: // mainnet
                 return new MainNetParams(scId, null, null, null, null, 1, 0,100, null, null, circuitType,0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, 840000,  false, Option.empty());
             case 1: // testnet
-                return new TestNetParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, 2000, false, Option.empty());
+                return new TestNetParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, 840000, false, Option.empty());
             case 2: // regtest
                 return new RegTestParams(scId, null, null, null, null, 1, 0, 100, null, null, circuitType, 0, null, null, null, null, null, null, null, false, null, null, 11111111,true, false, true, 0, 2000, false, 0, Option.empty());
 


### PR DESCRIPTION
Add a limit(cap) of funds from mainchain that are available for distribution at the end of withdrawal epoch.
Cap is calculated as 10% of mainchain coinbase reward from the current withdrawal epoch.
Cap is applied during block forging and block application.
Cap application is controlled by a 1.4.0 fork
