### PR TITLE
json-rpc batch requests: Returning an array of response object also in case of errors

### DIFF
--- a/qa/sc_evm_rpc_eth.py
+++ b/qa/sc_evm_rpc_eth.py
@@ -209,6 +209,7 @@ class SCEvmRPCEth(AccountChainSetup):
             }
         ])
         code, result = do_rpc_call(sc_node, payload)
+        assert_equal(400, code)
         expected_result = [
             {'jsonrpc': '2.0', 'id': 1, 'result': '1000000001'},
             {'error': {'code': -32600, 'message': 'Invalid request: missing field: id', 'data': 'missing field: id'}, 'jsonrpc': '2.0', 'id': None}

--- a/qa/sc_evm_rpc_eth.py
+++ b/qa/sc_evm_rpc_eth.py
@@ -194,7 +194,7 @@ class SCEvmRPCEth(AccountChainSetup):
         check_result(code, result, expected_http_code=200, expected_string_in_result='Method',
                      expected_rpc_code=METHOD_NOT_FOUND_CODE)
 
-        # batch request with a failure, the expected output is a single error json (TODO check this behaviour)
+        # batch request with a failure, the expected output is an Array containing the corresponding Response objects
         payload = json.dumps([
             {
                 "jsonrpc": "2.0",
@@ -209,9 +209,10 @@ class SCEvmRPCEth(AccountChainSetup):
             }
         ])
         code, result = do_rpc_call(sc_node, payload)
-        check_result(code, result, expected_http_code=400, expected_string_in_result='Invalid request',
-                     expected_rpc_code=INVALID_REQUEST_CODE)
-        expected_result = {'error': {'code': -32600, 'message': 'Invalid request'}, 'jsonrpc': '2.0', 'id': None}
+        expected_result = [
+            {'jsonrpc': '2.0', 'id': 1, 'result': '1000000001'},
+            {'error': {'code': -32600, 'message': 'Invalid request: missing field: id', 'data': 'missing field: id'}, 'jsonrpc': '2.0', 'id': None}
+        ]
         assert_equal(expected_result, result)
 
         # empty batch request
@@ -220,11 +221,13 @@ class SCEvmRPCEth(AccountChainSetup):
         check_result(code, result, expected_http_code=400, expected_string_in_result='Invalid request',
                      expected_rpc_code=INVALID_REQUEST_CODE)
 
-        # batch request with just a failure, the expected output is a single error json
+        # batch request with just a failure, the expected output is a an array with a single error json
         payload = json.dumps([1])
         code, result = do_rpc_call(sc_node, payload)
         assert_equal(400, code)
-        expected_result = {'error': {'code': -32600, 'message': 'Invalid request'}, 'jsonrpc': '2.0', 'id': None}
+        expected_result = [
+            {'error': {'code': -32600, 'message': 'Invalid request: missing field: id', 'data': 'missing field: id'}, 'jsonrpc': '2.0', 'id': None}
+        ]
         assert_equal(expected_result, result)
 
         # batch with a single request, the response should be a json array with a single result (not just a result)

--- a/sdk/src/main/scala/io/horizen/account/api/rpc/service/RpcProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/api/rpc/service/RpcProcessor.scala
@@ -43,12 +43,7 @@ case class RpcProcessor(rpcHandler: RpcHandler) extends SparkzLogging {
     })
 
     val json = if (jsonIsArray) {
-      if (hasError) {
-        // if any error has occurred, just reply with one single error message
-        EthJsonMapper.serialize(new RpcResponseError(new RpcId(), RpcError.fromCode(RpcCode.InvalidRequest)))
-      } else {
-        EthJsonMapper.serialize(responses)
-      }
+      EthJsonMapper.serialize(responses)
     } else {
       EthJsonMapper.serialize(responses.head)
     }

--- a/sdk/src/test/scala/io/horizen/account/api/http/route/AccountEthRpcRouteTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/api/http/route/AccountEthRpcRouteTest.scala
@@ -113,7 +113,10 @@ class AccountEthRpcRouteTest extends AccountEthRpcRouteMock {
           {"jsonrpc":"2.0","id":8,"method":"eth_chainId","params":[]},
           {"jsonrpc":"2.0","method":"eth_chainId","params":[]}
         ]""",
-        s"""{"error":{"code":-32600,"message":"Invalid request"},"jsonrpc":"2.0","id":null}""",
+        s"""[
+           {"jsonrpc":"2.0","id":8,"result":"$checkChainId"},
+           {"error":{"code":-32600,"message":"Invalid request: missing field: id","data":"missing field: id"},"jsonrpc":"2.0","id":null}
+        ]""".stripMargin,
         expectedHttpCode = StatusCodes.BadRequest.intValue
       )
     }
@@ -125,7 +128,11 @@ class AccountEthRpcRouteTest extends AccountEthRpcRouteMock {
           24,
           {"jsonrpc":"2.0","id":16,"method":"eth_chainId","params":[]}
         ]""",
-        s"""{"error":{"code":-32600,"message":"Invalid request"},"jsonrpc":"2.0","id":null}""",
+        s"""[
+           {"jsonrpc":"2.0","id":8,"result":"$checkChainId"},
+           {"error":{"code":-32600,"message":"Invalid request: missing field: id","data":"missing field: id"},"jsonrpc":"2.0","id":null},
+           {"jsonrpc":"2.0","id":16,"result":"0x1fca055"}
+        ]""".stripMargin,
         expectedHttpCode = StatusCodes.BadRequest.intValue
       )
     }
@@ -137,7 +144,11 @@ class AccountEthRpcRouteTest extends AccountEthRpcRouteMock {
           16,
           24
         ]""",
-        """{"error":{"code":-32600,"message":"Invalid request"},"jsonrpc":"2.0","id":null}""",
+        """[
+          {"error":{"code":-32600,"message":"Invalid request: missing field: id","data":"missing field: id"},"jsonrpc":"2.0","id":null},
+          {"error":{"code":-32600,"message":"Invalid request: missing field: id","data":"missing field: id"},"jsonrpc":"2.0","id":null},
+          {"error":{"code":-32600,"message":"Invalid request: missing field: id","data":"missing field: id"},"jsonrpc":"2.0","id":null}
+        ]""".stripMargin,
         expectedHttpCode = StatusCodes.BadRequest.intValue
       )
     }
@@ -164,7 +175,10 @@ class AccountEthRpcRouteTest extends AccountEthRpcRouteMock {
           {"jsonrpc":"2.0","id":-258,"method":"eth_chainId","params":[]},
           {"jsonrpc":"2.0","id":16,"method":"eth_chainId","params":[]}
         ]""",
-        s"""{"error":{"code":-32600,"message":"Invalid request"},"jsonrpc":"2.0","id":null}""",
+        s"""[
+           {"error":{"code":-32600,"message":"Invalid request: Rpc Id can't be a negative number","data":"Rpc Id can't be a negative number"},"jsonrpc":"2.0","id":null},
+           {"jsonrpc":"2.0","id":16,"result":"$checkChainId"}
+        ]""".stripMargin,
         expectedHttpCode = StatusCodes.BadRequest.intValue
       )
     }


### PR DESCRIPTION
As documented in issue SDK-1660 we are reverting some code changes in the fix for returning an array of response object also in case of errors- in a json-rpc batch request

https://horizenlabs.atlassian.net/browse/SDK-1660?atlOrigin=eyJpIjoiOGMxNDAxOWRjMTlmNDUyNDlmOGRjMzgwYzdkZjg5YWYiLCJwIjoiaiJ9
