### PR TITLE
Reward workflow changes + feePayments API changes + rewardsReceived native method

### DIFF
--- a/qa/sc_evm_forging_fee_payments.py
+++ b/qa/sc_evm_forging_fee_payments.py
@@ -117,7 +117,7 @@ class ScEvmForgingFeePayments(AccountChainSetup):
         # Do FT of some Zen to SC Node 2
         evm_address_sc_node_2 = sc_node_2.wallet_createPrivateKeySecp256k1()["result"]["proposition"]["address"]
 
-        ft_amount_in_zen = 2.0
+        ft_amount_in_zen = 12.0
         ft_amount_in_zennies = convertZenToZennies(ft_amount_in_zen)
         ft_amount_in_wei = convertZenniesToWei(ft_amount_in_zennies)
 
@@ -149,7 +149,7 @@ class ScEvmForgingFeePayments(AccountChainSetup):
         sc2_blockSignPubKey = sc_node_2.wallet_createPrivateKey25519()["result"]["proposition"]["publicKey"]
         sc2_vrfPubKey = sc_node_2.wallet_createVrfSecret()["result"]["proposition"]["publicKey"]
 
-        forger_stake_amount = 1  # Zen
+        forger_stake_amount = 11  # Zen
         forger_stake_amount_in_wei = convertZenToWei(forger_stake_amount)
 
         makeForgerStakeJsonRes = ac_makeForgerStake(sc_node_2, evm_address_sc_node_2, sc2_blockSignPubKey,
@@ -408,8 +408,8 @@ class ScEvmForgingFeePayments(AccountChainSetup):
         assert_equal(ft_pool_remaining, forger_pool_balance)
 
         fee_payments_api_response = http_block_getFeePayments(sc_node_1, last_block_id)['feePayments']
-        assert_equal(node_1_fees, fee_payments_api_response[0]['value'])
-        assert_equal(node_2_fees, fee_payments_api_response[1]['value'])
+        assert_equal(node_1_fees, [f for f in fee_payments_api_response if f['address']['address'] != self.FORGER_REWARD_ADDRESS][0]['value'])
+        assert_equal(node_2_fees, [f for f in fee_payments_api_response if f['address']['address'] == self.FORGER_REWARD_ADDRESS][0]['value'])
 
         # reach the VERSION_1_3_FORK_EPOCH fork and upgrade the forger stakes to the new format
         current_best_epoch = sc_node_1.block_forgingInfo()["result"]["bestBlockEpochNumber"]

--- a/qa/sc_evm_forging_fee_payments.py
+++ b/qa/sc_evm_forging_fee_payments.py
@@ -411,13 +411,6 @@ class ScEvmForgingFeePayments(AccountChainSetup):
         assert_equal(node_1_fees, [f for f in fee_payments_api_response if f['address']['address'] != self.FORGER_REWARD_ADDRESS][0]['value'])
         assert_equal(node_2_fees, [f for f in fee_payments_api_response if f['address']['address'] == self.FORGER_REWARD_ADDRESS][0]['value'])
 
-        # reach the VERSION_1_3_FORK_EPOCH fork and upgrade the forger stakes to the new format
-        current_best_epoch = sc_node_1.block_forgingInfo()["result"]["bestBlockEpochNumber"]
-
-        for i in range(0, VERSION_1_3_FORK_EPOCH - current_best_epoch):
-            generate_next_block(sc_node_1, "first node", force_switch_to_next_epoch=True)
-            self.sc_sync_all()
-
         '''
         #####################################################################################
         '''

--- a/qa/sc_evm_native_forger_v2.py
+++ b/qa/sc_evm_native_forger_v2.py
@@ -920,7 +920,9 @@ class SCEvmNativeForgerV2(AccountChainSetup):
         assert_equal(0, forger_pool_balance)
 
         payments = http_block_getFeePayments(sc_node_1, sc_last_we_block_id)['feePayments']
-        print(payments)
+        assert_equal(forger_stake_list[0]['forgerStakeData']['ownerPublicKey']['address'], payments[0]['address']['address'])
+        assert_equal(ft_pool_amount_wei, payments[0]['valueFromMainchain'])
+        assert_equal(payments[0]['value'], payments[0]['valueFromMainchain'] + payments[0]['valueFromFees'])
 
 
 def decode_paged_list_of_forgers(result):

--- a/sdk/src/main/java/io/horizen/account/state/EvmMessageProcessor.java
+++ b/sdk/src/main/java/io/horizen/account/state/EvmMessageProcessor.java
@@ -2,6 +2,7 @@ package io.horizen.account.state;
 
 import io.horizen.account.fork.ContractInteroperabilityFork;
 import io.horizen.account.fork.Version1_3_0Fork;
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader;
 import io.horizen.evm.*;
 import io.horizen.evm.results.InvocationResult;
 import io.horizen.utils.BytesUtils;
@@ -49,7 +50,7 @@ public class EvmMessageProcessor implements MessageProcessor {
     }
 
     @Override
-    public byte[] process(Invocation invocation, BaseAccountStateView view, ExecutionContext context)
+    public byte[] process(Invocation invocation, BaseAccountStateView view, MsgProcessorMetadataStorageReader metadata, ExecutionContext context)
         throws ExecutionFailedException {
         // prepare context
         var block = context.blockContext();

--- a/sdk/src/main/java/io/horizen/account/state/MessageProcessor.java
+++ b/sdk/src/main/java/io/horizen/account/state/MessageProcessor.java
@@ -1,6 +1,8 @@
 package io.horizen.account.state;
 
 
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader;
+
 // This interface models the entity which is responsible for handling the application of a transaction to a state view.
 // More in detail, a transaction is converted into a 'Message' object, which is processed
 // by a specific instance of MessageProcessor.
@@ -32,12 +34,17 @@ public interface MessageProcessor {
      *
      * @param invocation invocation to execute
      * @param view       state view
+     * @param metadata   metadata view. IMPORTANT: always refers to the tip, not the current view
      * @param context    contextual information accessible during execution. It contains also the consensus epoch number
      * @return return data on successful execution
      * @throws ExecutionRevertedException revert-and-keep-gas-left, also mark the message as "failed"
      * @throws ExecutionFailedException   revert-and-consume-all-gas, also mark the message as "failed"
      * @throws RuntimeException           any other exceptions are considered as "invalid message"
      */
-    byte[] process(Invocation invocation, BaseAccountStateView view, ExecutionContext context)
-        throws ExecutionFailedException;
+    byte[] process(
+        Invocation invocation,
+        BaseAccountStateView view,
+        MsgProcessorMetadataStorageReader metadata,
+        ExecutionContext context
+    ) throws ExecutionFailedException;
 }

--- a/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
@@ -124,7 +124,7 @@ class AccountForgeMessageBuilder(
         priceAndNonceIter.removeAndSkipAccount()
       } else {
 
-        stateView.applyTransaction(tx, listOfTxsInBlock.size, blockGasPool, blockContext) match {
+        stateView.applyTransaction(tx, listOfTxsInBlock.size, blockGasPool, blockContext, stateView) match {
           case Success(consensusDataReceipt) =>
             val ethTx = tx.asInstanceOf[EthereumTransaction]
 
@@ -249,7 +249,18 @@ class AccountForgeMessageBuilder(
             val currentBlockPayments = resultTuple._3
 
             val consensusEpochNumber: ConsensusEpochNumber = intToConsensusEpochNumber(blockContext.consensusEpochNumber)
-            dummyView.updateForgerBlockCounter(forgerAddress, consensusEpochNumber)
+            val fork_1_4_active = Version1_4_0Fork.get(consensusEpochNumber).active
+            if (fork_1_4_active) {
+              dummyView.updateForgerBlockCounter(
+                ForgerIdentifier(
+                  forgerAddress,
+                  Some(forgingStakeInfo.blockSignPublicKey),
+                  Some(forgingStakeInfo.vrfPublicKey)),
+                consensusEpochNumber
+              )
+            } else {
+              dummyView.updateForgerBlockCounter(ForgerIdentifier(forgerAddress), consensusEpochNumber)
+            }
 
             val feePayments = if (isWithdrawalEpochLastBlock) {
               // Current block is expected to be the continuation of the current tip, so there are no ommers.
@@ -260,11 +271,11 @@ class AccountForgeMessageBuilder(
               require(ommers.isEmpty, "No Ommers allowed for the last block of the withdrawal epoch.")
 
               val withdrawalEpochNumber: Int = WithdrawalEpochUtils.getWithdrawalEpochInfo(mainchainBlockReferencesData.size, dummyView.getWithdrawalEpochInfo, params).epoch
-              val distributionCap = if (Version1_4_0Fork.get(consensusEpochNumber).active) {
+              val distributionCap = if (fork_1_4_active) {
                 val mcLastBlockHeight = params.mainchainCreationBlockHeight + ((withdrawalEpochNumber + 1) * params.withdrawalEpochLength) - 1
                 AccountFeePaymentsUtils.getMainchainWithdrawalEpochDistributionCap(mcLastBlockHeight, params)
               } else MAX_MONEY_IN_WEI
-              val blockToAppendFeeInfo = if (Version1_4_0Fork.get(consensusEpochNumber).active) {
+              val blockToAppendFeeInfo = if (fork_1_4_active) {
                 Some(currentBlockPayments.copy(blockSignPublicKey = Some(forgingStakeInfo.blockSignPublicKey), vrfPublicKey = Some(forgingStakeInfo.vrfPublicKey)))
               } else {
                 Some(currentBlockPayments)

--- a/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
+++ b/sdk/src/main/scala/io/horizen/account/forger/AccountForgeMessageBuilder.scala
@@ -264,8 +264,13 @@ class AccountForgeMessageBuilder(
                 val mcLastBlockHeight = params.mainchainCreationBlockHeight + ((withdrawalEpochNumber + 1) * params.withdrawalEpochLength) - 1
                 AccountFeePaymentsUtils.getMainchainWithdrawalEpochDistributionCap(mcLastBlockHeight, params)
               } else MAX_MONEY_IN_WEI
+              val blockToAppendFeeInfo = if (Version1_4_0Fork.get(consensusEpochNumber).active) {
+                Some(currentBlockPayments.copy(blockSignPublicKey = Some(forgingStakeInfo.blockSignPublicKey), vrfPublicKey = Some(forgingStakeInfo.vrfPublicKey)))
+              } else {
+                Some(currentBlockPayments)
+              }
               // get all previous payments for current ending epoch and append the one of the current block
-              val (feePayments, poolBalanceDistributed) = dummyView.getFeePaymentsInfo(withdrawalEpochNumber, consensusEpochNumber, distributionCap, Some(currentBlockPayments))
+              val (feePayments, poolBalanceDistributed) = dummyView.getFeePaymentsInfo(withdrawalEpochNumber, consensusEpochNumber, distributionCap, blockToAppendFeeInfo)
 
               dummyView.subtractForgerPoolBalanceAndResetBlockCounters(consensusEpochNumber, poolBalanceDistributed)
 

--- a/sdk/src/main/scala/io/horizen/account/state/AccountState.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/AccountState.scala
@@ -424,13 +424,8 @@ class AccountState(
     val mcForgerPoolRewards = stateMetadataStorage.getMcForgerPoolRewards
     val poolBalanceDistributed = mcForgerPoolRewards.values.foldLeft(BigInteger.ZERO)((a, b) => a.add(b))
     if (Version1_4_0Fork.get(consensusEpochNumber).active) {
-      val (feePayments, delegatorPayments) =
-        using(getView)(
-          _.getForgersAndDelegatorsShares(
-            AccountFeePaymentsUtils.getForgersRewards(feePaymentInfoSeq, mcForgerPoolRewards),
-            mcForgerPoolRewards
-          )
-        )
+      val forgerRewards = AccountFeePaymentsUtils.getForgersRewards(feePaymentInfoSeq, mcForgerPoolRewards)
+      val (feePayments, delegatorPayments) = using(getView)(_.getForgersAndDelegatorsShares(forgerRewards))
       val allPayments = AccountFeePaymentsUtils.groupAllPaymentsByAddress(feePayments, delegatorPayments)
 
       (allPayments, poolBalanceDistributed)

--- a/sdk/src/main/scala/io/horizen/account/state/AccountStateReader.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/AccountStateReader.scala
@@ -1,5 +1,6 @@
 package io.horizen.account.state
 
+import io.horizen.account.network.ForgerInfo
 import io.horizen.account.state.nativescdata.forgerstakev2.{PagedStakesByDelegatorResponse, PagedStakesByForgerResponse}
 import io.horizen.account.state.receipt.EthereumConsensusDataLog
 import io.horizen.certificatesubmitter.keys.{CertifiersKeys, KeyRotationProof}
@@ -27,6 +28,7 @@ trait AccountStateReader {
   def getPagedListOfForgersStakes(startPos: Int, pageSize: Int): (Int, Seq[AccountForgingStakeInfo])
   def getPagedForgersStakesByForger(forger: ForgerPublicKeys, startPos: Int, pageSize: Int): PagedStakesByForgerResponse
   def getPagedForgersStakesByDelegator(delegator: Address, startPos: Int, pageSize: Int): PagedStakesByDelegatorResponse
+  def getForgerInfo(forger: ForgerPublicKeys): Option[ForgerInfo]
  
   def getForgerStakeData(stakeId: String, isForkV1_3Active: Boolean): Option[ForgerStakeData]
   def isForgingOpen: Boolean

--- a/sdk/src/main/scala/io/horizen/account/state/BaseAccountStateView.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/BaseAccountStateView.scala
@@ -1,11 +1,12 @@
 package io.horizen.account.state
 
 import io.horizen.account.state.receipt.EthereumConsensusDataLog
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.evm.Address
 
 import java.math.BigInteger
 
-trait BaseAccountStateView extends AccountStateReader {
+trait BaseAccountStateView extends AccountStateReader with MsgProcessorMetadataStorageReader {
 
   def addAccount(address: Address, code: Array[Byte]): Unit
   def increaseNonce(address: Address): Unit

--- a/sdk/src/main/scala/io/horizen/account/state/BaseAccountStateView.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/BaseAccountStateView.scala
@@ -1,7 +1,6 @@
 package io.horizen.account.state
 
 import io.horizen.account.state.receipt.EthereumConsensusDataLog
-import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.evm.Address
 
 import java.math.BigInteger

--- a/sdk/src/main/scala/io/horizen/account/state/BaseAccountStateView.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/BaseAccountStateView.scala
@@ -6,7 +6,7 @@ import io.horizen.evm.Address
 
 import java.math.BigInteger
 
-trait BaseAccountStateView extends AccountStateReader with MsgProcessorMetadataStorageReader {
+trait BaseAccountStateView extends AccountStateReader {
 
   def addAccount(address: Address, code: Array[Byte]): Unit
   def increaseNonce(address: Address): Unit

--- a/sdk/src/main/scala/io/horizen/account/state/CertificateKeyRotationMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/CertificateKeyRotationMsgProcessor.scala
@@ -5,6 +5,7 @@ import io.horizen.account.abi.ABIUtil.{METHOD_ID_LENGTH, getABIMethodId, getArgu
 import io.horizen.account.abi.{ABIDecoder, ABIEncodable, MsgProcessorInputDecoder}
 import io.horizen.account.state.CertificateKeyRotationMsgProcessor.{CertificateKeyRotationContractAddress, CertificateKeyRotationContractCode, SubmitKeyRotationReqCmdSig}
 import io.horizen.account.state.events.SubmitKeyRotation
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.utils.WellKnownAddresses.CERTIFICATE_KEY_ROTATION_SMART_CONTRACT_ADDRESS
 import io.horizen.certificatesubmitter.keys.KeyRotationProofTypes.{KeyRotationProofType, MasterKeyRotationProofType, SigningKeyRotationProofType}
 import io.horizen.certificatesubmitter.keys.{CertifiersKeys, KeyRotationProof, KeyRotationProofSerializer, KeyRotationProofTypes}
@@ -37,7 +38,7 @@ case class CertificateKeyRotationMsgProcessor(params: NetworkParams) extends Nat
   override val contractCode: Array[Byte] = CertificateKeyRotationContractCode
 
   @throws(classOf[ExecutionFailedException])
-  override def process(invocation: Invocation, view: BaseAccountStateView, context: ExecutionContext): Array[Byte] = {
+  override def process(invocation: Invocation, view: BaseAccountStateView, metadata: MsgProcessorMetadataStorageReader, context: ExecutionContext): Array[Byte] = {
     val gasView = view.getGasTrackedView(invocation.gasPool)
     getFunctionSignature(invocation.input) match {
       case SubmitKeyRotationReqCmdSig =>

--- a/sdk/src/main/scala/io/horizen/account/state/EoaMessageProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/EoaMessageProcessor.scala
@@ -1,5 +1,6 @@
 package io.horizen.account.state
 
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import sparkz.util.SparkzLogging
 
 /*
@@ -22,6 +23,7 @@ object EoaMessageProcessor extends MessageProcessor with SparkzLogging {
   override def process(
       invocation: Invocation,
       view: BaseAccountStateView,
+      metadata: MsgProcessorMetadataStorageReader,
       context: ExecutionContext
   ): Array[Byte] = {
     view.subBalance(invocation.caller, invocation.value)

--- a/sdk/src/main/scala/io/horizen/account/state/ForgerBlockCountersSerializer.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/ForgerBlockCountersSerializer.scala
@@ -1,27 +1,46 @@
 package io.horizen.account.state
 
-import io.horizen.account.proposition.{AddressProposition, AddressPropositionSerializer}
+import io.horizen.account.proposition.AddressPropositionSerializer
+import io.horizen.account.utils.ForgerIdentifier
+import io.horizen.proposition.{PublicKey25519PropositionSerializer, VrfPublicKeySerializer}
 import sparkz.core.serialization.SparkzSerializer
 import sparkz.util.serialization.{Reader, Writer}
 
-object ForgerBlockCountersSerializer extends SparkzSerializer[Map[AddressProposition, Long]] {
+object ForgerBlockCountersSerializer extends SparkzSerializer[Map[ForgerIdentifier, Long]] {
 
   private val addressSerializer: AddressPropositionSerializer = AddressPropositionSerializer.getSerializer
+  private val signPubKeySerializer: PublicKey25519PropositionSerializer =
+    PublicKey25519PropositionSerializer.getSerializer
+  private val vrfPubKeySerializer: VrfPublicKeySerializer = VrfPublicKeySerializer.getSerializer
+  final val SERIALIZATION_FORMAT_1_4_FLAG = -1
 
-  override def serialize(forgerBlockCounters: Map[AddressProposition, Long], w: Writer): Unit = {
+  override def serialize(forgerBlockCounters: Map[ForgerIdentifier, Long], w: Writer): Unit = {
     w.putInt(forgerBlockCounters.size)
-    forgerBlockCounters.foreach { case (address, counter) =>
-      addressSerializer.serialize(address, w)
-      w.putLong(counter)
+    forgerBlockCounters.foreach {
+      case (forgerIdentifier, counter) =>
+        addressSerializer.serialize(forgerIdentifier.address, w)
+        if (forgerIdentifier.blockSignPublicKey.isDefined && forgerIdentifier.vrfPublicKey.isDefined) {
+          w.putLong(SERIALIZATION_FORMAT_1_4_FLAG) //flag to indicate new serialization format is used
+          forgerIdentifier.blockSignPublicKey.foreach(p => signPubKeySerializer.serialize(p, w))
+          forgerIdentifier.vrfPublicKey.foreach(p => vrfPubKeySerializer.serialize(p, w))
+        }
+        w.putLong(counter)
     }
   }
 
-  override def parse(r: Reader): Map[AddressProposition, Long] = {
+  override def parse(r: Reader): Map[ForgerIdentifier, Long] = {
     val length = r.getInt()
     (1 to length).map { _ =>
       val address = addressSerializer.parse(r)
       val counter = r.getLong()
-      (address, counter)
+      if (counter == SERIALIZATION_FORMAT_1_4_FLAG) {
+        val blockSignPublicKey = signPubKeySerializer.parse(r)
+        val vrfPublicKey = vrfPubKeySerializer.parse(r)
+        val counter = r.getLong()
+        (ForgerIdentifier(address, Some(blockSignPublicKey), Some(vrfPublicKey)), counter)
+      } else {
+        (ForgerIdentifier(address), counter)
+      }
     }.toMap
   }
 

--- a/sdk/src/main/scala/io/horizen/account/state/ForgerStakeMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/ForgerStakeMsgProcessor.scala
@@ -14,6 +14,7 @@ import io.horizen.account.state.NativeSmartContractMsgProcessor.NULL_HEX_STRING_
 import io.horizen.account.state.events._
 import io.horizen.account.utils.{AccountPayment, WellKnownAddresses}
 import io.horizen.account.state.events.{DelegateForgerStake, OpenForgerList, StakeUpgrade, WithdrawForgerStake}
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.utils.WellKnownAddresses.FORGER_STAKE_SMART_CONTRACT_ADDRESS
 import io.horizen.account.utils.ZenWeiConverter.isValidZenAmount
 import io.horizen.evm.Address
@@ -469,7 +470,7 @@ case class ForgerStakeMsgProcessor(params: NetworkParams) extends NativeSmartCon
   }
 
     @throws(classOf[ExecutionFailedException])
-    override def process(invocation: Invocation, view: BaseAccountStateView, context: ExecutionContext): Array[Byte] = {
+    override def process(invocation: Invocation, view: BaseAccountStateView, metadata: MsgProcessorMetadataStorageReader, context: ExecutionContext): Array[Byte] = {
       val gasView = view.getGasTrackedView(invocation.gasPool)
       if (Version1_4_0Fork.get(context.blockContext.consensusEpochNumber).active && ForgerStakeStorage.isDisabled(gasView)) {
         getFunctionSignature(invocation.input) match {

--- a/sdk/src/main/scala/io/horizen/account/state/ForgerStakeV2MsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/ForgerStakeV2MsgProcessor.scala
@@ -299,8 +299,8 @@ object ForgerStakeV2MsgProcessor extends NativeSmartContractWithFork  with Forge
     val forgerKeys: ForgerPublicKeys = cmdInput.forgerPublicKeys
     val consensusEpochStart: Int = cmdInput.consensusEpochStart
     val maxNumOfEpoch: Int =
-      if (consensusEpochStart + cmdInput.maxNumOfEpoch - 1 > currentEpoch)
-        currentEpoch - consensusEpochStart - 1
+      if (consensusEpochStart + cmdInput.maxNumOfEpoch - 1 >= currentEpoch)
+        currentEpoch - consensusEpochStart
       else
         cmdInput.maxNumOfEpoch
 

--- a/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/McAddrOwnershipMsgProcessor.scala
@@ -7,6 +7,7 @@ import io.horizen.account.proof.SignatureSecp256k1
 import io.horizen.account.state.McAddrOwnershipMsgProcessor.{AddNewMultisigOwnershipCmd, AddNewOwnershipCmd, GetListOfAllOwnershipsCmd, GetListOfOwnerScAddressesCmd, GetListOfOwnershipsCmd, OwnershipLinkedListNullValue, OwnershipsLinkedListTipKey, RemoveOwnershipCmd, ScAddressRefsLinkedListNullValue, ScAddressRefsLinkedListTipKey, checkMcRedeemScriptForMultisig, checkMultisigAddress, getMcSignature, getOwnershipId, isValidOwnershipSignature, verifySignaturesWithThreshold}
 import io.horizen.account.state.NativeSmartContractMsgProcessor.NULL_HEX_STRING_32
 import io.horizen.account.state.events.{AddMcAddrOwnership, RemoveMcAddrOwnership}
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.utils.BigIntegerUInt256.getUnsignedByteArray
 import io.horizen.account.utils.Secp256k1.{PUBLIC_KEY_SIZE, SIGNATURE_RS_SIZE}
 import io.horizen.account.utils.WellKnownAddresses.MC_ADDR_OWNERSHIP_SMART_CONTRACT_ADDRESS
@@ -477,7 +478,7 @@ case class McAddrOwnershipMsgProcessor(networkParams: NetworkParams) extends Nat
   }
 
   @throws(classOf[ExecutionFailedException])
-  override def process(invocation: Invocation, view: BaseAccountStateView, context: ExecutionContext): Array[Byte] = {
+  override def process(invocation: Invocation, view: BaseAccountStateView, metadata: MsgProcessorMetadataStorageReader, context: ExecutionContext): Array[Byte] = {
     if (!isForkActive(context.blockContext.consensusEpochNumber)) {
       throw new ExecutionRevertedException(s"zenDao fork not active")
     }

--- a/sdk/src/main/scala/io/horizen/account/state/McForgerPoolRewardsSerializer.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/McForgerPoolRewardsSerializer.scala
@@ -1,34 +1,54 @@
 package io.horizen.account.state
 
-import io.horizen.account.proposition.{AddressProposition, AddressPropositionSerializer}
-import io.horizen.evm.utils.BigIntegerSerializer
+import io.horizen.account.proposition.AddressPropositionSerializer
+import io.horizen.account.utils.ForgerIdentifier
+import io.horizen.proposition.{PublicKey25519PropositionSerializer, VrfPublicKeySerializer}
 import sparkz.core.serialization.SparkzSerializer
 import sparkz.util.serialization.{Reader, Writer}
 
 import java.math.BigInteger
 
-object McForgerPoolRewardsSerializer extends SparkzSerializer[Map[AddressProposition, BigInteger]] {
-
+object McForgerPoolRewardsSerializer extends SparkzSerializer[Map[ForgerIdentifier, BigInteger]] {
+  final val SERIALIZATION_FORMAT_1_4_FLAG = -1
   private val addressSerializer: AddressPropositionSerializer = AddressPropositionSerializer.getSerializer
-  new BigIntegerSerializer()
+  private val signPubKeySerializer: PublicKey25519PropositionSerializer =
+    PublicKey25519PropositionSerializer.getSerializer
+  private val vrfPubKeySerializer: VrfPublicKeySerializer = VrfPublicKeySerializer.getSerializer
 
-  override def serialize(forgerPoolRewards: Map[AddressProposition, BigInteger], w: Writer): Unit = {
+  override def serialize(forgerPoolRewards: Map[ForgerIdentifier, BigInteger], w: Writer): Unit = {
     w.putInt(forgerPoolRewards.size)
-    forgerPoolRewards.foreach { case (address, reward) =>
-      addressSerializer.serialize(address, w)
-      val rewardBytes: Array[Byte] = reward.toByteArray
-      w.putInt(rewardBytes.length)
-      w.putBytes(rewardBytes)
+    forgerPoolRewards.foreach { case (forgerIdentifier, reward) =>
+      addressSerializer.serialize(forgerIdentifier.address, w)
+      if (forgerIdentifier.blockSignPublicKey.isDefined && forgerIdentifier.vrfPublicKey.isDefined) {
+        w.putInt(SERIALIZATION_FORMAT_1_4_FLAG) //flag to indicate new serialization format is used
+        forgerIdentifier.blockSignPublicKey.foreach(p => signPubKeySerializer.serialize(p, w))
+        forgerIdentifier.vrfPublicKey.foreach(p => vrfPubKeySerializer.serialize(p, w))
+        w.putInt(reward.toByteArray.length)
+        w.putBytes(reward.toByteArray)
+      }
+      else {
+        w.putInt(reward.toByteArray.length)
+        w.putBytes(reward.toByteArray)
+      }
     }
   }
 
-  override def parse(r: Reader): Map[AddressProposition, BigInteger] = {
+  override def parse(r: Reader): Map[ForgerIdentifier, BigInteger] = {
     val length = r.getInt()
     (1 to length).map { _ =>
       val address = addressSerializer.parse(r)
-      val rewardLength: Int = r.getInt
-      val reward: BigInteger = new BigInteger(r.getBytes(rewardLength))
-      (address, reward)
+      val valueLength: Int = r.getInt
+      if (valueLength == SERIALIZATION_FORMAT_1_4_FLAG) {
+        val blockSignPublicKey = signPubKeySerializer.parse(r)
+        val vrfPublicKey = vrfPubKeySerializer.parse(r)
+        val rewardLength: Int = r.getInt
+        val reward: BigInteger = new BigInteger(r.getBytes(rewardLength))
+        (ForgerIdentifier(address, Some(blockSignPublicKey), Some(vrfPublicKey)), reward)
+      }
+      else {
+        val reward: BigInteger = new BigInteger(r.getBytes(valueLength))
+        (ForgerIdentifier(address), reward)
+      }
     }.toMap
   }
 

--- a/sdk/src/main/scala/io/horizen/account/state/ProxyMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/ProxyMsgProcessor.scala
@@ -7,7 +7,7 @@ import io.horizen.account.state.events.ProxyInvocation
 import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.utils.WellKnownAddresses.PROXY_SMART_CONTRACT_ADDRESS
 import io.horizen.evm.Address
-import io.horizen.params.{MainNetParams, NetworkParams, RegTestParams}
+import io.horizen.params.{NetworkParams, RegTestParams}
 import io.horizen.utils.BytesUtils
 import org.web3j.utils.Numeric
 import sparkz.crypto.hash.Keccak256

--- a/sdk/src/main/scala/io/horizen/account/state/ProxyMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/ProxyMsgProcessor.scala
@@ -4,6 +4,7 @@ import io.horizen.account.abi.ABIUtil.{METHOD_ID_LENGTH, getABIMethodId, getArgu
 import io.horizen.account.fork.ContractInteroperabilityFork
 import io.horizen.account.state.ProxyMsgProcessor._
 import io.horizen.account.state.events.ProxyInvocation
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.utils.WellKnownAddresses.PROXY_SMART_CONTRACT_ADDRESS
 import io.horizen.evm.Address
 import io.horizen.params.{MainNetParams, NetworkParams, RegTestParams}
@@ -93,7 +94,7 @@ case class ProxyMsgProcessor(params: NetworkParams) extends NativeSmartContractW
 
 
   @throws(classOf[ExecutionFailedException])
-  override def process(invocation: Invocation, view: BaseAccountStateView, context: ExecutionContext): Array[Byte] = {
+  override def process(invocation: Invocation, view: BaseAccountStateView, metadata: MsgProcessorMetadataStorageReader, context: ExecutionContext): Array[Byte] = {
     log.debug(s"processing invocation: $invocation")
 
     val gasView = view.getGasTrackedView(invocation.gasPool)

--- a/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateViewGasTracked.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateViewGasTracked.scala
@@ -1,7 +1,6 @@
 package io.horizen.account.state
 
 import io.horizen.account.state.receipt.EthereumConsensusDataLog
-import io.horizen.account.storage.AccountStateMetadataStorageView
 import io.horizen.evm.{Address, Hash, StateDB}
 
 import java.math.BigInteger

--- a/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateViewGasTracked.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateViewGasTracked.scala
@@ -14,10 +14,9 @@ import java.math.BigInteger
 class StateDbAccountStateViewGasTracked(
     stateDb: StateDB,
     messageProcessors: Seq[MessageProcessor],
-    metadataStorageView: AccountStateMetadataStorageView,
     readOnly: Boolean,
     gas: GasPool
-) extends StateDbAccountStateView(stateDb, messageProcessors, metadataStorageView, readOnly) {
+) extends StateDbAccountStateView(stateDb, messageProcessors, readOnly) {
 
   /**
    * Consume gas for account access:

--- a/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateViewGasTracked.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/StateDbAccountStateViewGasTracked.scala
@@ -1,6 +1,7 @@
 package io.horizen.account.state
 
 import io.horizen.account.state.receipt.EthereumConsensusDataLog
+import io.horizen.account.storage.AccountStateMetadataStorageView
 import io.horizen.evm.{Address, Hash, StateDB}
 
 import java.math.BigInteger
@@ -13,9 +14,10 @@ import java.math.BigInteger
 class StateDbAccountStateViewGasTracked(
     stateDb: StateDB,
     messageProcessors: Seq[MessageProcessor],
+    metadataStorageView: AccountStateMetadataStorageView,
     readOnly: Boolean,
     gas: GasPool
-) extends StateDbAccountStateView(stateDb, messageProcessors, readOnly) {
+) extends StateDbAccountStateView(stateDb, messageProcessors, metadataStorageView, readOnly) {
 
   /**
    * Consume gas for account access:

--- a/sdk/src/main/scala/io/horizen/account/state/StateTransition.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/StateTransition.scala
@@ -1,6 +1,7 @@
 package io.horizen.account.state
 
 import io.horizen.account.fork.Version1_3_0Fork
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.utils.BigIntegerUtil
 import io.horizen.evm.{EvmContext, ForkRules}
 import sparkz.util.SparkzLogging
@@ -16,7 +17,8 @@ class StateTransition(
     blockGasPool: GasPool,
     val blockContext: BlockContext,
     val msg: Message,
-                     ) extends SparkzLogging with ExecutionContext {
+    metadata: MsgProcessorMetadataStorageReader
+  ) extends SparkzLogging with ExecutionContext {
 
   // the current stack of invocations
   private val invocationStack = new ListBuffer[Invocation]
@@ -241,7 +243,7 @@ class StateTransition(
     // create a snapshot before any changes are made by the processor
     val revert = view.snapshot
     // execute the message processor
-    val result = Try.apply(processor.process(invocation, view, this))
+    val result = Try.apply(processor.process(invocation, view, metadata, this))
     // handle errors
     result match {
       // if the processor throws ExecutionRevertedException we revert changes

--- a/sdk/src/main/scala/io/horizen/account/state/WithdrawalMsgProcessor.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/WithdrawalMsgProcessor.scala
@@ -4,6 +4,7 @@ import com.google.common.primitives.{Bytes, Ints}
 import io.horizen.account.abi.ABIUtil.{METHOD_ID_LENGTH, getABIMethodId, getArgumentsFromData, getFunctionSignature}
 import io.horizen.account.abi.{ABIDecoder, ABIEncodable, ABIListEncoder, MsgProcessorInputDecoder}
 import io.horizen.account.state.events.AddWithdrawalRequest
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.utils.WellKnownAddresses.WITHDRAWAL_REQ_SMART_CONTRACT_ADDRESS
 import io.horizen.account.utils.ZenWeiConverter
 import io.horizen.proposition.MCPublicKeyHashProposition
@@ -35,7 +36,7 @@ object WithdrawalMsgProcessor extends NativeSmartContractMsgProcessor with Withd
   val DustThresholdInWei: BigInteger = ZenWeiConverter.convertZenniesToWei(ZenCoinsUtils.getMinDustThreshold(ZenCoinsUtils.MC_DEFAULT_FEE_RATE))
 
   @throws(classOf[ExecutionFailedException])
-  override def process(invocation: Invocation, view: BaseAccountStateView, context: ExecutionContext): Array[Byte] = {
+  override def process(invocation: Invocation, view: BaseAccountStateView, metadata: MsgProcessorMetadataStorageReader, context: ExecutionContext): Array[Byte] = {
     val gasView = view.getGasTrackedView(invocation.gasPool)
     getFunctionSignature(invocation.input) match {
       case GetListOfWithdrawalReqsCmdSig =>

--- a/sdk/src/main/scala/io/horizen/account/state/nativescdata/forgerstakev2/RewardsReceivedCmdInputDecoder.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/nativescdata/forgerstakev2/RewardsReceivedCmdInputDecoder.scala
@@ -1,0 +1,57 @@
+package io.horizen.account.state.nativescdata.forgerstakev2
+
+import io.horizen.account.abi.{ABIDecoder, ABIEncodable, MsgProcessorInputDecoder}
+import io.horizen.account.state.ForgerPublicKeys
+import io.horizen.proposition.PublicKey25519Proposition
+import org.web3j.abi.TypeReference
+import org.web3j.abi.datatypes.generated.{Bytes1, Bytes32, Uint32}
+import org.web3j.abi.datatypes.{StaticStruct, Type}
+
+import java.util
+
+object RewardsReceivedCmdInputDecoder
+    extends ABIDecoder[RewardsReceivedCmdInput]
+    with MsgProcessorInputDecoder[RewardsReceivedCmdInput]
+    with VRFDecoder {
+
+  override val getListOfABIParamTypes: util.List[TypeReference[Type[_]]] =
+    org.web3j.abi.Utils.convert(
+      util.Arrays.asList(
+        new TypeReference[Bytes32]() {},
+        new TypeReference[Bytes32]() {},
+        new TypeReference[Bytes1]() {},
+        new TypeReference[Uint32]() {},
+        new TypeReference[Uint32]() {},
+      ),
+    )
+
+  override def createType(listOfParams: util.List[Type[_]]): RewardsReceivedCmdInput = {
+    val forgerPublicKey = new PublicKey25519Proposition(listOfParams.get(0).asInstanceOf[Bytes32].getValue)
+    val vrfKey = decodeVrfKey(listOfParams.get(1).asInstanceOf[Bytes32], listOfParams.get(2).asInstanceOf[Bytes1])
+    val forgerPublicKeys = ForgerPublicKeys(forgerPublicKey, vrfKey)
+    val consensusEpochStart = listOfParams.get(3).asInstanceOf[Uint32].getValue.intValueExact()
+    val maxNumOfEpoch = listOfParams.get(4).asInstanceOf[Uint32].getValue.intValueExact()
+    RewardsReceivedCmdInput(forgerPublicKeys, consensusEpochStart, maxNumOfEpoch)
+  }
+
+}
+
+case class RewardsReceivedCmdInput(
+  forgerPublicKeys: ForgerPublicKeys,
+  consensusEpochStart: Int,
+  maxNumOfEpoch: Int,
+) extends ABIEncodable[StaticStruct] {
+
+  override def asABIType(): StaticStruct = {
+    val forgerPublicKeysAbi = forgerPublicKeys.asABIType()
+    val listOfParams: util.List[Type[_]] =
+      new util.ArrayList(forgerPublicKeysAbi.getValue.asInstanceOf[util.List[Type[_]]])
+    listOfParams.add(new Uint32(consensusEpochStart))
+    listOfParams.add(new Uint32(maxNumOfEpoch))
+    new StaticStruct(listOfParams)
+  }
+
+  override def toString: String =
+    "%s(forgerPubKeys: %s)"
+      .format(this.getClass.toString, forgerPublicKeys)
+}

--- a/sdk/src/main/scala/io/horizen/account/state/nativescdata/forgerstakev2/RewardsReceivedCmdInputDecoder.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/nativescdata/forgerstakev2/RewardsReceivedCmdInputDecoder.scala
@@ -51,7 +51,10 @@ case class RewardsReceivedCmdInput(
     new StaticStruct(listOfParams)
   }
 
-  override def toString: String =
-    "%s(forgerPubKeys: %s)"
-      .format(this.getClass.toString, forgerPublicKeys)
+  override def toString: String = {
+    s"RewardsReceivedCmdInput(" +
+      s"forgerPublicKeys: $forgerPublicKeys, " +
+      s"consensusEpochStart: $consensusEpochStart, " +
+      s"maxNumOfEpoch: $maxNumOfEpoch)"
+  }
 }

--- a/sdk/src/main/scala/io/horizen/account/state/nativescdata/forgerstakev2/RewardsReceivedCmdOutput.scala
+++ b/sdk/src/main/scala/io/horizen/account/state/nativescdata/forgerstakev2/RewardsReceivedCmdOutput.scala
@@ -1,0 +1,42 @@
+package io.horizen.account.state.nativescdata.forgerstakev2
+
+import io.horizen.account.abi.{ABIDecoder, ABIEncodable, MsgProcessorInputDecoder}
+import org.web3j.abi.TypeReference
+import org.web3j.abi.datatypes.generated.Uint256
+import org.web3j.abi.datatypes.{DynamicArray, DynamicStruct, Type}
+
+import java.math.BigInteger
+import java.util
+import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters.asScalaBufferConverter
+
+case class RewardsReceivedCmdOutput(listOfRewards: Seq[BigInteger]) extends ABIEncodable[DynamicStruct] {
+
+  override def asABIType(): DynamicStruct = {
+    val seqOfStruct = listOfRewards.map(new Uint256(_))
+    val listOfStruct = JavaConverters.seqAsJavaList(seqOfStruct)
+    val theType = classOf[Uint256]
+    val listOfParams: util.List[Type[_]] = util.Arrays.asList(
+      new DynamicArray(theType, listOfStruct),
+    )
+    new DynamicStruct(listOfParams)
+  }
+
+  override def toString: String =
+    "%s(listOfRewards: %s)"
+      .format(this.getClass.toString, listOfRewards)
+}
+
+object RewardsReceivedCmdOutputDecoder
+    extends ABIDecoder[RewardsReceivedCmdOutput]
+    with MsgProcessorInputDecoder[RewardsReceivedCmdOutput] {
+
+  override val getListOfABIParamTypes: util.List[TypeReference[Type[_]]] = {
+    org.web3j.abi.Utils.convert(util.Arrays.asList(new TypeReference[DynamicArray[Uint256]]() {}))
+  }
+
+  override def createType(listOfParams: util.List[Type[_]]): RewardsReceivedCmdOutput = {
+    val listOfRewards = listOfParams.get(0).asInstanceOf[DynamicArray[Uint256]].getValue
+    RewardsReceivedCmdOutput(listOfRewards.asScala.map(_.getValue))
+  }
+}

--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorage.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorage.scala
@@ -1,6 +1,7 @@
 package io.horizen.account.storage
 
 import io.horizen.account.proposition.AddressProposition
+import io.horizen.account.state.ForgerPublicKeys
 import io.horizen.account.state.receipt.EthereumReceipt
 import io.horizen.account.utils.AccountBlockFeeInfo
 import io.horizen.block.WithdrawalEpochCertificate
@@ -59,4 +60,10 @@ class AccountStateMetadataStorage(storage: Storage)
   override def getForgerBlockCounters: Map[AddressProposition, Long] = getView.getForgerBlockCounters
 
   override def getMcForgerPoolRewards: Map[AddressProposition, BigInteger] = getView.getMcForgerPoolRewards
+
+  override def getForgerRewards(
+    forgerPublicKeys: ForgerPublicKeys,
+    consensusEpochStart: Int,
+    maxNumOfEpochs: Int,
+  ): Seq[BigInteger] = getView.getForgerRewards(forgerPublicKeys, consensusEpochStart, maxNumOfEpochs)
 }

--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorage.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorage.scala
@@ -1,6 +1,5 @@
 package io.horizen.account.storage
 
-import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.state.ForgerPublicKeys
 import io.horizen.account.state.receipt.EthereumReceipt
 import io.horizen.account.utils.{AccountBlockFeeInfo, ForgerIdentifier}

--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorage.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorage.scala
@@ -3,7 +3,7 @@ package io.horizen.account.storage
 import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.state.ForgerPublicKeys
 import io.horizen.account.state.receipt.EthereumReceipt
-import io.horizen.account.utils.AccountBlockFeeInfo
+import io.horizen.account.utils.{AccountBlockFeeInfo, ForgerIdentifier}
 import io.horizen.block.WithdrawalEpochCertificate
 import io.horizen.consensus.ConsensusEpochNumber
 import io.horizen.storage.{SidechainStorageInfo, Storage}
@@ -57,9 +57,9 @@ class AccountStateMetadataStorage(storage: Storage)
 
   override def getTransactionReceipt(txHash: Array[Byte]): Option[EthereumReceipt] = getView.getTransactionReceipt(txHash)
 
-  override def getForgerBlockCounters: Map[AddressProposition, Long] = getView.getForgerBlockCounters
+  override def getForgerBlockCounters: Map[ForgerIdentifier, Long] = getView.getForgerBlockCounters
 
-  override def getMcForgerPoolRewards: Map[AddressProposition, BigInteger] = getView.getMcForgerPoolRewards
+  override def getMcForgerPoolRewards: Map[ForgerIdentifier, BigInteger] = getView.getMcForgerPoolRewards
 
   override def getForgerRewards(
     forgerPublicKeys: ForgerPublicKeys,

--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageReader.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageReader.scala
@@ -1,6 +1,7 @@
 package io.horizen.account.storage
 
 import io.horizen.account.proposition.AddressProposition
+import io.horizen.account.state.ForgerPublicKeys
 import io.horizen.account.state.receipt.EthereumReceipt
 import io.horizen.account.utils.AccountBlockFeeInfo
 import io.horizen.block.WithdrawalEpochCertificate
@@ -38,4 +39,10 @@ trait AccountStateMetadataStorageReader {
   def getForgerBlockCounters: Map[AddressProposition, Long]
 
   def getMcForgerPoolRewards: Map[AddressProposition, BigInteger]
+
+  def getForgerRewards(
+    forgerPublicKeys: ForgerPublicKeys,
+    consensusEpochStart: Int,
+    maxNumOfEpochs: Int,
+  ): Seq[BigInteger]
 }

--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageReader.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageReader.scala
@@ -3,7 +3,7 @@ package io.horizen.account.storage
 import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.state.ForgerPublicKeys
 import io.horizen.account.state.receipt.EthereumReceipt
-import io.horizen.account.utils.AccountBlockFeeInfo
+import io.horizen.account.utils.{AccountBlockFeeInfo, ForgerIdentifier}
 import io.horizen.block.WithdrawalEpochCertificate
 import io.horizen.consensus.ConsensusEpochNumber
 import io.horizen.utils.WithdrawalEpochInfo
@@ -36,9 +36,9 @@ trait AccountStateMetadataStorageReader {
   // zero bytes when storage is empty
   def getAccountStateRoot: Array[Byte] // 32 bytes, kessack hash
 
-  def getForgerBlockCounters: Map[AddressProposition, Long]
+  def getForgerBlockCounters: Map[ForgerIdentifier, Long]
 
-  def getMcForgerPoolRewards: Map[AddressProposition, BigInteger]
+  def getMcForgerPoolRewards: Map[ForgerIdentifier, BigInteger]
 
   def getForgerRewards(
     forgerPublicKeys: ForgerPublicKeys,

--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageReader.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageReader.scala
@@ -1,6 +1,5 @@
 package io.horizen.account.storage
 
-import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.state.ForgerPublicKeys
 import io.horizen.account.state.receipt.EthereumReceipt
 import io.horizen.account.utils.{AccountBlockFeeInfo, ForgerIdentifier}

--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageView.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageView.scala
@@ -1,7 +1,6 @@
 package io.horizen.account.storage
 
 import com.google.common.primitives.{Bytes, Ints}
-import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.state.receipt.{EthereumReceipt, EthereumReceiptSerializer}
 import io.horizen.account.state.{ForgerBlockCountersSerializer, ForgerPublicKeys, McForgerPoolRewardsSerializer}
 import io.horizen.account.storage.AccountStateMetadataStorageView.DEFAULT_ACCOUNT_STATE_ROOT

--- a/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageView.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/AccountStateMetadataStorageView.scala
@@ -2,22 +2,23 @@ package io.horizen.account.storage
 
 import com.google.common.primitives.{Bytes, Ints}
 import io.horizen.account.proposition.AddressProposition
-import io.horizen.account.state.{ForgerBlockCountersSerializer, McForgerPoolRewardsSerializer}
 import io.horizen.account.state.receipt.{EthereumReceipt, EthereumReceiptSerializer}
+import io.horizen.account.state.{ForgerBlockCountersSerializer, ForgerPublicKeys, McForgerPoolRewardsSerializer}
 import io.horizen.account.storage.AccountStateMetadataStorageView.DEFAULT_ACCOUNT_STATE_ROOT
+import io.horizen.account.utils.AccountFeePaymentsUtils.DelegatorFeePayment
 import io.horizen.account.utils.{AccountBlockFeeInfo, AccountBlockFeeInfoSerializer, FeeUtils}
 import io.horizen.block.SidechainBlockBase.GENESIS_BLOCK_PARENT_ID
 import io.horizen.block.{WithdrawalEpochCertificate, WithdrawalEpochCertificateSerializer}
 import io.horizen.consensus.{ConsensusEpochNumber, intToConsensusEpochNumber}
 import io.horizen.storage.Storage
 import io.horizen.utils.{ByteArrayWrapper, WithdrawalEpochInfo, WithdrawalEpochInfoSerializer, Pair => JPair, _}
-import sparkz.core.{VersionTag, bytesToVersion, versionToBytes}
+import sparkz.core.{VersionTag, versionToBytes}
 import sparkz.crypto.hash.Blake2b256
 import sparkz.util.{ModifierId, SparkzLogging, bytesToId, idToBytes}
 
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
-import java.util.{UUID, ArrayList => JArrayList}
+import java.util.{ArrayList => JArrayList}
 import scala.collection.mutable.ListBuffer
 import scala.compat.java8.OptionConverters._
 import scala.util.{Failure, Success, Try}
@@ -50,6 +51,7 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
   private[horizen] var receiptsOpt: Option[Seq[EthereumReceipt]] = None
   //Contains the base fee to be used when forging the next block
   private[horizen] var nextBaseFeeOpt: Option[BigInteger] = None
+  private[horizen] var delegatorPaymentsSeq: Seq[(ByteArrayWrapper, BigInteger)] = Seq.empty
 
   // all getters same as in StateMetadataStorage, but looking first in the cached/dirty entries in memory
 
@@ -277,6 +279,7 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
     accountStateRootOpt = None
     receiptsOpt = None
     nextBaseFeeOpt = None
+    delegatorPaymentsSeq = Seq.empty
   }
 
   private[horizen] def saveToStorage(version: ByteArrayWrapper): Unit = {
@@ -317,7 +320,7 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
 
       updateList.add(new JPair(getBlockFeeInfoKey(epochInfo.epoch, nextBlockFeeInfoCounter),
         new ByteArrayWrapper(AccountBlockFeeInfoSerializer.toBytes(feeInfo))))
-      }
+    }
     )
 
     // Update Consensus related data
@@ -385,6 +388,11 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
     })
 
     nextBaseFeeOpt.foreach(baseFee => updateList.add(new JPair(baseFeeKey, new ByteArrayWrapper(baseFee.toByteArray))))
+
+    delegatorPaymentsSeq.foreach {
+      case (key, value) =>
+        updateList.add(new JPair(key, new ByteArrayWrapper(getForgerReward(key).add(value).toByteArray)))
+    }
 
     storage.update(version, updateList, removeList)
 
@@ -460,9 +468,51 @@ class AccountStateMetadataStorageView(storage: Storage) extends AccountStateMeta
     }
   }
 
+  override def getForgerRewards(
+    forgerPublicKeys: ForgerPublicKeys,
+    consensusEpochStart: Int,
+    maxNumOfEpochs: Int,
+  ): Seq[BigInteger] = {
+    (0 to maxNumOfEpochs).map { epoch =>
+      getForgerReward(getForgerRewardsKey(forgerPublicKeys, consensusEpochStart + epoch))
+    }
+  }
+
+  private def getForgerReward(forgerRewardsKey: ByteArrayWrapper) = {
+    storage.get(forgerRewardsKey).asScala match {
+      case Some(baw) =>
+        Try(new BigInteger(baw.data)) match {
+          case Success(rewards) => rewards
+          case Failure(exception) =>
+            log.error("Error while forger rewards parsing.", exception)
+            BigInteger.ZERO
+        }
+      case _ => BigInteger.ZERO
+    }
+  }
+
+  def updateForgerDelegatorPayments(
+    delegatorPayments: Seq[DelegatorFeePayment],
+    consensusEpochNumber: ConsensusEpochNumber
+  ): Unit = {
+    delegatorPaymentsSeq = delegatorPayments.map { delegatorPayment =>
+      val forgerPublicKey = delegatorPayment.forgerKeys
+      val forgerRewardsKey = getForgerRewardsKey(forgerPublicKey, consensusEpochNumber)
+      (forgerRewardsKey, delegatorPayment.feePayment.value)
+    }
+  }
 
   def resetForgerBlockCounters(): Unit = {
     forgerBlockCountersOpt = Some(Map.empty[AddressProposition, Long])
+  }
+
+  private[horizen] def getForgerRewardsKey(forgerKeys: ForgerPublicKeys, consensusEpochNumber: Int): ByteArrayWrapper = {
+    calculateKey(Bytes.concat(
+      "forgerRewardsKey".getBytes(StandardCharsets.UTF_8),
+      forgerKeys.blockSignPublicKey.bytes(),
+      forgerKeys.vrfPublicKey.bytes(),
+      Ints.toByteArray(consensusEpochNumber)
+    ))
   }
 
   private[horizen] def getTopQualityCertificateKey(referencedWithdrawalEpoch: Int): ByteArrayWrapper = {

--- a/sdk/src/main/scala/io/horizen/account/storage/MsgProcessorMetadataStorageReader.scala
+++ b/sdk/src/main/scala/io/horizen/account/storage/MsgProcessorMetadataStorageReader.scala
@@ -1,0 +1,14 @@
+package io.horizen.account.storage
+
+import io.horizen.account.state.ForgerPublicKeys
+
+import java.math.BigInteger
+
+// minimal reader interface to access metadata storage from native smart contracts
+trait MsgProcessorMetadataStorageReader {
+  def getForgerRewards(
+    forgerPublicKeys: ForgerPublicKeys,
+    consensusEpochStart: Int,
+    maxNumOfEpochs: Int,
+  ): Seq[BigInteger]
+}

--- a/sdk/src/main/scala/io/horizen/account/utils/AccountBlockFeeInfo.scala
+++ b/sdk/src/main/scala/io/horizen/account/utils/AccountBlockFeeInfo.scala
@@ -3,17 +3,23 @@ package io.horizen.account.utils
 import com.fasterxml.jackson.annotation.JsonView
 import io.horizen.account.proposition.{AddressProposition, AddressPropositionSerializer}
 import io.horizen.json.Views
+import io.horizen.proposition.{PublicKey25519Proposition, PublicKey25519PropositionSerializer, VrfPublicKey, VrfPublicKeySerializer}
 import sparkz.core.serialization.{BytesSerializable, SparkzSerializer}
 import sparkz.util.serialization.{Reader, Writer}
 
 import java.math.BigInteger
 
 @JsonView(Array(classOf[Views.Default]))
-case class AccountBlockFeeInfo(baseFee: BigInteger, forgerTips: BigInteger, forgerAddress: AddressProposition) extends BytesSerializable {
+case class AccountBlockFeeInfo(
+  baseFee: BigInteger,
+  forgerTips: BigInteger,
+  forgerAddress: AddressProposition,
+  blockSignPublicKey: Option[PublicKey25519Proposition] = None,
+  vrfPublicKey: Option[VrfPublicKey] = None,
+) extends BytesSerializable {
   override type M = AccountBlockFeeInfo
   override def serializer: SparkzSerializer[AccountBlockFeeInfo] = AccountBlockFeeInfoSerializer
 }
-
 
 object AccountBlockFeeInfoSerializer extends SparkzSerializer[AccountBlockFeeInfo] {
   override def serialize(obj: AccountBlockFeeInfo, w: Writer): Unit = {
@@ -24,6 +30,8 @@ object AccountBlockFeeInfoSerializer extends SparkzSerializer[AccountBlockFeeInf
     w.putInt(forgerTipsByteArray.length)
     w.putBytes(forgerTipsByteArray)
     AddressPropositionSerializer.getSerializer.serialize(obj.forgerAddress, w)
+    obj.blockSignPublicKey.foreach(p => PublicKey25519PropositionSerializer.getSerializer.serialize(p, w))
+    obj.vrfPublicKey.foreach(p => VrfPublicKeySerializer.getSerializer.serialize(p, w))
   }
 
   override def parse(r: Reader): AccountBlockFeeInfo = {
@@ -34,7 +42,12 @@ object AccountBlockFeeInfoSerializer extends SparkzSerializer[AccountBlockFeeInf
     val forgerTips = new BigIntegerUInt256(r.getBytes(forgerTipsLength)).getBigInt
 
     val forgerRewardKey: AddressProposition = AddressPropositionSerializer.getSerializer.parse(r)
-
-    AccountBlockFeeInfo(baseFee, forgerTips, forgerRewardKey)
+    r.remaining match {
+      case 0 => AccountBlockFeeInfo(baseFee, forgerTips, forgerRewardKey)
+      case _ =>
+        val blockSignPublicKey = PublicKey25519PropositionSerializer.getSerializer.parse(r)
+        val vrfPublicKey = VrfPublicKeySerializer.getSerializer.parse(r)
+        AccountBlockFeeInfo(baseFee, forgerTips, forgerRewardKey, Some(blockSignPublicKey), Some(vrfPublicKey))
+    }
   }
 }

--- a/sdk/src/main/scala/io/horizen/account/utils/AccountFeePaymentsUtils.scala
+++ b/sdk/src/main/scala/io/horizen/account/utils/AccountFeePaymentsUtils.scala
@@ -1,7 +1,6 @@
 package io.horizen.account.utils
 
 import io.horizen.account.network.ForgerInfo
-import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.state.{ForgerPublicKeys, ForgerStakeV2MsgProcessor}
 import io.horizen.evm.{StateDB, TrieHasher}
 import io.horizen.params.NetworkParams
@@ -11,9 +10,10 @@ import java.math.BigInteger
 object AccountFeePaymentsUtils {
   val DEFAULT_ACCOUNT_FEE_PAYMENTS_HASH: Array[Byte] = StateDB.EMPTY_ROOT_HASH.toBytes
   val MC_DISTRIBUTION_CAP_DIVIDER: BigInteger = BigInteger.valueOf(10)
+  val TOTAL_SHARE: BigInteger = BigInteger.valueOf(ForgerStakeV2MsgProcessor.MAX_REWARD_SHARE)
 
   def calculateFeePaymentsHash(feePayments: Seq[AccountPayment]): Array[Byte] = {
-    if(feePayments.isEmpty) {
+    if (feePayments.isEmpty) {
       // No fees for the whole epoch, so no fee payments for the Forgers.
       DEFAULT_ACCOUNT_FEE_PAYMENTS_HASH
     } else {
@@ -22,14 +22,18 @@ object AccountFeePaymentsUtils {
     }
   }
 
-  def getForgersRewards(blockFeeInfoSeq : Seq[AccountBlockFeeInfo], mcForgerPoolRewards: Map[AddressProposition, BigInteger] = Map.empty): Seq[AccountPayment] = {
+  def getForgersRewards(
+    blockFeeInfoSeq: Seq[AccountBlockFeeInfo],
+    mcForgerPoolRewards: Map[ForgerIdentifier, BigInteger] = Map.empty,
+  ): Seq[ForgerPayment] = {
     if (blockFeeInfoSeq.isEmpty)
-      return mcForgerPoolRewards.map(reward => AccountPayment(reward._1, reward._2)).toSeq
+      return mcForgerPoolRewards.map(reward => ForgerPayment(reward._1, reward._2)).toSeq
 
     var poolFee: BigInteger = BigInteger.ZERO
-    val forgersBlockRewards: Seq[AccountPayment] = blockFeeInfoSeq.map(feeInfo => {
+    val forgersBlockRewards: Seq[ForgerPayment] = blockFeeInfoSeq.map(feeInfo => {
       poolFee = poolFee.add(feeInfo.baseFee)
-      AccountPayment(feeInfo.forgerAddress, feeInfo.forgerTips)
+      val forgerIdentifier = ForgerIdentifier(feeInfo.forgerAddress, feeInfo.blockSignPublicKey, feeInfo.vrfPublicKey)
+      ForgerPayment(forgerIdentifier, feeInfo.forgerTips)
     })
 
     // Split poolFee in equal parts to be paid to forgers.
@@ -39,49 +43,74 @@ object AccountFeePaymentsUtils {
     val rest: Long = divAndRem(1).longValueExact()
 
     // Calculate final fee for forger considering forger fee, pool fee and the undistributed satoshis
-    val allForgersRewards : Seq[AccountPayment] = forgersBlockRewards.zipWithIndex.map {
-      case (forgerBlockReward: AccountPayment, index: Int) =>
-        val finalForgerFee = forgerBlockReward.value.add(forgerPoolFee).add(if(index < rest) BigInteger.ONE else BigInteger.ZERO)
-        AccountPayment(forgerBlockReward.address, finalForgerFee)
+    val allForgersRewards: Seq[ForgerPayment] = forgersBlockRewards.zipWithIndex.map {
+      case (forgerBlockReward: ForgerPayment, index: Int) =>
+        val finalForgerFee =
+          forgerBlockReward.value.add(forgerPoolFee).add(if (index < rest) BigInteger.ONE else BigInteger.ZERO)
+        ForgerPayment(forgerBlockReward.identifier, finalForgerFee)
     }
 
     // Get all unique forger addresses
-    val forgerKeys = (allForgersRewards.map(_.address) ++ mcForgerPoolRewards.keys).distinct
+    val forgerKeys: Seq[ForgerIdentifier] = (allForgersRewards.map(_.identifier) ++ mcForgerPoolRewards.keys).distinct
 
     // sum all rewards for per forger address
-    forgerKeys.map {
-      forgerKey => {
-        val forgerTotalFee = allForgersRewards
-          .filter(info => forgerKey.equals(info.address))
-          .foldLeft(BigInteger.ZERO)((sum, info) => sum.add(info.value))
-        // add mcForgerPoolReward if exists
-        val mcForgerPoolReward = mcForgerPoolRewards.getOrElse(forgerKey, BigInteger.ZERO)
-        // return the resulting entry
-        AccountPayment(forgerKey, forgerTotalFee.add(mcForgerPoolReward))
-      }
+    forgerKeys.map { forgerKey =>
+      val forgerTotalFee = allForgersRewards
+        .filter(info => forgerKey.equals(info.identifier))
+        .foldLeft(BigInteger.ZERO)((sum, info) => sum.add(info.value))
+      // add mcForgerPoolReward if exists
+      val mcForgerPoolReward = mcForgerPoolRewards.getOrElse(forgerKey, BigInteger.ZERO)
+      // return the resulting entry
+      ForgerPayment(forgerKey, forgerTotalFee.add(mcForgerPoolReward))
     }
   }
 
-  def getForgerAndDelegatorShares(mcForgerPoolRewards: Map[AddressProposition, BigInteger], feePayment: AccountPayment, forgerInfo: ForgerInfo): (AccountPayment, DelegatorFeePayment) = {
+  def getForgerAndDelegatorShares(
+    mcForgerPoolRewards: Map[ForgerIdentifier, BigInteger],
+    feePayment: ForgerPayment,
+    forgerInfo: ForgerInfo,
+  ): (AccountPayment, Option[DelegatorFeePayment]) = {
+    val rewardAddress = feePayment.identifier.address
     val delegatorShare = BigInteger.valueOf(forgerInfo.rewardShare)
-    val totalShare = BigInteger.valueOf(ForgerStakeV2MsgProcessor.MAX_REWARD_SHARE)
-    val totalMcReward = mcForgerPoolRewards.getOrElse(feePayment.address, BigInteger.ZERO)
+    val totalMcReward = mcForgerPoolRewards.getOrElse(feePayment.identifier, BigInteger.ZERO)
 
-    val delegatorReward = feePayment.value.multiply(delegatorShare).divide(totalShare)
-    val delegatorMcReward = totalMcReward.multiply(delegatorShare).divide(totalShare)
+    if (delegatorShare.compareTo(BigInteger.ZERO) == 0) {
+      // No delegator share, all reward goes to the forger
+      val totalFeeReward = feePayment.value.subtract(totalMcReward)
+      val forgerPayment = AccountPayment(rewardAddress, feePayment.value, Some(totalMcReward), Some(totalFeeReward))
+      return (forgerPayment, None)
+    }
+
+    val delegatorReward = feePayment.value.multiply(delegatorShare).divide(TOTAL_SHARE)
+    val delegatorMcReward = totalMcReward.multiply(delegatorShare).divide(TOTAL_SHARE)
     val delegatorFeeReward = delegatorReward.subtract(delegatorMcReward)
 
     val forgerReward = feePayment.value.subtract(delegatorReward)
     val forgerMcReward = totalMcReward.subtract(delegatorMcReward)
     val forgerFeeReward = forgerReward.subtract(forgerMcReward)
 
-    (
-      AccountPayment(feePayment.address, forgerReward, Some(forgerMcReward), Some(forgerFeeReward)),
-      DelegatorFeePayment(
-        AccountPayment(forgerInfo.rewardAddress, delegatorReward, Some(delegatorMcReward), Some(delegatorFeeReward)),
-        forgerInfo.forgerPublicKeys
-      )
+    val forgerPayment = AccountPayment(rewardAddress, forgerReward, Some(forgerMcReward), Some(forgerFeeReward))
+    val delegatorPayment = DelegatorFeePayment(
+      AccountPayment(forgerInfo.rewardAddress, delegatorReward, Some(delegatorMcReward), Some(delegatorFeeReward)),
+      forgerInfo.forgerPublicKeys,
     )
+    (forgerPayment, Some(delegatorPayment))
+  }
+
+  def groupAllPaymentsByAddress(
+    feePayments: Seq[AccountPayment],
+    delegatorPayments: Seq[DelegatorFeePayment],
+  ): Seq[AccountPayment] = {
+    (feePayments ++ delegatorPayments.map(_.feePayment))
+      .groupBy(_.address)
+      .map { case (address, payments) =>
+        AccountPayment(
+          address,
+          payments.map(_.value).foldLeft(BigInteger.ZERO)((a, b) => a.add(b)),
+          Some(payments.map(_.valueFromMainchain).foldLeft(BigInteger.ZERO)((a, b) => a.add(b.getOrElse(BigInteger.ZERO)))),
+          Some(payments.map(_.valueFromFees).foldLeft(BigInteger.ZERO)((a, b) => a.add(b.getOrElse(BigInteger.ZERO)))),
+        )
+      }.toSeq
   }
 
   def getMainchainWithdrawalEpochDistributionCap(epochMaxHeight: Long, params: NetworkParams): BigInteger = {

--- a/sdk/src/main/scala/io/horizen/account/utils/AccountPayment.scala
+++ b/sdk/src/main/scala/io/horizen/account/utils/AccountPayment.scala
@@ -19,13 +19,13 @@ case class AccountPayment(address: AddressProposition,
 }
 
 object AccountPaymentSerializer extends SparkzSerializer[AccountPayment] {
-  final val NEW_SERIALIZATION_FORMAT_FLAG = -1
+  final val SERIALIZATION_FORMAT_1_4_FLAG = -1
 
   override def serialize(obj: AccountPayment, w: Writer): Unit = {
     AddressPropositionSerializer.getSerializer.serialize(obj.address, w)
     // porkaround to support old and new serialization format in parallel
     if (obj.valueFromMainchain.isDefined && obj.valueFromFees.isDefined) {
-      w.putInt(NEW_SERIALIZATION_FORMAT_FLAG) //flag to indicate new serialization format is used
+      w.putInt(SERIALIZATION_FORMAT_1_4_FLAG) //flag to indicate new serialization format is used
       w.putInt(obj.value.toByteArray.length)
       w.putBytes(obj.value.toByteArray)
       w.putInt(obj.valueFromMainchain.get.toByteArray.length)
@@ -41,7 +41,7 @@ object AccountPaymentSerializer extends SparkzSerializer[AccountPayment] {
   override def parse(r: Reader): AccountPayment = {
     val address = AddressPropositionSerializer.getSerializer.parse(r)
     val valueLength = r.getInt
-    if (valueLength == NEW_SERIALIZATION_FORMAT_FLAG) {
+    if (valueLength == SERIALIZATION_FORMAT_1_4_FLAG) {
       val valueLength = r.getInt
       val value = new BigIntegerUInt256(r.getBytes(valueLength)).getBigInt
       val valueFromMainchainLength = r.getInt

--- a/sdk/src/main/scala/io/horizen/account/utils/AccountPayment.scala
+++ b/sdk/src/main/scala/io/horizen/account/utils/AccountPayment.scala
@@ -9,24 +9,50 @@ import sparkz.core.serialization.{BytesSerializable, SparkzSerializer}
 import java.math.BigInteger
 
 @JsonView(Array(classOf[Views.Default]))
-case class AccountPayment(address: AddressProposition, value: BigInteger) extends BytesSerializable {
+case class AccountPayment(address: AddressProposition,
+                          value: BigInteger,
+                          valueFromMainchain: Option[BigInteger] = None,
+                          valueFromFees: Option[BigInteger] = None) extends BytesSerializable {
   override type M = AccountPayment
+
   override def serializer: SparkzSerializer[AccountPayment] = AccountPaymentSerializer
 }
 
 object AccountPaymentSerializer extends SparkzSerializer[AccountPayment] {
+  final val NEW_SERIALIZATION_FORMAT_FLAG = -1
+
   override def serialize(obj: AccountPayment, w: Writer): Unit = {
     AddressPropositionSerializer.getSerializer.serialize(obj.address, w)
-    w.putInt(obj.value.toByteArray.length)
-    w.putBytes(obj.value.toByteArray)
+    // porkaround to support old and new serialization format in parallel
+    if (obj.valueFromMainchain.isDefined && obj.valueFromFees.isDefined) {
+      w.putInt(NEW_SERIALIZATION_FORMAT_FLAG) //flag to indicate new serialization format is used
+      w.putInt(obj.value.toByteArray.length)
+      w.putBytes(obj.value.toByteArray)
+      w.putInt(obj.valueFromMainchain.get.toByteArray.length)
+      w.putBytes(obj.valueFromMainchain.get.toByteArray)
+      w.putInt(obj.valueFromFees.get.toByteArray.length)
+      w.putBytes(obj.valueFromFees.get.toByteArray)
+    } else {
+      w.putInt(obj.value.toByteArray.length)
+      w.putBytes(obj.value.toByteArray)
+    }
   }
 
   override def parse(r: Reader): AccountPayment = {
     val address = AddressPropositionSerializer.getSerializer.parse(r)
     val valueLength = r.getInt
-    val value = new BigIntegerUInt256(r.getBytes(valueLength)).getBigInt
-
-    AccountPayment(address, value)
+    if (valueLength == NEW_SERIALIZATION_FORMAT_FLAG) {
+      val valueLength = r.getInt
+      val value = new BigIntegerUInt256(r.getBytes(valueLength)).getBigInt
+      val valueFromMainchainLength = r.getInt
+      val valueFromMainchain = new BigIntegerUInt256(r.getBytes(valueFromMainchainLength)).getBigInt
+      val valueFromFeesLength = r.getInt
+      val valueFromFees = new BigIntegerUInt256(r.getBytes(valueFromFeesLength)).getBigInt
+      AccountPayment(address, value, Some(valueFromMainchain), Some(valueFromFees))
+    } else {
+      val value = new BigIntegerUInt256(r.getBytes(valueLength)).getBigInt
+      AccountPayment(address, value, None, None)
+    }
   }
 }
 

--- a/sdk/src/main/scala/io/horizen/account/utils/ForgerIdentifier.scala
+++ b/sdk/src/main/scala/io/horizen/account/utils/ForgerIdentifier.scala
@@ -1,0 +1,10 @@
+package io.horizen.account.utils
+
+import io.horizen.account.proposition.AddressProposition
+import io.horizen.proposition.{PublicKey25519Proposition, VrfPublicKey}
+
+case class ForgerIdentifier(
+  address: AddressProposition,
+  blockSignPublicKey: Option[PublicKey25519Proposition] = None,
+  vrfPublicKey: Option[VrfPublicKey] = None,
+)

--- a/sdk/src/main/scala/io/horizen/account/utils/ForgerPayment.scala
+++ b/sdk/src/main/scala/io/horizen/account/utils/ForgerPayment.scala
@@ -1,0 +1,7 @@
+package io.horizen.account.utils
+import java.math.BigInteger
+
+case class ForgerPayment(
+  identifier: ForgerIdentifier,
+  value: BigInteger
+)

--- a/sdk/src/main/scala/io/horizen/account/utils/ForgerPayment.scala
+++ b/sdk/src/main/scala/io/horizen/account/utils/ForgerPayment.scala
@@ -3,5 +3,6 @@ import java.math.BigInteger
 
 case class ForgerPayment(
   identifier: ForgerIdentifier,
-  value: BigInteger
+  value: BigInteger,
+  valueFromMainchain: BigInteger
 )

--- a/sdk/src/test/scala/io/horizen/account/forger/AccountForgeMessageBuilderTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/forger/AccountForgeMessageBuilderTest.scala
@@ -9,6 +9,7 @@ import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.secret.{PrivateKeySecp256k1, PrivateKeySecp256k1Creator}
 import io.horizen.account.state._
 import io.horizen.account.state.receipt.{EthereumReceipt, ReceiptFixture}
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.transaction.EthereumTransaction
 import io.horizen.account.transaction.EthereumTransaction.EthereumTransactionType
 import io.horizen.account.utils.{AccountMockDataHelper, EthereumTransactionEncoder, FeeUtils, WellKnownAddresses, ZenWeiConverter}
@@ -419,6 +420,7 @@ class AccountForgeMessageBuilderTest
         mockMsgProcessor.process(
           ArgumentMatchers.any[Invocation],
           ArgumentMatchers.any[BaseAccountStateView],
+          ArgumentMatchers.any[MsgProcessorMetadataStorageReader],
           ArgumentMatchers.any[ExecutionContext]
         )
       )

--- a/sdk/src/test/scala/io/horizen/account/performance/AccountForgeMessageBuilderPerfTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/performance/AccountForgeMessageBuilderPerfTest.scala
@@ -8,6 +8,7 @@ import io.horizen.account.mempool.AccountMemoryPool
 import io.horizen.account.state._
 import io.horizen.account.state.receipt.EthereumConsensusDataReceipt
 import io.horizen.account.state.receipt.EthereumConsensusDataReceipt.ReceiptStatus
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.utils.ZenWeiConverter
 import io.horizen.account.wallet.AccountWallet
 import io.horizen.block.MainchainBlockReferenceData
@@ -34,7 +35,8 @@ class AccountForgeMessageBuilderPerfTest extends MockitoSugar with EthereumTrans
         ArgumentMatchers.any[SidechainTypes#SCAT],
         ArgumentMatchers.any[Int],
         ArgumentMatchers.any[GasPool],
-        ArgumentMatchers.any[BlockContext]
+        ArgumentMatchers.any[BlockContext],
+        ArgumentMatchers.any[MsgProcessorMetadataStorageReader]
       )
     )
     .thenAnswer(asw => {

--- a/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/AccountStateTest.scala
@@ -5,7 +5,7 @@ import io.horizen.account.fork.GasFeeFork
 import io.horizen.account.fork.GasFeeFork.DefaultGasFeeFork
 import io.horizen.account.storage.{AccountStateMetadataStorage, AccountStateMetadataStorageView}
 import io.horizen.account.transaction.EthereumTransaction
-import io.horizen.account.utils.{AccountBlockFeeInfo, AccountPayment}
+import io.horizen.account.utils.{AccountBlockFeeInfo, AccountPayment, ForgerIdentifier}
 import io.horizen.consensus.{ConsensusEpochNumber, ConsensusParamsUtil, intToConsensusEpochNumber, intToConsensusSlotNumber}
 import io.horizen.evm._
 import io.horizen.fixtures.{SecretFixture, SidechainTypesTestsExtension, StoreFixture}
@@ -202,7 +202,7 @@ class AccountStateTest
 
     Mockito.when(metadataStorage.getFeePayments(ArgumentMatchers.any[Int]()))
       .thenReturn(Seq(blockFeeInfo1, blockFeeInfo2, blockFeeInfo3, blockFeeInfo4))
-    Mockito.when(metadataStorage.getMcForgerPoolRewards).thenAnswer(_ => Map(addr1 -> perBlockFee, addr2 -> perBlockFee, addr3 -> perBlockFee.add(perBlockFee)))
+    Mockito.when(metadataStorage.getMcForgerPoolRewards).thenAnswer(_ => Map(ForgerIdentifier(addr1) -> perBlockFee, ForgerIdentifier(addr2) -> perBlockFee, ForgerIdentifier(addr3) -> perBlockFee.add(perBlockFee)))
 
     val feePayments = state.getFeePaymentsInfo(0, intToConsensusEpochNumber(0))._1
     assertEquals(s"Fee payments size expected to be different.", 3, feePayments.size)

--- a/sdk/src/test/scala/io/horizen/account/state/AccountStateViewTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/AccountStateViewTest.scala
@@ -6,7 +6,7 @@ import io.horizen.account.fork.Version1_2_0Fork
 import io.horizen.account.storage.AccountStateMetadataStorageView
 import io.horizen.account.utils.WellKnownAddresses.FORGER_POOL_RECIPIENT_ADDRESS
 import io.horizen.account.utils.ZenWeiConverter.MAX_MONEY_IN_WEI
-import io.horizen.account.utils.{WellKnownAddresses, ZenWeiConverter}
+import io.horizen.account.utils.{ForgerIdentifier, WellKnownAddresses, ZenWeiConverter}
 import io.horizen.consensus.intToConsensusEpochNumber
 import io.horizen.evm.{Address, StateDB}
 import io.horizen.fixtures.StoreFixture
@@ -166,9 +166,9 @@ class AccountStateViewTest extends JUnitSuite with MockitoSugar with MessageProc
     val addr2 = getPrivateKeySecp256k1(1001).publicImage()
     val addr3 = getPrivateKeySecp256k1(1002).publicImage()
     val blockCounters = Map(
-      addr1 -> 2L,
-      addr2 -> 3L,
-      addr3 -> 5L,
+      ForgerIdentifier(addr1) -> 2L,
+      ForgerIdentifier(addr2) -> 3L,
+      ForgerIdentifier(addr3) -> 5L,
     )
 
     when(stateDb.getBalance(FORGER_POOL_RECIPIENT_ADDRESS)).thenReturn(BigInteger.valueOf(1000L))
@@ -179,9 +179,9 @@ class AccountStateViewTest extends JUnitSuite with MockitoSugar with MessageProc
     when(metadataStorageView.getConsensusEpochNumber).thenAnswer(_ => Some(36))
     val rewardsAfterFork = stateView.getMcForgerPoolRewards(intToConsensusEpochNumber(36), MAX_MONEY_IN_WEI)
     assertEquals(3, rewardsAfterFork.size)
-    assertEquals(BigInteger.valueOf(200L), rewardsAfterFork(addr1))
-    assertEquals(BigInteger.valueOf(300L), rewardsAfterFork(addr2))
-    assertEquals(BigInteger.valueOf(500L), rewardsAfterFork(addr3))
+    assertEquals(BigInteger.valueOf(200L), rewardsAfterFork(ForgerIdentifier(addr1)))
+    assertEquals(BigInteger.valueOf(300L), rewardsAfterFork(ForgerIdentifier(addr2)))
+    assertEquals(BigInteger.valueOf(500L), rewardsAfterFork(ForgerIdentifier(addr3)))
 
   }
 

--- a/sdk/src/test/scala/io/horizen/account/state/CertificateKeyRotationMsgProcessorTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/CertificateKeyRotationMsgProcessorTest.scala
@@ -162,7 +162,7 @@ class CertificateKeyRotationMsgProcessorTest
       data = BytesUtils.fromHexString(SubmitKeyRotationReqCmdSig) ++ encodedInput,
       nonce = randomNonce
     )
-    withGas(TestContext.process(certificateKeyRotationMsgProcessor, msg, view, blockContext, _))
+    withGas(TestContext.process(certificateKeyRotationMsgProcessor, msg, view, blockContext, _, view))
   }
 
   private def processBadKeyRotationMessage(newKey: SchnorrSecret, keyRotationProof: KeyRotationProof, view: AccountStateView, epoch: Int = 0,

--- a/sdk/src/test/scala/io/horizen/account/state/ContractInteropCallTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/ContractInteropCallTest.scala
@@ -4,6 +4,7 @@ import com.google.common.primitives.Bytes
 import io.horizen.account.abi.ABIEncodable
 import io.horizen.account.abi.ABIUtil.{getArgumentsFromData, getFunctionSignature}
 import io.horizen.account.state.ContractInteropTestBase._
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.account.utils.BigIntegerUtil.toUint256Bytes
 import io.horizen.account.utils.{FeeUtils, Secp256k1}
 import io.horizen.evm._
@@ -50,6 +51,7 @@ class ContractInteropCallTest extends ContractInteropTestBase {
     override def process(
                           invocation: Invocation,
                           view: BaseAccountStateView,
+                          metadata: MsgProcessorMetadataStorageReader,
                           context: ExecutionContext
                         ): Array[Byte] = {
       val gasView = view.getGasTrackedView(invocation.gasPool)

--- a/sdk/src/test/scala/io/horizen/account/state/ContractInteropStackTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/ContractInteropStackTest.scala
@@ -1,5 +1,6 @@
 package io.horizen.account.state
 
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.evm.{Address, TraceOptions, Tracer}
 import io.horizen.utils.BytesUtils
 import org.junit.Assert.assertEquals
@@ -40,6 +41,7 @@ class ContractInteropStackTest extends ContractInteropTestBase {
     override def process(
         invocation: Invocation,
         view: BaseAccountStateView,
+        metadata: MsgProcessorMetadataStorageReader,
         context: ExecutionContext
     ): Array[Byte] = {
       // parse input

--- a/sdk/src/test/scala/io/horizen/account/state/ContractInteropTestBase.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/ContractInteropTestBase.scala
@@ -80,7 +80,7 @@ abstract class ContractInteropTestBase extends MessageProcessorFixture {
   }
 
   protected def transition(msg: Message, blckContext: BlockContext = blockContext, gasLimit: BigInteger = gasLimit): Array[Byte] = {
-    val transition = new StateTransition(stateView, processors, new GasPool(gasLimit), blckContext, msg)
+    val transition = new StateTransition(stateView, processors, new GasPool(gasLimit), blckContext, msg, stateView)
     transition.execute(Invocation.fromMessage(msg, new GasPool(gasLimit)))
 
   }

--- a/sdk/src/test/scala/io/horizen/account/state/ContractInteropTransferTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/ContractInteropTransferTest.scala
@@ -1,5 +1,6 @@
 package io.horizen.account.state
 
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
 import io.horizen.evm._
 import io.horizen.utils.BytesUtils
 import org.junit.Assert.assertEquals
@@ -18,6 +19,7 @@ class ContractInteropTransferTest extends ContractInteropTestBase {
     override def process(
         invocation: Invocation,
         view: BaseAccountStateView,
+        metadata: MsgProcessorMetadataStorageReader,
         context: ExecutionContext
     ): Array[Byte] = {
       // accept incoming value transfers

--- a/sdk/src/test/scala/io/horizen/account/state/EoaMessageProcessorTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/EoaMessageProcessorTest.scala
@@ -111,7 +111,7 @@ class EoaMessageProcessorTest extends JUnitSuite with MockitoSugar with SecretFi
       .when(mockStateView.subBalance(ArgumentMatchers.any[Address], ArgumentMatchers.any[BigInteger]))
       .thenThrow(new ExecutionFailedException("something went error"))
     assertThrows[ExecutionFailedException](
-      withGas(TestContext.process(EoaMessageProcessor, msg, mockStateView, defaultBlockContext, _))
+      withGas(TestContext.process(EoaMessageProcessor, msg, mockStateView, defaultBlockContext, _, mockStateView))
     )
 
     // Test 3: Failure during addBalance
@@ -120,7 +120,7 @@ class EoaMessageProcessorTest extends JUnitSuite with MockitoSugar with SecretFi
       .when(mockStateView.addBalance(ArgumentMatchers.any[Address], ArgumentMatchers.any[BigInteger]))
       .thenThrow(new ExecutionFailedException("something went error"))
     assertThrows[ExecutionFailedException](
-      withGas(TestContext.process(EoaMessageProcessor, msg, mockStateView, defaultBlockContext, _))
+      withGas(TestContext.process(EoaMessageProcessor, msg, mockStateView, defaultBlockContext, _, mockStateView))
     )
   }
 }

--- a/sdk/src/test/scala/io/horizen/account/state/EvmMessageProcessorIntegrationTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/EvmMessageProcessorIntegrationTest.scala
@@ -92,7 +92,7 @@ class EvmMessageProcessorIntegrationTest extends EvmMessageProcessorTestBase {
       //Try with a smart contract compiled for Shanghai
       msg = getMessage(null, data = deployCodeShanghai ++ initialValue)
       val ex = intercept[ExecutionFailedException] {
-        withGas(TestContext.process(evmMessageProcessor, msg, stateView, defaultBlockContext, _))
+        withGas(TestContext.process(evmMessageProcessor, msg, stateView, defaultBlockContext, _, stateView))
       }
       assertTrue(ex.getMessage.contains("PUSH0"))
 

--- a/sdk/src/test/scala/io/horizen/account/state/ForgerBlockCountersSerializerTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/ForgerBlockCountersSerializerTest.scala
@@ -1,10 +1,14 @@
 package io.horizen.account.state
 
 import io.horizen.account.fixtures.ForgerAccountFixture.getPrivateKeySecp256k1
-import io.horizen.account.proposition.AddressProposition
+import io.horizen.account.utils.ForgerIdentifier
+import io.horizen.proposition.{PublicKey25519Proposition, VrfPublicKey}
+import io.horizen.secret.PrivateKey25519Creator
+import io.horizen.vrf.VrfGeneratedDataProvider
 import org.junit.Assert.{assertEquals, fail}
 import org.junit.Test
 
+import java.nio.charset.StandardCharsets
 import scala.util.{Failure, Success}
 
 class ForgerBlockCountersSerializerTest {
@@ -15,27 +19,55 @@ class ForgerBlockCountersSerializerTest {
     val addr2 = getPrivateKeySecp256k1(1001).publicImage()
     val addr3 = getPrivateKeySecp256k1(1002).publicImage()
     val forgerBlockCounters = Map(
-      addr1 -> 1L,
-      addr2 -> 100L,
-      addr3 -> 9999999L,
+      ForgerIdentifier(addr1) -> 1L,
+      ForgerIdentifier(addr2) -> 100L,
+      ForgerIdentifier(addr3) -> 9999999L,
     )
 
     val bytes = ForgerBlockCountersSerializer.toBytes(forgerBlockCounters)
 
     ForgerBlockCountersSerializer.parseBytesTry(bytes) match {
-      case Failure(_) => fail("Parsing failed in ForgerBlockCountersSerializer")
+      case Failure(_)     => fail("Parsing failed in ForgerBlockCountersSerializer")
       case Success(value) => assertEquals("Parsed value different from serialized value", value, forgerBlockCounters)
     }
   }
 
   @Test
   def serializationRoundTripTest_Empty(): Unit = {
-    val forgerBlockCounters = Map.empty[AddressProposition, Long]
+    val forgerBlockCounters = Map.empty[ForgerIdentifier, Long]
 
     val bytes = ForgerBlockCountersSerializer.toBytes(forgerBlockCounters)
 
     ForgerBlockCountersSerializer.parseBytesTry(bytes) match {
-      case Failure(_) => fail("Parsing failed in ForgerBlockCountersSerializer")
+      case Failure(_)     => fail("Parsing failed in ForgerBlockCountersSerializer")
+      case Success(value) => assertEquals("Parsed value different from serialized value", value, forgerBlockCounters)
+    }
+  }
+
+  @Test
+  def serializationRoundTripTest_NewFormat(): Unit = {
+    val addr1 = getPrivateKeySecp256k1(1000).publicImage()
+    val proposition1: PublicKey25519Proposition =
+      PrivateKey25519Creator.getInstance().generateSecret("test1".getBytes(StandardCharsets.UTF_8)).publicImage()
+    val vrfPublicKey1: VrfPublicKey = VrfGeneratedDataProvider.getVrfSecretKey(1).publicImage()
+    val addr2 = getPrivateKeySecp256k1(1001).publicImage()
+    val proposition2: PublicKey25519Proposition =
+      PrivateKey25519Creator.getInstance().generateSecret("test2".getBytes(StandardCharsets.UTF_8)).publicImage()
+    val vrfPublicKey2: VrfPublicKey = VrfGeneratedDataProvider.getVrfSecretKey(2).publicImage()
+    val addr3 = getPrivateKeySecp256k1(1002).publicImage()
+    val proposition3: PublicKey25519Proposition =
+      PrivateKey25519Creator.getInstance().generateSecret("test3".getBytes(StandardCharsets.UTF_8)).publicImage()
+    val vrfPublicKey3: VrfPublicKey = VrfGeneratedDataProvider.getVrfSecretKey(3).publicImage()
+    val forgerBlockCounters = Map(
+      ForgerIdentifier(addr1, Some(proposition1), Some(vrfPublicKey1)) -> 1L,
+      ForgerIdentifier(addr2, Some(proposition2), Some(vrfPublicKey2)) -> 100L,
+      ForgerIdentifier(addr3, Some(proposition3), Some(vrfPublicKey3)) -> 9999999L,
+    )
+
+    val bytes = ForgerBlockCountersSerializer.toBytes(forgerBlockCounters)
+
+    ForgerBlockCountersSerializer.parseBytesTry(bytes) match {
+      case Failure(_)     => fail("Parsing failed in ForgerBlockCountersSerializer")
       case Success(value) => assertEquals("Parsed value different from serialized value", value, forgerBlockCounters)
     }
   }

--- a/sdk/src/test/scala/io/horizen/account/state/ForgerStakeV2MsgProcessorTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/ForgerStakeV2MsgProcessorTest.scala
@@ -799,7 +799,7 @@ class ForgerStakeV2MsgProcessorTest
       var updateForgerData_bad = BytesUtils.fromHexString(UpdateForgerCmd) ++ regCmdInput_bad.encode()
       msg = getMessage(contractAddress, BigInteger.ZERO, updateForgerData_bad, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Illegal reward share value"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -856,7 +856,7 @@ class ForgerStakeV2MsgProcessorTest
       updateForgerData_bad = BytesUtils.fromHexString(UpdateForgerCmd) ++ regCmdInput_bad.encode()
       msg = getMessage(contractAddress, BigInteger.ZERO, updateForgerData_bad, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Reward address cannot be the ZERO address"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -876,7 +876,7 @@ class ForgerStakeV2MsgProcessorTest
       updateForgerData_bad = BytesUtils.fromHexString(UpdateForgerCmd) ++ regCmdInput_bad.encode()
       msg = getMessage(contractAddress, BigInteger.ZERO, updateForgerData_bad, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Forger does not exist"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -923,7 +923,7 @@ class ForgerStakeV2MsgProcessorTest
       updateForgerData_bad = BytesUtils.fromHexString(UpdateForgerCmd) ++ regCmdInput_bad.encode()
       msg = getMessage(contractAddress, BigInteger.ZERO, updateForgerData_bad, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Reward share or reward address are not null"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -2159,7 +2159,7 @@ class ForgerStakeV2MsgProcessorTest
       // assert invocation fails until stake v2 is active
       val msg1 = getMessage(contractAddress, BigInteger.ZERO, BytesUtils.fromHexString(StakeStartCmd) ++ Array.emptyByteArray, randomNonce)
       val gas1 = new GasPool(1000000000)
-      assertThrows[ExecutionRevertedException](TestContext.process(forgerStakeV2MessageProcessor, msg1, view, blockContextForkV1_4_plus10, gas1))
+      assertThrows[ExecutionRevertedException](TestContext.process(forgerStakeV2MessageProcessor, msg1, view, blockContextForkV1_4_plus10, gas1, view))
       StakeStorage.setActive(view)
 
       // assert default value -1 is returned if delegation does not exist

--- a/sdk/src/test/scala/io/horizen/account/state/ForgerStakeV2MsgProcessorTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/ForgerStakeV2MsgProcessorTest.scala
@@ -352,7 +352,7 @@ class ForgerStakeV2MsgProcessorTest
 
       msg = getMessage(forgerStakeMessageProcessor.contractAddress, 0, BytesUtils.fromHexString(GetListOfForgersCmdV1), randomNonce)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeMessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeMessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       assertTrue(s"Wrong error message ${exc.getMessage}", exc.getMessage.contains("disabled"))
 
@@ -382,7 +382,7 @@ class ForgerStakeV2MsgProcessorTest
 
       // should fail because input has a trailing byte
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContextForkV1_4, _, view))
       }
       assertTrue(s"Wrong exc message: ${exc.getMessage}, expected:invalid msg data length", exc.getMessage.contains("invalid msg data length"))
       view.commit(bytesToVersion(getVersion.data()))
@@ -538,7 +538,7 @@ class ForgerStakeV2MsgProcessorTest
       // Check that register forger cannot be called before activate
 
       var exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       var expectedErr = "Forger stake V2 has not been activated yet"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -562,7 +562,7 @@ class ForgerStakeV2MsgProcessorTest
       registerForgerData = BytesUtils.fromHexString(RegisterForgerCmd) ++ regCmdInput.encode()
       msg = getMessage(contractAddress, validStakeWeiAmount, registerForgerData, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Invalid signature, could not validate against blockSignerProposition"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -575,7 +575,7 @@ class ForgerStakeV2MsgProcessorTest
       registerForgerData = BytesUtils.fromHexString(RegisterForgerCmd) ++ regCmdInput.encode()
       msg = getMessage(contractAddress, validStakeWeiAmount, registerForgerData, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Invalid signature, could not validate against vrfKey"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -587,7 +587,7 @@ class ForgerStakeV2MsgProcessorTest
       registerForgerData = BytesUtils.fromHexString(RegisterForgerCmd) ++ regCmdInput.encode()
       msg = getMessage(contractAddress, validWeiAmount, registerForgerData, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "is below the minimum stake amount threshold"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -599,7 +599,7 @@ class ForgerStakeV2MsgProcessorTest
       registerForgerData = BytesUtils.fromHexString(RegisterForgerCmd) ++ regCmdInput.encode()
       msg = getMessage(contractAddress, validStakeWeiAmount.add(BigInteger.ONE), registerForgerData, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "is not a legal wei amount"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -638,7 +638,7 @@ class ForgerStakeV2MsgProcessorTest
       // -------------------------------------------------------------------------------
       // Try register the same forger twice. It should fail.
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Can not register an already existing forger"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -651,7 +651,7 @@ class ForgerStakeV2MsgProcessorTest
       registerForgerData = BytesUtils.fromHexString(RegisterForgerCmd) ++ regCmdInput.encode()
       msg = getMessage(contractAddress, validStakeWeiAmount, registerForgerData, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Reward share cannot be different from 0 if reward address is not defined"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -665,7 +665,7 @@ class ForgerStakeV2MsgProcessorTest
       registerForgerData = BytesUtils.fromHexString(RegisterForgerCmd) ++ regCmdInput.encode()
       msg = getMessage(contractAddress, validStakeWeiAmount, registerForgerData, randomNonce, from = senderAddress)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Reward share cannot be 0 if reward address is defined"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -697,7 +697,7 @@ class ForgerStakeV2MsgProcessorTest
       registerForgerData = BytesUtils.fromHexString(RegisterForgerCmd) ++ regCmdInput.encode()
       msg = getMessage(contractAddress, validStakeWeiAmount, registerForgerData, randomNonce, from = origin)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Not enough balance"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -780,7 +780,7 @@ class ForgerStakeV2MsgProcessorTest
       // Check that delegate and withdraw cannot be called before activate
 
       var exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       var expectedErr = "Forger stake V2 has not been activated yet"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -792,7 +792,7 @@ class ForgerStakeV2MsgProcessorTest
 
       msg = getMessage(contractAddress, BigInteger.ZERO, BytesUtils.fromHexString(WithdrawCmd) ++ withdrawCmdInput.encode(), randomNonce)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       assertTrue(exc.getMessage.contains("Forger stake V2 has not been activated yet"))
 
@@ -813,7 +813,7 @@ class ForgerStakeV2MsgProcessorTest
       // Try delegate to a non-existing forger. It should fail.
       msg = getMessage(contractAddress, validWeiAmount, delegateData, randomNonce)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Forger doesn't exist."
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -1023,7 +1023,7 @@ class ForgerStakeV2MsgProcessorTest
       // should fail because input has a trailing byte
       blockContext = getBlockContextForEpoch(blockContext.consensusEpochNumber + 10)
       val ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContext, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Wrong message data field length"))
 
@@ -1317,7 +1317,7 @@ class ForgerStakeV2MsgProcessorTest
       // assert invocation fails until stake v2 is active
       val msg1 = getMessage(contractAddress, BigInteger.ZERO, BytesUtils.fromHexString(StakeTotalCmd) ++ Array.emptyByteArray, randomNonce)
       val gas = new GasPool(1000000000)
-      assertThrows[ExecutionRevertedException](TestContext.process(forgerStakeV2MessageProcessor, msg1, view, blockContextForkV1_4_plus10, gas))
+      assertThrows[ExecutionRevertedException](TestContext.process(forgerStakeV2MessageProcessor, msg1, view, blockContextForkV1_4_plus10, gas, view))
 
       val BI_0 = BigInteger.ZERO
       val BI_20 = BigInteger.valueOf(20 * ZenCoinsUtils.COIN)
@@ -1392,7 +1392,7 @@ class ForgerStakeV2MsgProcessorTest
       stakeTotalCmdInput = StakeTotalCmdInput(None, Some(address4), None, None)
       data= stakeTotalCmdInput.encode()
       msg = getMessage(contractAddress, BigInteger.ZERO, BytesUtils.fromHexString(StakeTotalCmd) ++ data, randomNonce)
-      assertThrows[ExecutionRevertedException](TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4_plus10, gas))
+      assertThrows[ExecutionRevertedException](TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4_plus10, gas, view))
     }
   }
 
@@ -1411,14 +1411,15 @@ class ForgerStakeV2MsgProcessorTest
       // test getRewardsReceived fails until ForgerStakeV2 is active
       val msg1 = getMessage(contractAddress, BigInteger.ZERO, BytesUtils.fromHexString(RewardsReceivedCmd) ++ Array.emptyByteArray, randomNonce)
       val gas = new GasPool(1000000000)
-      assertThrows[ExecutionRevertedException](TestContext.process(forgerStakeV2MessageProcessor, msg1, view, blockContextForkV1_4_plus10, gas))
+      assertThrows[ExecutionRevertedException](TestContext.process(forgerStakeV2MessageProcessor, msg1, view, blockContextForkV1_4_plus10, gas, view))
 
       StakeStorage.setActive(view)
+      StakeStorage.addForger(view, blockSignerProposition1, vrfPublicKey1, 100, Address.ZERO, V1_4_MOCK_FORK_POINT + 3, Address.ZERO, BigInteger.ZERO)
 
       // test getRewardsReceived
       val rewardsReceivedCmdInput = RewardsReceivedCmdInput(ForgerPublicKeys(blockSignerProposition1, vrfPublicKey1), 10, 5)
       val msg = getMessage(contractAddress, BigInteger.ZERO, BytesUtils.fromHexString(RewardsReceivedCmd) ++ rewardsReceivedCmdInput.encode(), randomNonce)
-      val returnData = assertGas(2100, msg, view, forgerStakeV2MessageProcessor, blockContextForkV1_4_plus10)
+      val returnData = assertGas(10600, msg, view, forgerStakeV2MessageProcessor, blockContextForkV1_4_plus10)
       assertNotNull(returnData)
       val rewardsReceivedOutput = RewardsReceivedCmdOutputDecoder.decode(returnData)
       assertEquals(
@@ -1482,7 +1483,7 @@ class ForgerStakeV2MsgProcessorTest
 
       // Try getForger after fork 1.4 but before activate
      exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
 
       expectedErr = "Forger stake V2 has not been activated yet"
@@ -1505,7 +1506,7 @@ class ForgerStakeV2MsgProcessorTest
 
       // Try getPagedForgers after fork 1.4 but before activate
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
 
       expectedErr = "Forger stake V2 has not been activated yet"
@@ -1529,7 +1530,7 @@ class ForgerStakeV2MsgProcessorTest
       // Try getForger for a non-existing forger. It should fail.
       msg = getMessage(contractAddress, BigInteger.ZERO,  getForgerData, randomNonce)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Forger doesn't exist."
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -1613,7 +1614,7 @@ class ForgerStakeV2MsgProcessorTest
         )
         val msg = getMessage(
           contractAddress, 0, BytesUtils.fromHexString(GetPagedForgersCmd) ++ cmdInput.encode(), randomNonce)
-        val returnData = withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        val returnData = withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
         //Check getPagedForgers
         val res = PagedForgersOutputDecoder.decode(returnData)
         assertEquals(currentPage, res.listOfForgerInfo)
@@ -1644,7 +1645,7 @@ class ForgerStakeV2MsgProcessorTest
       // Check that it is not payable
       msg = getMessage(contractAddress, validWeiAmount, getForgerData, randomNonce)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Call value must be zero"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -1652,7 +1653,7 @@ class ForgerStakeV2MsgProcessorTest
 
       msg = getMessage(contractAddress, validWeiAmount, getPagedForgersData, randomNonce)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Call value must be zero"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -1664,7 +1665,7 @@ class ForgerStakeV2MsgProcessorTest
 
       // should fail because input has a trailing byte
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Wrong message data field length"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -1674,7 +1675,7 @@ class ForgerStakeV2MsgProcessorTest
 
       // should fail because input has a trailing byte
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContextForkV1_4, _, view))
       }
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
 
@@ -1780,7 +1781,7 @@ class ForgerStakeV2MsgProcessorTest
 
       // Try getForger after fork 1.4 but before activate
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
 
       expectedErr = "Forger stake V2 has not been activated yet"
@@ -1818,7 +1819,7 @@ class ForgerStakeV2MsgProcessorTest
       // Check that it is not payable
       msg = getMessage(contractAddress, validWeiAmount, getCurrentConsensusEpochData, randomNonce)
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msg, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "Call value must be zero"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -1829,7 +1830,7 @@ class ForgerStakeV2MsgProcessorTest
 
       // should fail because input has a trailing byte
       exc = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContextForkV1_4, _))
+        withGas(TestContext.process(forgerStakeV2MessageProcessor, msgBad, view, blockContextForkV1_4, _, view))
       }
       expectedErr = "invalid msg data length"
       assertTrue(s"Wrong error message, expected $expectedErr, got: ${exc.getMessage}", exc.getMessage.contains(expectedErr))
@@ -1930,7 +1931,7 @@ class ForgerStakeV2MsgProcessorTest
       listOfForgerStakes = listOfForgerStakes :+ AccountForgingStakeInfo(expStakeId,
         ForgerStakeData(ForgerPublicKeys(blockSignerProposition, vrfPublicKey),
           ownerAddressProposition1, stakeAmount))
-      val returnData = withGas(TestContext.process(forgerStakeMessageProcessor, msg, view, blockContext, _))
+      val returnData = withGas(TestContext.process(forgerStakeMessageProcessor, msg, view, blockContext, _, view))
       assertNotNull(returnData)
       totalAmount = totalAmount.add(stakeAmount)
     }

--- a/sdk/src/test/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorMultisigTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorMultisigTest.scala
@@ -249,7 +249,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
       val txHash2 = Keccak256.hash("second tx")
       view.setupTxContext(txHash2, 10)
       // try processing a msg with the same data (same msg), should fail
-      assertThrows[ExecutionRevertedException](withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _)))
+      assertThrows[ExecutionRevertedException](withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view)))
 
       // Checking that log doesn't change
       listOfLogs = view.getLogs(txHash2)
@@ -480,7 +480,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       var ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Could not verify multisig address against redeemScript"))
 
@@ -495,7 +495,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Could not verify multisig address against redeemScript"))
 
@@ -511,7 +511,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Could not verify multisig address against redeemScript"))
 
@@ -526,7 +526,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Signature 0 not valid"))
 
@@ -542,7 +542,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Signatures are not enough. Input has 1, needs at least 2"))
 
@@ -559,7 +559,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Signature 1 not valid"))
 
@@ -576,7 +576,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       // in this case we are giving up checking signatures because after the first fails we can not
       // reach the threshold with the second one even if it is valid
@@ -600,7 +600,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Unexpected format of redeemScript"))
 
@@ -620,7 +620,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       // in this case we are giving up checking signatures after we have an invalid one
       assertTrue(ex.getMessage.contains("Signature 1 not valid"))
@@ -654,7 +654,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         listOfAllExpectedData.add(McAddrOwnershipData(scAddrStr1.toLowerCase(), mcAddr))
         listOfScAddress1ExpectedData.add(McAddrOwnershipData(scAddrStr1.toLowerCase(), mcAddr))
 
-        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view))
         assertNotNull(returnData)
       }
 
@@ -674,7 +674,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         listOfAllExpectedData.add(McAddrOwnershipData(scAddrStr2.toLowerCase(), mcAddr))
         listOfScAddress2ExpectedData.add(McAddrOwnershipData(scAddrStr2.toLowerCase(), mcAddr))
 
-        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view))
         assertNotNull(returnData)
       }
 
@@ -735,7 +735,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
 
         listOfExpectedData.add(McAddrOwnershipData(scAddrStr1, mcAddr))
 
-        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view))
         assertNotNull(returnData)
       }
 
@@ -801,7 +801,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         randomNonce, scAddressObj1
       )
       var ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Value must be zero"))
 
@@ -815,7 +815,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1)
 
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Wrong message data field length"))
 
@@ -828,7 +828,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1)
 
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("already associated"))
 
@@ -841,7 +841,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         randomNonce,
         origin)
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Invalid mc signature"))
 
@@ -856,7 +856,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         randomNonce,
         scAddressObj1)
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Invalid mc signature"))
 
@@ -871,7 +871,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         randomNonce,
         scAddressObj1)
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Invalid mc signature"))
 
@@ -900,7 +900,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
       )
 
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msg2, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msg2, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains(s"already associated to sc address ${scAddrStr1.toLowerCase()}"))
     }
@@ -939,7 +939,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         randomNonce, scAddressObj1
       )
       var ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Value must be zero"))
 
@@ -949,7 +949,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         randomNonce, scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Value must be zero"))
 
@@ -960,7 +960,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         randomNonce, scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Wrong message data field length"))
 
@@ -970,7 +970,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         randomNonce, origin
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("account does not exist"))
 
@@ -981,7 +981,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         randomNonce, origin
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("is not the owner"))
 
@@ -1063,7 +1063,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
     )
 
     // try processing the removal of ownership, should succeed
-    val returnData = withGas(TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, _))
+    val returnData = withGas(TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, _, stateView))
     assertNotNull(returnData)
     assertArrayEquals(getOwnershipId(mcTransparentAddress), returnData)
   }
@@ -1072,7 +1072,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
     val msg = getMessage(contractAddress, 0, BytesUtils.fromHexString(GetListOfAllOwnershipsCmd), randomNonce)
 
     val (returnData, usedGas) = withGas { gas =>
-      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas)
+      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas, stateView)
       (result, gas.getUsedGas)
     }
     // gas consumption depends on the number of items in the list
@@ -1091,7 +1091,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
       contractAddress, 0,
       BytesUtils.fromHexString(GetListOfOwnershipsCmd) ++ data, randomNonce)
     val (returnData, usedGas) = withGas { gas =>
-      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas)
+      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas, stateView)
       (result, gas.getUsedGas)
     }
     // gas consumption depends on the number of items in the list
@@ -1134,7 +1134,7 @@ class McAddrOwnershipMsgProcessorMultisigTest
         scAddressObj1
       )
       val ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       // the signature has been applied on a different message
       assertTrue(ex.getMessage.contains("Invalid mc signature"))

--- a/sdk/src/test/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/McAddrOwnershipMsgProcessorTest.scala
@@ -322,7 +322,7 @@ class McAddrOwnershipMsgProcessorTest
       val txHash2 = Keccak256.hash("second tx")
       view.setupTxContext(txHash2, 10)
       // try processing a msg with the same data (same msg), should fail
-      assertThrows[ExecutionRevertedException](withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _)))
+      assertThrows[ExecutionRevertedException](withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view)))
 
       // Checking that log doesn't change
       listOfLogs = view.getLogs(txHash2)
@@ -482,7 +482,7 @@ class McAddrOwnershipMsgProcessorTest
         listOfAllExpectedData.add(McAddrOwnershipData(scAddrStr1.toLowerCase(), mcAddr))
         listOfScAddress1ExpectedData.add(McAddrOwnershipData(scAddrStr1.toLowerCase(), mcAddr))
 
-        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view))
         assertNotNull(returnData)
       }
 
@@ -502,7 +502,7 @@ class McAddrOwnershipMsgProcessorTest
         listOfAllExpectedData.add(McAddrOwnershipData(scAddrStr2.toLowerCase(), mcAddr))
         listOfScAddress2ExpectedData.add(McAddrOwnershipData(scAddrStr2.toLowerCase(), mcAddr))
 
-        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view))
         assertNotNull(returnData)
       }
 
@@ -573,7 +573,7 @@ class McAddrOwnershipMsgProcessorTest
 
         listOfExpectedData.add(McAddrOwnershipData(scAddrStr1, mcAddr))
 
-        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view))
         assertNotNull(returnData)
       }
 
@@ -639,7 +639,7 @@ class McAddrOwnershipMsgProcessorTest
         randomNonce, scAddressObj1
       )
       var ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Value must be zero"))
 
@@ -653,7 +653,7 @@ class McAddrOwnershipMsgProcessorTest
         scAddressObj1)
 
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Wrong message data field length"))
 
@@ -666,7 +666,7 @@ class McAddrOwnershipMsgProcessorTest
         scAddressObj1)
 
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("already associated"))
 
@@ -679,7 +679,7 @@ class McAddrOwnershipMsgProcessorTest
         randomNonce,
         origin)
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Invalid mc signature"))
 
@@ -694,7 +694,7 @@ class McAddrOwnershipMsgProcessorTest
         randomNonce,
         scAddressObj1)
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Invalid mc signature"))
 
@@ -709,7 +709,7 @@ class McAddrOwnershipMsgProcessorTest
         randomNonce,
         scAddressObj1)
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Invalid mc signature"))
 
@@ -738,7 +738,7 @@ class McAddrOwnershipMsgProcessorTest
       )
 
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msg2, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msg2, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains(s"already associated to sc address ${scAddrStr1.toLowerCase()}"))
     }
@@ -777,7 +777,7 @@ class McAddrOwnershipMsgProcessorTest
         randomNonce, scAddressObj1
       )
       var ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Value must be zero"))
 
@@ -787,7 +787,7 @@ class McAddrOwnershipMsgProcessorTest
         randomNonce, scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Value must be zero"))
 
@@ -798,7 +798,7 @@ class McAddrOwnershipMsgProcessorTest
         randomNonce, scAddressObj1
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("Wrong message data field length"))
 
@@ -808,7 +808,7 @@ class McAddrOwnershipMsgProcessorTest
         randomNonce, origin
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       assertTrue(ex.getMessage.contains("account does not exist"))
 
@@ -819,7 +819,7 @@ class McAddrOwnershipMsgProcessorTest
         randomNonce, origin
       )
       ex = intercept[ExecutionRevertedException] {
-        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _))
+        withGas(TestContext.process(messageProcessor, msgBad, view, defaultBlockContext, _, view))
       }
       val ownershipIdStr = BytesUtils.toHexString(getOwnershipId(mcAddrStr1))
       assertTrue(ex.getMessage.contains("is not the owner"))
@@ -902,7 +902,7 @@ class McAddrOwnershipMsgProcessorTest
     )
 
     // try processing the removal of ownership, should succeed
-    val returnData = withGas(TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, _))
+    val returnData = withGas(TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, _, stateView))
     assertNotNull(returnData)
     assertArrayEquals(getOwnershipId(mcTransparentAddress), returnData)
   }
@@ -911,7 +911,7 @@ class McAddrOwnershipMsgProcessorTest
     val msg = getMessage(contractAddress, 0, BytesUtils.fromHexString(GetListOfAllOwnershipsCmd), randomNonce)
 
     val (returnData, usedGas) = withGas { gas =>
-      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas)
+      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas, stateView)
       (result, gas.getUsedGas)
     }
     // gas consumption depends on the number of items in the list
@@ -930,7 +930,7 @@ class McAddrOwnershipMsgProcessorTest
       contractAddress, 0,
       BytesUtils.fromHexString(GetListOfOwnershipsCmd) ++ data, randomNonce)
     val (returnData, usedGas) = withGas { gas =>
-      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas)
+      val result = TestContext.process(messageProcessor, msg, stateView, defaultBlockContext, gas, stateView)
       (result, gas.getUsedGas)
     }
     // gas consumption depends on the number of items in the list
@@ -969,7 +969,7 @@ class McAddrOwnershipMsgProcessorTest
 
       listOfExpectedData.add(McAddrOwnershipData(scAddrStr1, mcAddr))
 
-      val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+      val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view))
       assertNotNull(returnData)
 
 
@@ -991,7 +991,7 @@ class McAddrOwnershipMsgProcessorTest
         scAddressObj1
       )
 
-      val returnData2 = withGas(TestContext.process(messageProcessor, msg2, view, defaultBlockContext, _))
+      val returnData2 = withGas(TestContext.process(messageProcessor, msg2, view, defaultBlockContext, _, view))
       assertNotNull(returnData2)
       println("This is the returned value: " + BytesUtils.toHexString(returnData2))
 
@@ -1027,7 +1027,7 @@ class McAddrOwnershipMsgProcessorTest
 
         listOfScAddress2ExpectedData.add(McAddrOwnershipData(scAddrStr2.toLowerCase(), mcAddr))
 
-        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view))
         assertNotNull(returnData)
       }
 
@@ -1045,7 +1045,7 @@ class McAddrOwnershipMsgProcessorTest
 
         listOfExpectedData.add(McAddrOwnershipData(scAddrStr1, mcAddr))
 
-        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _))
+        val returnData = withGas(TestContext.process(messageProcessor, msg, view, defaultBlockContext, _, view))
         assertNotNull(returnData)
       }
 

--- a/sdk/src/test/scala/io/horizen/account/state/McForgerPoolRewardsSerializerTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/McForgerPoolRewardsSerializerTest.scala
@@ -1,11 +1,15 @@
 package io.horizen.account.state
 
 import io.horizen.account.fixtures.ForgerAccountFixture.getPrivateKeySecp256k1
-import io.horizen.account.proposition.AddressProposition
+import io.horizen.account.utils.ForgerIdentifier
+import io.horizen.proposition.{PublicKey25519Proposition, VrfPublicKey}
+import io.horizen.secret.PrivateKey25519Creator
+import io.horizen.vrf.VrfGeneratedDataProvider
 import org.junit.Assert.{assertEquals, fail}
 import org.junit.Test
 
 import java.math.BigInteger
+import java.nio.charset.StandardCharsets
 import scala.util.{Failure, Success}
 
 class McForgerPoolRewardsSerializerTest {
@@ -16,27 +20,55 @@ class McForgerPoolRewardsSerializerTest {
     val addr2 = getPrivateKeySecp256k1(1001).publicImage()
     val addr3 = getPrivateKeySecp256k1(1002).publicImage()
     val forgerBlockRewards = Map(
-      addr1 -> BigInteger.valueOf(1L),
-      addr2 -> BigInteger.valueOf(100L),
-      addr3 -> BigInteger.valueOf(9999999L),
+      ForgerIdentifier(addr1) -> BigInteger.valueOf(1L),
+      ForgerIdentifier(addr2) -> BigInteger.valueOf(100L),
+      ForgerIdentifier(addr3) -> BigInteger.valueOf(9999999L),
     )
 
     val bytes = McForgerPoolRewardsSerializer.toBytes(forgerBlockRewards)
 
     McForgerPoolRewardsSerializer.parseBytesTry(bytes) match {
-      case Failure(_) => fail("Parsing failed in McForgerPoolRewardsSerializer")
+      case Failure(_)     => fail("Parsing failed in McForgerPoolRewardsSerializer")
       case Success(value) => assertEquals("Parsed value different from serialized value", value, forgerBlockRewards)
     }
   }
 
   @Test
   def serializationRoundTripTest_Empty(): Unit = {
-    val forgerBlockRewards = Map.empty[AddressProposition, BigInteger]
+    val forgerBlockRewards = Map.empty[ForgerIdentifier, BigInteger]
 
     val bytes = McForgerPoolRewardsSerializer.toBytes(forgerBlockRewards)
 
     McForgerPoolRewardsSerializer.parseBytesTry(bytes) match {
-      case Failure(_) => fail("Parsing failed in McForgerPoolRewardsSerializer")
+      case Failure(_)     => fail("Parsing failed in McForgerPoolRewardsSerializer")
+      case Success(value) => assertEquals("Parsed value different from serialized value", value, forgerBlockRewards)
+    }
+  }
+
+  @Test
+  def serializationRoundTripTest_NewFormat(): Unit = {
+    val addr1 = getPrivateKeySecp256k1(1000).publicImage()
+    val proposition1: PublicKey25519Proposition =
+      PrivateKey25519Creator.getInstance().generateSecret("test1".getBytes(StandardCharsets.UTF_8)).publicImage()
+    val vrfPublicKey1: VrfPublicKey = VrfGeneratedDataProvider.getVrfSecretKey(1).publicImage()
+    val addr2 = getPrivateKeySecp256k1(1001).publicImage()
+    val proposition2: PublicKey25519Proposition =
+      PrivateKey25519Creator.getInstance().generateSecret("test2".getBytes(StandardCharsets.UTF_8)).publicImage()
+    val vrfPublicKey2: VrfPublicKey = VrfGeneratedDataProvider.getVrfSecretKey(2).publicImage()
+    val addr3 = getPrivateKeySecp256k1(1002).publicImage()
+    val proposition3: PublicKey25519Proposition =
+      PrivateKey25519Creator.getInstance().generateSecret("test3".getBytes(StandardCharsets.UTF_8)).publicImage()
+    val vrfPublicKey3: VrfPublicKey = VrfGeneratedDataProvider.getVrfSecretKey(3).publicImage()
+    val forgerBlockRewards = Map(
+      ForgerIdentifier(addr1, Some(proposition1), Some(vrfPublicKey1)) -> BigInteger.valueOf(1L),
+      ForgerIdentifier(addr2, Some(proposition2), Some(vrfPublicKey2)) -> BigInteger.valueOf(100L),
+      ForgerIdentifier(addr3, Some(proposition3), Some(vrfPublicKey3)) -> BigInteger.valueOf(9999999L),
+    )
+
+    val bytes = McForgerPoolRewardsSerializer.toBytes(forgerBlockRewards)
+
+    McForgerPoolRewardsSerializer.parseBytesTry(bytes) match {
+      case Failure(_)     => fail("Parsing failed in McForgerPoolRewardsSerializer")
       case Success(value) => assertEquals("Parsed value different from serialized value", value, forgerBlockRewards)
     }
   }

--- a/sdk/src/test/scala/io/horizen/account/state/MessageProcessorFixture.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/MessageProcessorFixture.scala
@@ -85,7 +85,7 @@ trait MessageProcessorFixture extends AccountFixture with ClosableResourceHandle
   ): Array[Byte] = {
     view.setupAccessList(msg, ctx.forgerAddress, new ForkRules(true))
     val gas = new GasPool(1000000000)
-    val result = Try.apply(TestContext.process(processor, msg, view, ctx, gas))
+    val result = Try.apply(TestContext.process(processor, msg, view, ctx, gas, view))
     if (expectedGas != gas.getUsedGas){
       val msg = s"Unexpected gas consumption. Expected $expectedGas, actual: ${gas.getUsedGas}"
       Console.err.println(msg)
@@ -109,7 +109,7 @@ trait MessageProcessorFixture extends AccountFixture with ClosableResourceHandle
                ): Array[Byte] = {
     view.setupAccessList(msg, ctx.forgerAddress, new ForkRules(true))
     val gas = new GasPool(1000000000)
-    val transition = new StateTransition(view, processors, gas, ctx, msg)
+    val transition = new StateTransition(view, processors, gas, ctx, msg, view)
     val result = Try.apply(transition.execute(Invocation.fromMessage(msg, gas)))
     assertEquals("Unexpected gas consumption", expectedGas, gas.getUsedGas)
     // return result or rethrow any exception

--- a/sdk/src/test/scala/io/horizen/account/state/TestContext.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/TestContext.scala
@@ -1,5 +1,7 @@
 package io.horizen.account.state
 
+import io.horizen.account.storage.MsgProcessorMetadataStorageReader
+
 case class TestContext(msg: Message, blockContext: BlockContext) extends ExecutionContext {
   override var depth = 0
   override def execute(invocation: Invocation): Array[Byte] = ???
@@ -22,8 +24,9 @@ object TestContext {
       msg: Message,
       view: BaseAccountStateView,
       blockContext: BlockContext,
-      gasPool: GasPool
+      gasPool: GasPool,
+      metadata: MsgProcessorMetadataStorageReader
   ): Array[Byte] = {
-    processor.process(Invocation.fromMessage(msg, gasPool), view, TestContext(msg, blockContext))
+    processor.process(Invocation.fromMessage(msg, gasPool), view, metadata, TestContext(msg, blockContext))
   }
 }

--- a/sdk/src/test/scala/io/horizen/account/state/WithdrawalMsgProcessorTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/state/WithdrawalMsgProcessorTest.scala
@@ -107,7 +107,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
     val msgWithWrongFunctionCall = getMessage(WithdrawalMsgProcessor.contractAddress, value, data)
     assertThrows[ExecutionRevertedException] {
       withGas(
-        TestContext.process(WithdrawalMsgProcessor, msgWithWrongFunctionCall, mockStateView, defaultBlockContext, _)
+        TestContext.process(WithdrawalMsgProcessor, msgWithWrongFunctionCall, mockStateView, defaultBlockContext, _, mockStateView)
       )
     }
   }
@@ -157,7 +157,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
     val withdrawalAmount = ZenWeiConverter.convertZenniesToWei(50)
     val msg = getMessage(WithdrawalMsgProcessor.contractAddress, withdrawalAmount, Array.emptyByteArray)
     assertThrows[ExecutionRevertedException](
-      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _))
+      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _, mockStateView))
     )
 
     // helper: mock balance call and assert that the withdrawal request throws
@@ -165,7 +165,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
       val msg = addWithdrawalRequestMessage(withdrawalAmount)
       Mockito.when(mockStateView.getBalance(msg.getFrom)).thenReturn(balance)
       assertThrows[ExecutionRevertedException](
-        withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, blockContext, _))
+        withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, blockContext, _, mockStateView))
       )
     }
 
@@ -211,7 +211,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
 
     // Withdrawal request list with invalid data should throw ExecutionRevertedException
     assertThrows[ExecutionRevertedException](
-      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _))
+      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _, mockStateView))
     )
 
     // No withdrawal requests
@@ -223,7 +223,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
       .when(mockStateView.getAccountStorage(WithdrawalMsgProcessor.contractAddress, counterKey))
       .thenReturn(numOfWithdrawalReqs)
 
-    var returnData = withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _))
+    var returnData = withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _, mockStateView))
     val expectedListOfWR = new util.ArrayList[WithdrawalRequest]()
     assertArrayEquals(WithdrawalRequestsListEncoder.encode(expectedListOfWR), returnData)
 
@@ -253,7 +253,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
       })
 
     returnData =
-      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _), 10000000)
+      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _, mockStateView), 10000000)
     assertArrayEquals(WithdrawalRequestsListEncoder.encode(expectedListOfWR), returnData)
   }
 
@@ -266,7 +266,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
     )
 
     assertThrows[ExecutionRevertedException] {
-      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _))
+      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _, mockStateView))
     }
 
     msg = getMessage(
@@ -276,7 +276,7 @@ class WithdrawalMsgProcessorTest extends JUnitSuite with MockitoSugar with Withd
     )
 
     assertThrows[ExecutionRevertedException] {
-      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _))
+      withGas(TestContext.process(WithdrawalMsgProcessor, msg, mockStateView, defaultBlockContext, _, mockStateView))
     }
   }
 }

--- a/sdk/src/test/scala/io/horizen/account/storage/AccountStateMetadataStorageViewTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/storage/AccountStateMetadataStorageViewTest.scala
@@ -5,7 +5,7 @@ import io.horizen.SidechainTypes
 import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.state.receipt.{EthereumReceipt, ReceiptFixture}
 import io.horizen.account.storage.AccountStateMetadataStorageView.DEFAULT_ACCOUNT_STATE_ROOT
-import io.horizen.account.utils.AccountBlockFeeInfo
+import io.horizen.account.utils.{AccountBlockFeeInfo, ForgerIdentifier}
 import io.horizen.block.{WithdrawalEpochCertificate, WithdrawalEpochCertificateFixture}
 import io.horizen.consensus.{ConsensusEpochNumber, intToConsensusEpochNumber}
 import io.horizen.fixtures.{SecretFixture, StoreFixture, TransactionFixture}
@@ -113,9 +113,9 @@ class AccountStateMetadataStorageViewTest
     assertTrue("receipts should not be in storage", stateMetadataStorage.getTransactionReceipt(receipt1.transactionHash).isEmpty)
 
     val addressProposition = new AddressProposition(BytesUtils.fromHexString("00000000000000000000000000000000000000aa"))
-    storageView.updateForgerBlockCounter(addressProposition)
-    assertTrue("Counter for forger does not exists",storageView.getForgerBlockCounters.contains(addressProposition))
-    assertTrue("Counter for forger is incorrect",storageView.getForgerBlockCounters(addressProposition) == 1)
+    storageView.updateForgerBlockCounter(ForgerIdentifier(addressProposition))
+    assertTrue("Counter for forger does not exists",storageView.getForgerBlockCounters.contains(ForgerIdentifier(addressProposition)))
+    assertTrue("Counter for forger is incorrect",storageView.getForgerBlockCounters(ForgerIdentifier(addressProposition)) == 1)
 
     storageView.commit(bytesToVersion(getVersion.data()))
 

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountBlockFeeInfoSerializerTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountBlockFeeInfoSerializerTest.scala
@@ -1,0 +1,44 @@
+package io.horizen.account.utils
+
+import io.horizen.account.proposition.AddressProposition
+import io.horizen.fixtures.SecretFixture
+import io.horizen.proposition.{PublicKey25519Proposition, VrfPublicKey}
+import io.horizen.secret.PrivateKey25519Creator
+import io.horizen.vrf.VrfGeneratedDataProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+
+class AccountBlockFeeInfoSerializerTest extends SecretFixture {
+  @Test
+  def serializeAccountBlockFeeInfo(): Unit = {
+    val address: AddressProposition = getAddressProposition(123)
+    val baseFee: BigInteger = BigInteger.valueOf(1234567890L)
+    val forgerTips: BigInteger = BigInteger.valueOf(1234567890L)
+    val feeInto: AccountBlockFeeInfo = AccountBlockFeeInfo(baseFee, forgerTips, address)
+
+    val serializedBytes: Array[Byte] = AccountBlockFeeInfoSerializer.toBytes(feeInto)
+
+    val deserializedFeeInto: AccountBlockFeeInfo = AccountBlockFeeInfoSerializer.parseBytes(serializedBytes)
+
+    assertEquals(feeInto, deserializedFeeInto)
+  }
+
+  @Test
+  def serializeAccountBlockFeeInfoNewFormat(): Unit = {
+    val address: AddressProposition = getAddressProposition(123)
+    val proposition: PublicKey25519Proposition = PrivateKey25519Creator.getInstance().generateSecret("test1".getBytes(StandardCharsets.UTF_8)).publicImage()
+    val vrfPublicKey: VrfPublicKey = VrfGeneratedDataProvider.getVrfSecretKey(1).publicImage()
+    val baseFee: BigInteger = BigInteger.valueOf(1234567890L)
+    val forgerTips: BigInteger = BigInteger.valueOf(1234567890L)
+    val feeInto: AccountBlockFeeInfo = AccountBlockFeeInfo(baseFee, forgerTips, address, Some(proposition), Some(vrfPublicKey))
+
+    val serializedBytes: Array[Byte] = AccountBlockFeeInfoSerializer.toBytes(feeInto)
+
+    val deserializedFeeInto: AccountBlockFeeInfo = AccountBlockFeeInfoSerializer.parseBytes(serializedBytes)
+
+    assertEquals(feeInto, deserializedFeeInto)
+  }
+}

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
@@ -226,17 +226,10 @@ class AccountFeePaymentsUtilsTest extends JUnitSuite with SidechainRelatedMainch
     val forgerPublicKeys = ForgerPublicKeys(blockSignerProposition, vrfPublicKey)
     val rewardAddress: AddressProposition = PrivateKeySecp256k1Creator.getInstance().generateSecret("nativemsgprocessortest1".getBytes(StandardCharsets.UTF_8)).publicImage()
 
-    val mcForgerPoolRewards = Map(
-      ForgerIdentifier(forgerAddr_a) -> BigInteger.valueOf(10),
-      ForgerIdentifier(forgerAddr_b) -> BigInteger.valueOf(10),
-      ForgerIdentifier(forgerAddr_c) -> BigInteger.valueOf(10),
-      ForgerIdentifier(forgerAddr_d) -> BigInteger.valueOf(10),
-    )
-
-    val feePayment = ForgerPayment(ForgerIdentifier(forgerAddr_a), BigInteger.valueOf(100))
+    val feePayment = ForgerPayment(ForgerIdentifier(forgerAddr_a), BigInteger.valueOf(100), BigInteger.valueOf(10))
     val forgerInfo = ForgerInfo(forgerPublicKeys, 100, rewardAddress)
 
-    val (forgerPayment, Some(delegatorPayment)) = getForgerAndDelegatorShares(mcForgerPoolRewards, feePayment, forgerInfo)
+    val (forgerPayment, Some(delegatorPayment)) = getForgerAndDelegatorShares(feePayment, forgerInfo)
 
     assertEquals(forgerPayment.address, forgerAddr_a)
     assertEquals(forgerPayment.value, BigInteger.valueOf(90))

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountFeePaymentsUtilsTest.scala
@@ -17,12 +17,7 @@ import org.scalatestplus.mockito._
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 
-
-class AccountFeePaymentsUtilsTest
-  extends JUnitSuite
-    with SidechainRelatedMainchainOutputFixture
-    with MockitoSugar
-{
+class AccountFeePaymentsUtilsTest extends JUnitSuite with SidechainRelatedMainchainOutputFixture with MockitoSugar {
   val addr_a: Array[Byte] = BytesUtils.fromHexString("00000000000000000000000000000000000000aa")
   val addr_b: Array[Byte] = BytesUtils.fromHexString("00000000000000000000000000000000000000bb")
   val addr_c: Array[Byte] = BytesUtils.fromHexString("00000000000000000000000000000000000000cc")
@@ -34,7 +29,7 @@ class AccountFeePaymentsUtilsTest
 
   @Test
   def testNullBlockFeeInfoSeq(): Unit = {
-    val blockFeeInfoSeq : Seq[AccountBlockFeeInfo] = Seq()
+    val blockFeeInfoSeq: Seq[AccountBlockFeeInfo] = Seq()
     val accountPaymentsList = getForgersRewards(blockFeeInfoSeq)
     assertTrue(accountPaymentsList.isEmpty)
   }
@@ -42,20 +37,14 @@ class AccountFeePaymentsUtilsTest
   @Test
   def testHomogeneousBlockFeeInfoSeq(): Unit = {
 
-    var blockFeeInfoSeq : Seq[AccountBlockFeeInfo] = Seq()
+    var blockFeeInfoSeq: Seq[AccountBlockFeeInfo] = Seq()
 
-    val abfi_a = AccountBlockFeeInfo(
-      baseFee = BigInteger.valueOf(100),
-      forgerTips = BigInteger.valueOf(10),
-      forgerAddr_a)
-    val abfi_b = AccountBlockFeeInfo(
-      baseFee = BigInteger.valueOf(100),
-      forgerTips = BigInteger.valueOf(10),
-      forgerAddr_b)
-    val abfi_c = AccountBlockFeeInfo(
-      baseFee = BigInteger.valueOf(100),
-      forgerTips = BigInteger.valueOf(10),
-      forgerAddr_c)
+    val abfi_a =
+      AccountBlockFeeInfo(baseFee = BigInteger.valueOf(100), forgerTips = BigInteger.valueOf(10), forgerAddr_a)
+    val abfi_b =
+      AccountBlockFeeInfo(baseFee = BigInteger.valueOf(100), forgerTips = BigInteger.valueOf(10), forgerAddr_b)
+    val abfi_c =
+      AccountBlockFeeInfo(baseFee = BigInteger.valueOf(100), forgerTips = BigInteger.valueOf(10), forgerAddr_c)
 
     blockFeeInfoSeq = blockFeeInfoSeq :+ abfi_a
     blockFeeInfoSeq = blockFeeInfoSeq :+ abfi_b
@@ -71,7 +60,7 @@ class AccountFeePaymentsUtilsTest
   @Test
   def testNotUniqueForgerAddresses(): Unit = {
 
-    var blockFeeInfoSeq : Seq[AccountBlockFeeInfo] = Seq()
+    var blockFeeInfoSeq: Seq[AccountBlockFeeInfo] = Seq()
 
     val abfi_a = AccountBlockFeeInfo(
       baseFee = BigInteger.valueOf(100),
@@ -99,21 +88,18 @@ class AccountFeePaymentsUtilsTest
     val accountPaymentsList = getForgersRewards(blockFeeInfoSeq)
     assertEquals(accountPaymentsList.length, 3)
 
-    accountPaymentsList.foreach(
-      payment => {
-        if (payment.address.equals(forgerAddr_c))
-          assertEquals(payment.value, BigInteger.valueOf(220))
-        else
-          assertEquals(payment.value, BigInteger.valueOf(110))
-      }
-    )
+    accountPaymentsList.foreach(payment => {
+      if (payment.identifier.address.equals(forgerAddr_c))
+        assertEquals(payment.value, BigInteger.valueOf(220))
+      else
+        assertEquals(payment.value, BigInteger.valueOf(110))
+    })
   }
-
 
   @Test
   def testPoolWithRemainder(): Unit = {
 
-    var blockFeeInfoSeq : Seq[AccountBlockFeeInfo] = Seq()
+    var blockFeeInfoSeq: Seq[AccountBlockFeeInfo] = Seq()
 
     val abfi_a = AccountBlockFeeInfo(
       baseFee = BigInteger.valueOf(3),
@@ -148,24 +134,22 @@ class AccountFeePaymentsUtilsTest
     val accountPaymentsList = getForgersRewards(blockFeeInfoSeq)
     assertEquals(accountPaymentsList.length, 3)
 
-    accountPaymentsList.foreach(
-      payment => {
-        if (payment.address.equals(forgerAddr_c))
-          // last address is repeated, its reward are summed
-          //   (forgerTip (4) + poolFee quota (3)) + (forgerTip (6) + poolFee quota (3))
-          assertEquals(payment.value, BigInteger.valueOf((4 + 3) + (6 + 3)))
-        else {
-          // first 2 addresses have 1 satoshi more due to the remainder:
-          //   forgerTip (10) + poolFee quota (3) + remainder quota (1)
-          assertEquals(payment.value, BigInteger.valueOf(10 + 3 + 1))
-        }
+    accountPaymentsList.foreach(payment => {
+      if (payment.identifier.address.equals(forgerAddr_c))
+        // last address is repeated, its reward are summed
+        //   (forgerTip (4) + poolFee quota (3)) + (forgerTip (6) + poolFee quota (3))
+        assertEquals(payment.value, BigInteger.valueOf((4 + 3) + (6 + 3)))
+      else {
+        // first 2 addresses have 1 satoshi more due to the remainder:
+        //   forgerTip (10) + poolFee quota (3) + remainder quota (1)
+        assertEquals(payment.value, BigInteger.valueOf(10 + 3 + 1))
       }
-    )
+    })
   }
 
   @Test
   def testWithMcForgerPoolRewards(): Unit = {
-    var blockFeeInfoSeq : Seq[AccountBlockFeeInfo] = Seq()
+    var blockFeeInfoSeq: Seq[AccountBlockFeeInfo] = Seq()
 
     val abfi_a = AccountBlockFeeInfo(
       baseFee = BigInteger.valueOf(100),
@@ -185,13 +169,11 @@ class AccountFeePaymentsUtilsTest
       forgerAddr_c)
 
     val mcForgerPoolRewards = Map(
-      forgerAddr_a -> BigInteger.valueOf(10),
-      forgerAddr_b -> BigInteger.valueOf(10),
-      forgerAddr_c -> BigInteger.valueOf(10),
-      forgerAddr_d -> BigInteger.valueOf(10),
-
+      ForgerIdentifier(forgerAddr_a) -> BigInteger.valueOf(10),
+      ForgerIdentifier(forgerAddr_b) -> BigInteger.valueOf(10),
+      ForgerIdentifier(forgerAddr_c) -> BigInteger.valueOf(10),
+      ForgerIdentifier(forgerAddr_d) -> BigInteger.valueOf(10),
     )
-
 
     blockFeeInfoSeq = blockFeeInfoSeq :+ abfi_a
     blockFeeInfoSeq = blockFeeInfoSeq :+ abfi_b
@@ -201,16 +183,14 @@ class AccountFeePaymentsUtilsTest
     val accountPaymentsList = getForgersRewards(blockFeeInfoSeq, mcForgerPoolRewards)
     assertEquals(accountPaymentsList.length, 4)
 
-    accountPaymentsList.foreach(
-      payment => {
-        if (payment.address.equals(forgerAddr_c))
-          assertEquals(BigInteger.valueOf(230), payment.value)
-        else if (payment.address.equals(forgerAddr_d))
-          assertEquals(BigInteger.valueOf(10), payment.value)
-        else
-          assertEquals(BigInteger.valueOf(120), payment.value)
-      }
-    )
+    accountPaymentsList.foreach(payment => {
+      if (payment.identifier.address.equals(forgerAddr_c))
+        assertEquals(BigInteger.valueOf(230), payment.value)
+      else if (payment.identifier.address.equals(forgerAddr_d))
+        assertEquals(BigInteger.valueOf(10), payment.value)
+      else
+        assertEquals(BigInteger.valueOf(120), payment.value)
+    })
   }
 
   @Test
@@ -247,16 +227,16 @@ class AccountFeePaymentsUtilsTest
     val rewardAddress: AddressProposition = PrivateKeySecp256k1Creator.getInstance().generateSecret("nativemsgprocessortest1".getBytes(StandardCharsets.UTF_8)).publicImage()
 
     val mcForgerPoolRewards = Map(
-      forgerAddr_a -> BigInteger.valueOf(10),
-      forgerAddr_b -> BigInteger.valueOf(10),
-      forgerAddr_c -> BigInteger.valueOf(10),
-      forgerAddr_d -> BigInteger.valueOf(10),
+      ForgerIdentifier(forgerAddr_a) -> BigInteger.valueOf(10),
+      ForgerIdentifier(forgerAddr_b) -> BigInteger.valueOf(10),
+      ForgerIdentifier(forgerAddr_c) -> BigInteger.valueOf(10),
+      ForgerIdentifier(forgerAddr_d) -> BigInteger.valueOf(10),
     )
 
-    val feePayment = AccountPayment(forgerAddr_a, BigInteger.valueOf(100))
+    val feePayment = ForgerPayment(ForgerIdentifier(forgerAddr_a), BigInteger.valueOf(100))
     val forgerInfo = ForgerInfo(forgerPublicKeys, 100, rewardAddress)
 
-    val (forgerPayment, delegatorPayment) = getForgerAndDelegatorShares(mcForgerPoolRewards, feePayment, forgerInfo)
+    val (forgerPayment, Some(delegatorPayment)) = getForgerAndDelegatorShares(mcForgerPoolRewards, feePayment, forgerInfo)
 
     assertEquals(forgerPayment.address, forgerAddr_a)
     assertEquals(forgerPayment.value, BigInteger.valueOf(90))

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountMockDataHelper.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountMockDataHelper.scala
@@ -11,7 +11,7 @@ import io.horizen.account.proposition.AddressProposition
 import io.horizen.account.secret.PrivateKeySecp256k1
 import io.horizen.account.state._
 import io.horizen.account.state.receipt.EthereumReceipt
-import io.horizen.account.storage.AccountStateMetadataStorageView
+import io.horizen.account.storage.{AccountStateMetadataStorageView, MsgProcessorMetadataStorageReader}
 import io.horizen.account.transaction.EthereumTransaction
 import io.horizen.account.wallet.AccountWallet
 import io.horizen.block.SidechainBlockBase.GENESIS_BLOCK_PARENT_ID
@@ -457,7 +457,7 @@ case class AccountMockDataHelper(genesis: Boolean)
       .when(mockMsgProcessor.canProcess(any[Invocation], any[BaseAccountStateView], any[Int]))
       .thenReturn(true)
     Mockito
-      .when(mockMsgProcessor.process(any[Invocation], any[BaseAccountStateView], any[ExecutionContext]))
+      .when(mockMsgProcessor.process(any[Invocation], any[BaseAccountStateView], any[MsgProcessorMetadataStorageReader], any[ExecutionContext]))
       .thenReturn(Array.empty[Byte])
     mockMsgProcessor
   }

--- a/sdk/src/test/scala/io/horizen/account/utils/AccountPaymentSerializerTest.scala
+++ b/sdk/src/test/scala/io/horizen/account/utils/AccountPaymentSerializerTest.scala
@@ -20,4 +20,19 @@ class AccountPaymentSerializerTest extends SecretFixture  {
 
     assertEquals(accountPayment, deserializedAccountPayment)
   }
+
+  @Test
+  def serializeAccountPaymentNewFormat(): Unit = {
+    val address: AddressProposition = getAddressProposition(123)
+    val value: BigInteger = BigInteger.valueOf(1234567890L)
+    val valueFromMainchain: BigInteger = BigInteger.valueOf(2222222222L)
+    val valueFromFees: BigInteger = BigInteger.valueOf(5555555555L)
+    val accountPayment: AccountPayment = AccountPayment(address, value, Some(valueFromMainchain), Some(valueFromFees))
+
+    val serializedBytes: Array[Byte] = AccountPaymentSerializer.toBytes(accountPayment)
+
+    val deserializedAccountPayment: AccountPayment = AccountPaymentSerializer.parseBytes(serializedBytes)
+
+    assertEquals(accountPayment, deserializedAccountPayment)
+  }
 }


### PR DESCRIPTION
## Description
Reward workflow changes
feePayments API changes
rewardsReceived native method

## Jira Ticket
[SDK-1760](https://horizenlabs.atlassian.net/browse/SDK-1760)
[SDK-1746](https://horizenlabs.atlassian.net/browse/SDK-1746)

## Changes

- metadata storage to store additional forger info - block sign key and vrf public key
- fee rewards flow changes:
  - get forger info from ForgerStakeV2
  - divide forger reward into 2 parts - one for forger, one for delegators
  - store forger delegators rewards into metadata storage
- FeePayments API endoint contain additional info about rewards coming from block fees and from mainchain
- rewardsReceived native method to retrieve info about delegator rewards for a forger

## Checks
- [x] Project Builds
- [x] Project passes tests and checks
- [x] Updated documentation accordingly
- [x] Breaking changes have been correctly tagged and notified
 
## Additional information


[SDK-1760]: https://horizenlabs.atlassian.net/browse/SDK-1760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-1746]: https://horizenlabs.atlassian.net/browse/SDK-1746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ